### PR TITLE
Improve whitepaper and litepaper page styling

### DIFF
--- a/nil-website/src/index.css
+++ b/nil-website/src/index.css
@@ -64,3 +64,62 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer components {
+  .markdown-content {
+    @apply prose prose-lg max-w-none text-muted-foreground leading-relaxed;
+  }
+
+  .markdown-content h1,
+  .markdown-content h2,
+  .markdown-content h3,
+  .markdown-content h4 {
+    @apply text-foreground font-bold tracking-tight;
+  }
+
+  .markdown-content p {
+    @apply text-base sm:text-lg;
+  }
+
+  .markdown-content a {
+    @apply text-primary font-semibold no-underline transition-colors;
+  }
+
+  .markdown-content a:hover {
+    @apply text-primary/80;
+  }
+
+  .markdown-content strong {
+    @apply text-foreground;
+  }
+
+  .markdown-content blockquote {
+    @apply border-l-4 border-primary/40 bg-primary/5 text-foreground py-2 pl-4 pr-6 rounded-r-lg;
+  }
+
+  .markdown-content code {
+    @apply bg-muted text-foreground px-1.5 py-0.5 rounded font-mono text-sm;
+  }
+
+  .markdown-content pre {
+    @apply bg-muted text-foreground border border-border rounded-xl p-4 overflow-x-auto;
+  }
+
+  .markdown-content table {
+    @apply w-full text-left border-collapse my-6;
+  }
+
+  .markdown-content th,
+  .markdown-content td {
+    @apply border border-border px-3 py-2 text-sm;
+  }
+
+  .markdown-content ul li::marker,
+  .markdown-content ol li::marker {
+    color: hsl(var(--primary));
+  }
+
+  .markdown-content hr {
+    @apply border-border my-8;
+  }
+}

--- a/nil-website/src/pages/Papers.tsx
+++ b/nil-website/src/pages/Papers.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type ReactNode } from 'react';
 import { motion } from 'framer-motion';
 import { marked } from 'marked';
 
@@ -21,8 +21,9 @@ const MarkdownPage = ({ filePath, title }: MarkdownPageProps) => {
         }
         const text = await response.text();
         setContent(marked.parse(text));
-      } catch (err: any) {
-        setError(err.message);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'An unexpected error occurred';
+        setError(message);
       } finally {
         setLoading(false);
       }
@@ -31,31 +32,38 @@ const MarkdownPage = ({ filePath, title }: MarkdownPageProps) => {
     fetchMarkdown();
   }, [filePath]);
 
-  if (loading) return (
-    <div className="pt-24 pb-12 px-4 container mx-auto max-w-4xl">
-        <h1 className="text-4xl font-bold mb-4 text-foreground">{title}</h1>
-        <p className="text-muted-foreground">Loading...</p>
-    </div>
-  );
-
-  if (error) return (
-    <div className="pt-24 pb-12 px-4 container mx-auto max-w-4xl">
-        <h1 className="text-4xl font-bold mb-4 text-foreground">{title}</h1>
-        <p className="text-red-500">Error: {error}</p>
-    </div>
-  );
-
-  return (
-    <div className="pt-24 pb-12 px-4 container mx-auto max-w-4xl">
+  const renderPage = (body: ReactNode) => (
+    <div className="bg-gradient-to-b from-background via-secondary/10 to-background w-full">
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
+        className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16 space-y-8"
       >
-        <h1 className="text-4xl font-bold mb-4 text-foreground">{title}</h1>
-        <div className="prose dark:prose-invert max-w-none text-muted-foreground" dangerouslySetInnerHTML={{ __html: content }} />
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-primary/80">Research</p>
+          <h1 className="text-4xl sm:text-5xl font-bold tracking-tight text-foreground">{title}</h1>
+          <p className="text-lg text-muted-foreground max-w-3xl">
+            A formatted reading experience for the latest NilStore papers with consistent spacing, contrast, and typography.
+          </p>
+        </div>
+
+        <div className="bg-card border border-border/60 rounded-2xl shadow-lg shadow-black/5 p-6 sm:p-8 lg:p-10">
+          {body}
+        </div>
       </motion.div>
     </div>
+  );
+
+  if (loading) return renderPage(<p className="text-muted-foreground">Loading...</p>);
+
+  if (error) return renderPage(<p className="text-destructive">Error: {error}</p>);
+
+  return renderPage(
+    <div
+      className="markdown-content"
+      dangerouslySetInnerHTML={{ __html: content }}
+    />
   );
 };
 


### PR DESCRIPTION
## Summary
- refine the whitepaper and litepaper layouts with consistent headers, spacing, and card framing to match the rest of the site
- add shared markdown typography and color rules for paper content to improve readability

## Testing
- npm run lint *(fails: pre-existing lint errors across the project)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939b95ef7808322a00856c3b7ddfab1)