### PR TITLE
Phase 2: enforce sessions for debug raw fetch

### DIFF
--- a/nil_gateway/debug_raw_fetch.go
+++ b/nil_gateway/debug_raw_fetch.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
+
+	"nilchain/x/nilchain/types"
 )
 
 // GatewayDebugRawFetch serves file bytes directly from an on-disk NilFS slab without
@@ -45,6 +50,86 @@ func GatewayDebugRawFetch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var (
+		onchainSession *types.RetrievalSession
+		stripe         stripeParams
+	)
+	if requireOnchainSession {
+		rawSession := strings.TrimSpace(r.Header.Get("X-Nil-Session-Id"))
+		if rawSession == "" {
+			writeJSONError(w, http.StatusBadRequest, "missing X-Nil-Session-Id", "")
+			return
+		}
+		sessionID, _, nerr := parseSessionIDHex(rawSession)
+		if nerr != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid X-Nil-Session-Id", nerr.Error())
+			return
+		}
+		sess, serr := fetchRetrievalSession(sessionID)
+		if serr != nil {
+			if errors.Is(serr, ErrSessionNotFound) {
+				writeJSONError(w, http.StatusNotFound, "retrieval session not found on chain", "")
+				return
+			}
+			writeJSONError(w, http.StatusInternalServerError, "failed to fetch retrieval session", serr.Error())
+			return
+		}
+		onchainSession = sess
+		if onchainSession.Status != types.RetrievalSessionStatus_RETRIEVAL_SESSION_STATUS_OPEN {
+			writeJSONError(w, http.StatusConflict, "session not OPEN", fmt.Sprintf("status: %s", onchainSession.Status))
+			return
+		}
+		if len(onchainSession.ManifestRoot) != 48 || !bytes.Equal(onchainSession.ManifestRoot, manifestRoot.Bytes[:]) {
+			writeJSONError(w, http.StatusBadRequest, "session manifest_root mismatch", "")
+			return
+		}
+		if hasDealQuery && dealID != onchainSession.DealId {
+			writeJSONError(w, http.StatusBadRequest, "session deal_id mismatch", "")
+			return
+		}
+		if rawOwner := strings.TrimSpace(r.URL.Query().Get("owner")); rawOwner != "" && rawOwner != onchainSession.Owner {
+			writeJSONError(w, http.StatusForbidden, "session owner mismatch", "")
+			return
+		}
+
+		h, herr := fetchLatestHeight(r.Context(), lcdBase)
+		if herr != nil {
+			writeJSONError(w, http.StatusInternalServerError, "failed to fetch chain height", herr.Error())
+			return
+		}
+		meta, derr := fetchDealMeta(onchainSession.DealId)
+		if derr != nil {
+			writeJSONError(w, http.StatusInternalServerError, "failed to fetch deal", derr.Error())
+			return
+		}
+		if meta.EndBlock != 0 && h >= meta.EndBlock {
+			writeJSONError(w, http.StatusGone, "deal expired", fmt.Sprintf("end_block=%d", meta.EndBlock))
+			return
+		}
+		if onchainSession.ExpiresAt != 0 && h > onchainSession.ExpiresAt {
+			writeJSONError(w, http.StatusForbidden, "session expired", "")
+			return
+		}
+		if meta.EndBlock != 0 && onchainSession.ExpiresAt != 0 && onchainSession.ExpiresAt > meta.EndBlock {
+			writeJSONError(w, http.StatusForbidden, "session outlives deal term", "")
+			return
+		}
+
+		serviceHint, serr := fetchDealServiceHintFromLCD(r.Context(), onchainSession.DealId)
+		if serr != nil {
+			log.Printf("GatewayDebugRawFetch: failed to fetch service hint: %v", serr)
+			serviceHint = ""
+		}
+		stripe, serr = stripeParamsFromHint(serviceHint)
+		if serr != nil {
+			stripe = stripeParams{mode: 1, leafCount: types.BLOBS_PER_MDU}
+		}
+		if stripe.mode == 2 {
+			writeJSONError(w, http.StatusBadRequest, "debug raw fetch not supported for Mode 2 deals", "")
+			return
+		}
+	}
+
 	q := r.URL.Query()
 	filePath, err := validateNilfsFilePath(q.Get("file_path"))
 	if err != nil {
@@ -70,9 +155,21 @@ func GatewayDebugRawFetch(w http.ResponseWriter, r *http.Request) {
 		}
 		rangeLen = v
 	}
+	if requireOnchainSession {
+		if rangeLen == 0 {
+			writeJSONError(w, http.StatusBadRequest, "range_len is required", "")
+			return
+		}
+		if rangeLen > uint64(types.BLOB_SIZE) {
+			writeJSONError(w, http.StatusBadRequest, "range too large", fmt.Sprintf("range_len must be <= %d", types.BLOB_SIZE))
+			return
+		}
+	}
 
 	var dealDir string
-	if hasDealQuery {
+	if requireOnchainSession {
+		dealDir, err = resolveDealDirForDeal(onchainSession.DealId, manifestRoot, rawManifestRoot)
+	} else if hasDealQuery {
 		dealDir, err = resolveDealDirForDeal(dealID, manifestRoot, rawManifestRoot)
 	} else {
 		dealDir, err = resolveDealDir(manifestRoot, rawManifestRoot)
@@ -90,7 +187,7 @@ func GatewayDebugRawFetch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	content, _, _, _, servedLen, _, err := resolveNilfsFileSegmentForFetch(dealDir, filePath, rangeStart, rangeLen)
+	content, mduIdx, _, absOffset, servedLen, _, err := resolveNilfsFileSegmentForFetch(dealDir, filePath, rangeStart, rangeLen)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			writeJSONError(w, http.StatusNotFound, "file not found in deal", "")
@@ -103,6 +200,57 @@ func GatewayDebugRawFetch(w http.ResponseWriter, r *http.Request) {
 	if servedLen == 0 {
 		writeJSONError(w, http.StatusRequestedRangeNotSatisfiable, "range not satisfiable", "")
 		return
+	}
+	if requireOnchainSession {
+		endAbs := absOffset + servedLen - 1
+		if absOffset/RawMduCapacity != endAbs/RawMduCapacity {
+			writeJSONError(w, http.StatusBadRequest, "range crosses MDU boundary", "split into multiple requests")
+			return
+		}
+		offsetInMdu := absOffset % RawMduCapacity
+		blobIndex, berr := rawOffsetToEncodedBlobIndex(offsetInMdu)
+		if berr != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid blob range", berr.Error())
+			return
+		}
+		endOffsetInMdu := endAbs % RawMduCapacity
+		endBlob, eerr := rawOffsetToEncodedBlobIndex(endOffsetInMdu)
+		if eerr != nil || endBlob != blobIndex {
+			writeJSONError(w, http.StatusBadRequest, "range crosses blob boundary", "split into multiple requests")
+			return
+		}
+		if stripe.leafCount == 0 {
+			writeJSONError(w, http.StatusInternalServerError, "invalid stripe params", "leaf_count is zero")
+			return
+		}
+		if onchainSession.BlobCount == 0 {
+			writeJSONError(w, http.StatusBadRequest, "invalid session range", "blob_count is zero")
+			return
+		}
+		leafIndex, lerr := leafIndexForBlobIndex(blobIndex, stripe)
+		if lerr != nil {
+			writeJSONError(w, http.StatusInternalServerError, "failed to map leaf index", lerr.Error())
+			return
+		}
+		sessionStart, overflow := addUint64(onchainSession.StartMduIndex*stripe.leafCount, uint64(onchainSession.StartBlobIndex))
+		if overflow {
+			writeJSONError(w, http.StatusBadRequest, "invalid session range", "start_global overflow")
+			return
+		}
+		sessionEnd := sessionStart + onchainSession.BlobCount - 1
+		if sessionEnd < sessionStart {
+			writeJSONError(w, http.StatusBadRequest, "invalid session range", "end_global overflow")
+			return
+		}
+		reqGlobal, overflow := addUint64(mduIdx*stripe.leafCount, leafIndex)
+		if overflow {
+			writeJSONError(w, http.StatusBadRequest, "invalid request range", "global index overflow")
+			return
+		}
+		if reqGlobal < sessionStart || reqGlobal > sessionEnd {
+			writeJSONError(w, http.StatusForbidden, "range outside session", "split into multiple sessions or re-open with a larger blob range")
+			return
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/octet-stream")

--- a/nil_gateway/debug_raw_fetch_test.go
+++ b/nil_gateway/debug_raw_fetch_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestGatewayDebugRawFetch_ByPath_NoManifestBin(t *testing.T) {
+	requireOnchainSessionForTest(t, false)
 	useTempUploadDir(t)
 	owner := testDealOwner(t)
 

--- a/nil_gateway/router_proxy.go
+++ b/nil_gateway/router_proxy.go
@@ -409,6 +409,12 @@ func RouterGatewayManifestInfo(w http.ResponseWriter, r *http.Request) {
 }
 func RouterGatewayMduKzg(w http.ResponseWriter, r *http.Request) { RouterGatewayFetch(w, r) }
 func RouterGatewayDebugRawFetch(w http.ResponseWriter, r *http.Request) {
+	if requireOnchainSession {
+		if strings.TrimSpace(r.Header.Get("X-Nil-Session-Id")) == "" {
+			writeJSONError(w, http.StatusBadRequest, "missing X-Nil-Session-Id", "")
+			return
+		}
+	}
 	RouterGatewayFetch(w, r)
 }
 func RouterGatewayPlanRetrievalSession(w http.ResponseWriter, r *http.Request) {

--- a/nil_gateway/session_enforcement_test.go
+++ b/nil_gateway/session_enforcement_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -195,5 +196,135 @@ func TestSpFetchShard_RequiresOnchainSession_WhenEnabled(t *testing.T) {
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 missing session, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestGatewayDebugRawFetch_RequiresOnchainSession_WhenEnabled(t *testing.T) {
+	requireOnchainSessionForTest(t, true)
+	useTempUploadDir(t)
+
+	if err := crypto_ffi.Init(trustedSetup); err != nil {
+		t.Fatalf("crypto_ffi.Init failed: %v", err)
+	}
+
+	owner := testDealOwner(t)
+
+	roots := make([][]byte, 2)
+	roots[0] = make([]byte, 32)
+	roots[1] = make([]byte, 32)
+	commitment, _, err := crypto_ffi.ComputeManifestCommitment(roots)
+	if err != nil {
+		t.Fatalf("ComputeManifestCommitment failed: %v", err)
+	}
+	manifestRoot, err := parseManifestRoot("0x" + fmt.Sprintf("%x", commitment))
+	if err != nil {
+		t.Fatalf("parseManifestRoot failed: %v", err)
+	}
+
+	filePath := "debug.md"
+	fileContent := []byte("Hello Debug Raw Fetch")
+
+	dealDir := filepath.Join(uploadDir, manifestRoot.Key)
+	if err := os.MkdirAll(dealDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	b := crypto_ffi.NewMdu0Builder(1)
+	defer b.Free()
+	b.AppendFile(filePath, uint64(len(fileContent)), 0)
+	mdu0Data, _ := b.Bytes()
+	if err := os.WriteFile(filepath.Join(dealDir, "mdu_0.bin"), mdu0Data, 0o644); err != nil {
+		t.Fatalf("write mdu_0.bin failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dealDir, "mdu_1.bin"), encodeRawToMdu(fileContent), 0o644); err != nil {
+		t.Fatalf("write mdu_1.bin failed: %v", err)
+	}
+
+	const dealID = uint64(1)
+	sessionHex := "0x" + strings.Repeat("22", 32)
+	sessionBytes, _ := hex.DecodeString(strings.Repeat("22", 32))
+	sessionB64 := base64.URLEncoding.EncodeToString(sessionBytes)
+
+	lcdSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/cosmos/base/tendermint/v1beta1/blocks/latest"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"block": map[string]any{
+					"header": map[string]any{
+						"height": "10",
+					},
+				},
+			})
+			return
+		case strings.HasPrefix(r.URL.Path, "/nilchain/nilchain/v1/deals/"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"deal": map[string]any{
+					"id":           "1",
+					"owner":        owner,
+					"cid":          manifestRoot.Canonical,
+					"end_block":    "1000",
+					"service_hint": "",
+				},
+			})
+			return
+		case strings.HasPrefix(r.URL.Path, "/nilchain/nilchain/v1/retrieval-sessions/"):
+			sid := strings.TrimPrefix(r.URL.Path, "/nilchain/nilchain/v1/retrieval-sessions/")
+			if sid != sessionB64 {
+				http.NotFound(w, r)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"session": map[string]any{
+					"session_id":       base64.URLEncoding.EncodeToString(sessionBytes),
+					"deal_id":          "1",
+					"owner":            owner,
+					"provider":         "nil1testprovider",
+					"manifest_root":    base64.StdEncoding.EncodeToString(manifestRoot.Bytes[:]),
+					"start_mdu_index":  "1",
+					"start_blob_index": "0",
+					"blob_count":       "1",
+					"total_bytes":      "131072",
+					"nonce":            "1",
+					"expires_at":       "100",
+					"opened_height":    "1",
+					"updated_height":   "1",
+					"status":           "RETRIEVAL_SESSION_STATUS_OPEN",
+				},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer lcdSrv.Close()
+	oldLCD := lcdBase
+	lcdBase = lcdSrv.URL
+	t.Cleanup(func() { lcdBase = oldLCD })
+
+	r := testRouter()
+	q := url.Values{}
+	q.Set("deal_id", "1")
+	q.Set("owner", owner)
+	q.Set("file_path", filePath)
+	q.Set("range_start", "0")
+	q.Set("range_len", fmt.Sprintf("%d", len(fileContent)))
+
+	req := httptest.NewRequest(http.MethodGet, "/gateway/debug/raw-fetch/"+manifestRoot.Canonical+"?"+q.Encode(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 missing session, got %d (%s)", w.Code, w.Body.String())
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/gateway/debug/raw-fetch/"+manifestRoot.Canonical+"?"+q.Encode(), nil)
+	req2.Header.Set("X-Nil-Session-Id", sessionHex)
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("expected 200 with session, got %d (%s)", w2.Code, w2.Body.String())
+	}
+	if got := w2.Body.String(); got != string(fileContent) {
+		t.Fatalf("content mismatch: want %q got %q", string(fileContent), got)
 	}
 }


### PR DESCRIPTION
## Summary\n- enforce X-Nil-Session-Id for /gateway/debug/raw-fetch when session enforcement is enabled\n- validate session status/expiry and restrict ranges to a single blob within the session\n- add test coverage for debug raw fetch session enforcement\n\n## Testing\n- ok  	nil_gateway	(cached)