### PR TITLE
Phase 9: Mode2 routine rotation

### DIFF
--- a/docs/TESTNET_READINESS_REPORT.md
+++ b/docs/TESTNET_READINESS_REPORT.md
@@ -81,5 +81,4 @@ go test ./...
 
 ## What remains / known gaps
 
-- Mode1 does not yet have explicit make-before-break churn state (drain scheduler is Mode2-only).
-- `Params.rotation_bytes_per_epoch` is plumbed but routine rotation is not yet implemented (currently disabled by default).
+- Mode1 does not yet have explicit make-before-break churn state (drain/rotation schedulers are Mode2-only).

--- a/nilchain/x/nilchain/keeper/rotation.go
+++ b/nilchain/x/nilchain/keeper/rotation.go
@@ -1,0 +1,174 @@
+package keeper
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"nilchain/x/nilchain/types"
+)
+
+// scheduleRoutineRotations deterministically moves a bounded amount of slot-bytes into
+// REPAIRING even when providers are not draining (Mode2-only).
+//
+// Ordering:
+// - deals are iterated in ID order (collections walk order)
+// - slots are iterated in (deal_id, slot) order
+func (k Keeper) scheduleRoutineRotations(ctx sdk.Context, epochID uint64) error {
+	params := k.GetParams(ctx)
+	if params.RotationBytesPerEpoch == 0 {
+		return nil
+	}
+
+	height := uint64(ctx.BlockHeight())
+
+	// Track global active/repairing bytes for enforcing the repairing ratio cap.
+	activeBytes := uint64(0)
+	repairingBytes := uint64(0)
+	if params.MaxRepairingBytesRatioBps > 0 {
+		var err error
+		activeBytes, repairingBytes, err = k.totalMode2ActiveAndRepairingSlotBytes(ctx, height)
+		if err != nil {
+			return err
+		}
+	}
+
+	scheduledBytes := uint64(0)
+	stopAll := false
+
+	err := k.Deals.Walk(ctx, nil, func(dealID uint64, deal types.Deal) (stop bool, err error) {
+		if stopAll {
+			return true, nil
+		}
+		// end_block is exclusive: once height >= end_block, the deal is expired.
+		if height < deal.StartBlock || height >= deal.EndBlock {
+			return false, nil
+		}
+		if deal.RedundancyMode != 2 || len(deal.Mode2Slots) == 0 {
+			return false, nil
+		}
+
+		in, ok := slabInputs(deal)
+		if !ok {
+			return false, nil
+		}
+		stripe, err := stripeParamsForDeal(deal)
+		if err != nil || stripe.mode != 2 || stripe.rows == 0 {
+			return false, nil
+		}
+
+		slotBytes, overflow := mulUint64(in.userMdus, stripe.rows)
+		if overflow {
+			return true, fmt.Errorf("slot bytes overflow")
+		}
+		slotBytes, overflow = mulUint64(slotBytes, uint64(types.BlobSizeBytes))
+		if overflow {
+			return true, fmt.Errorf("slot bytes overflow")
+		}
+		if slotBytes == 0 {
+			return false, nil
+		}
+
+		dealChanged := false
+		for i := 0; i < len(deal.Mode2Slots); i++ {
+			if stopAll {
+				break
+			}
+			entry := deal.Mode2Slots[i]
+			if entry == nil || entry.Status != types.SlotStatus_SLOT_STATUS_ACTIVE {
+				continue
+			}
+			if strings.TrimSpace(entry.PendingProvider) != "" {
+				continue
+			}
+			// Skip if the provider is draining (handled by drain scheduler).
+			if provider, err := k.Providers.Get(ctx, strings.TrimSpace(entry.Provider)); err == nil && provider.Draining {
+				continue
+			}
+
+			// Enforce rotation budget.
+			nextScheduled, overflow := addUint64(scheduledBytes, slotBytes)
+			if overflow {
+				return true, fmt.Errorf("scheduled bytes overflow")
+			}
+			if nextScheduled > params.RotationBytesPerEpoch {
+				stopAll = true
+				break
+			}
+
+			// Enforce repairing ratio cap if configured.
+			if params.MaxRepairingBytesRatioBps > 0 && activeBytes > 0 {
+				nextRepairing, overflow := addUint64(repairingBytes, slotBytes)
+				if overflow {
+					return true, fmt.Errorf("repairing bytes overflow")
+				}
+				// cap = ceil(active_bytes * bps / 10_000)
+				cap := mulDivCeil(activeBytes, params.MaxRepairingBytesRatioBps, 10000)
+				if cap > 0 && nextRepairing > cap {
+					stopAll = true
+					break
+				}
+			}
+
+			slot := uint32(i)
+			pending, err := k.selectMode2ReplacementProvider(ctx, deal, slot, epochID)
+			if err != nil {
+				ctx.Logger().Error(
+					"failed to select replacement provider (rotation)",
+					"deal", dealID,
+					"slot", slot,
+					"provider", entry.Provider,
+					"error", err,
+				)
+				continue
+			}
+
+			entry.Status = types.SlotStatus_SLOT_STATUS_REPAIRING
+			entry.PendingProvider = strings.TrimSpace(pending)
+			entry.StatusSinceHeight = ctx.BlockHeight()
+			entry.RepairTargetGen = deal.CurrentGen
+			deal.Mode2Slots[i] = entry
+			dealChanged = true
+
+			scheduledBytes = nextScheduled
+			if params.MaxRepairingBytesRatioBps > 0 {
+				// Move bytes from ACTIVE -> REPAIRING to keep the cap tight while scheduling.
+				if activeBytes >= slotBytes {
+					activeBytes -= slotBytes
+				} else {
+					activeBytes = 0
+				}
+				repairingBytes += slotBytes
+			}
+
+			extra := make([]byte, 0, 4)
+			extra = binary.BigEndian.AppendUint32(extra, slot)
+			eid := deriveEvidenceID("rotation_repair_started", dealID, epochID, extra)
+			if err := k.recordEvidenceSummary(ctx, dealID, strings.TrimSpace(entry.Provider), "rotation_repair_started", eid[:], "chain", false); err != nil {
+				ctx.Logger().Error("failed to record evidence summary", "error", err)
+			}
+
+			ctx.Logger().Info(
+				"slot repair started (rotation)",
+				"deal", dealID,
+				"slot", slot,
+				"provider", entry.Provider,
+				"pending_provider", entry.PendingProvider,
+				"scheduled_bytes", scheduledBytes,
+			)
+		}
+
+		if dealChanged {
+			if err := k.Deals.Set(ctx, dealID, deal); err != nil {
+				return true, err
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/nilchain/x/nilchain/keeper/rotation_test.go
+++ b/nilchain/x/nilchain/keeper/rotation_test.go
@@ -1,0 +1,104 @@
+package keeper_test
+
+import (
+	"strings"
+	"testing"
+
+	"cosmossdk.io/collections"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"nilchain/x/nilchain/keeper"
+	"nilchain/x/nilchain/types"
+)
+
+func TestCheckMissedProofs_SchedulesRotationRepairs(t *testing.T) {
+	f := initFixture(t)
+	msgServer := keeper.NewMsgServerImpl(f.keeper)
+
+	sdkCtx := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(5)
+
+	params := types.DefaultParams()
+	params.EpochLenBlocks = 5
+	params.RotationBytesPerEpoch = 100_000_000 // high enough for test
+	params.MaxRepairingBytesRatioBps = 0       // no cap for this test
+	require.NoError(t, f.keeper.Params.Set(sdkCtx, params))
+
+	mkAddr := func(tag byte) string {
+		addr := make([]byte, 20)
+		addr[19] = tag
+		out, err := f.addressCodec.BytesToString(addr)
+		require.NoError(t, err)
+		return out
+	}
+
+	providerA := mkAddr(0xA1)
+	providerB := mkAddr(0xB2)
+	providerC := mkAddr(0xC3)
+	providerD := mkAddr(0xD4)
+
+	for _, addr := range []string{providerA, providerB, providerC, providerD} {
+		_, err := msgServer.RegisterProvider(sdkCtx, &types.MsgRegisterProvider{
+			Creator:      addr,
+			Capabilities: "General",
+			TotalStorage: 1_000_000_000,
+			Endpoints:    testProviderEndpoints,
+		})
+		require.NoError(t, err)
+	}
+
+	dealID := uint64(1)
+	deal := types.Deal{
+		Id:             dealID,
+		Owner:          mkAddr(0xEE),
+		StartBlock:     1,
+		EndBlock:       10_000,
+		RedundancyMode: 2,
+		Mode2Profile:   &types.StripeReplicaProfile{K: 2, M: 1},
+		Providers:      []string{providerA, providerB, providerC},
+		Mode2Slots: []*types.DealSlot{
+			{Slot: 0, Provider: providerA, Status: types.SlotStatus_SLOT_STATUS_ACTIVE},
+			{Slot: 1, Provider: providerB, Status: types.SlotStatus_SLOT_STATUS_ACTIVE},
+			{Slot: 2, Provider: providerC, Status: types.SlotStatus_SLOT_STATUS_ACTIVE},
+		},
+		TotalMdus:   3,
+		WitnessMdus: 1,
+		CurrentGen:  1,
+		ServiceHint: "General",
+	}
+	require.NoError(t, f.keeper.Deals.Set(sdkCtx, dealID, deal))
+
+	// Ensure quota is satisfied so slashing doesn't start repairs on its own.
+	epochID := uint64(1)
+	for _, slot := range []uint32{0, 1, 2} {
+		require.NoError(t, f.keeper.Mode2EpochCredits.Set(
+			sdkCtx,
+			collections.Join(collections.Join(dealID, slot), epochID),
+			1,
+		))
+	}
+
+	require.NoError(t, f.keeper.CheckMissedProofs(sdkCtx))
+
+	updated, err := f.keeper.Deals.Get(sdkCtx, dealID)
+	require.NoError(t, err)
+
+	require.Len(t, updated.Mode2Slots, 3)
+	slot0 := updated.Mode2Slots[0]
+	require.NotNil(t, slot0)
+	require.Equal(t, types.SlotStatus_SLOT_STATUS_REPAIRING, slot0.Status)
+	require.NotEmpty(t, slot0.PendingProvider)
+	require.NotContains(t, []string{providerA, providerB, providerC}, slot0.PendingProvider)
+
+	// Ensure evidence summary was recorded.
+	var foundEvidence bool
+	require.NoError(t, f.keeper.Proofs.Walk(sdkCtx, nil, func(_ uint64, proof types.Proof) (bool, error) {
+		if strings.Contains(proof.Commitment, "evidence:rotation_repair_started") {
+			foundEvidence = true
+			require.NotEmpty(t, proof.Creator)
+			require.False(t, proof.Valid)
+		}
+		return false, nil
+	}))
+	require.True(t, foundEvidence)
+}

--- a/nilchain/x/nilchain/keeper/slashing.go
+++ b/nilchain/x/nilchain/keeper/slashing.go
@@ -358,5 +358,8 @@ func (k Keeper) CheckMissedProofs(ctx context.Context) error {
 	}
 	// Run controlled churn after rewards are distributed so a draining provider
 	// is still paid for the epoch they served.
-	return k.scheduleDrainingRepairs(sdkCtx, epochID)
+	if err := k.scheduleDrainingRepairs(sdkCtx, epochID); err != nil {
+		return err
+	}
+	return k.scheduleRoutineRotations(sdkCtx, epochID)
 }


### PR DESCRIPTION
Implements Mode2-only routine rotation using rotation_bytes_per_epoch, adds tests, and updates testnet readiness report.\n\nTests: ok  	nilchain/app	(cached)
?   	nilchain/cmd/nilchaind	[no test files]
?   	nilchain/cmd/nilchaind/cmd	[no test files]
?   	nilchain/docs	[no test files]
?   	nilchain/precompiles/nilstore	[no test files]
?   	nilchain/testutil/sample	[no test files]
ok  	nilchain/x/crypto_ffi	(cached)
ok  	nilchain/x/nilchain/client/cli	(cached)
ok  	nilchain/x/nilchain/keeper	(cached)
?   	nilchain/x/nilchain/module	[no test files]
ok  	nilchain/x/nilchain/types	(cached)