### PR TITLE
Docs: sync specs with wallet-first posture

### DIFF
--- a/litepaper.md
+++ b/litepaper.md
@@ -73,6 +73,8 @@ Concretely, the mainnet Mode 1 design adds:
     * **Mode 1:** upload via gateway/CLI or browser; any assigned Provider can accept the full MDU stream.
     * **Mode 2:** the client performs RS(K, K+M) encoding per SP‑MDU (WASM/CLI) and uploads per‑slot shards directly to assigned Providers.
 3.  **Commit:** User submits `MsgUpdateDealContent` to commit the `manifest_root` (gateway optional, user signs via wallet).
+
+*Devnet note:* a faucet-backed relay can be enabled for demos, but it is disabled by default in the mainnet-parity posture.
 4.  **Placement:** In the current **FullReplica (Mode 1)** alpha implementation, the Chain deterministically assigns a set of Providers to hold *full replicas* of the file (targeting 12, capped by available Providers). In **StripeReplica (Mode 2)**, the Chain assigns an ordered slot list of size `N = K+M`, replicating metadata to all slots while striping user data per slot.
 
 ### Step 2: The Loop

--- a/nil-website/public/litepaper.md
+++ b/nil-website/public/litepaper.md
@@ -53,6 +53,8 @@ We don't ban S3. We just pay for speed.
 1.  **Deal:** User sends `MsgCreateDeal(Hint: "Hot", MaxSpend: 100)` (thin-provisioned container).
 2.  **Upload:** User streams data to the assigned nodes and receives a `manifest_root`.
 3.  **Commit:** User submits `MsgUpdateDealContent` to commit the `manifest_root`.
+
+*Devnet note:* A gateway relay/faucet can sponsor gas for demos, but it is disabled by default in mainnet-parity mode.
 4.  **Placement:** In the current **FullReplica (Mode 1)** alpha implementation, the Chain deterministically assigns a set of Providers to hold *full replicas* of the file (targeting 12, capped by available Providers). In **StripeReplica (Mode 2)**, the Chain assigns an ordered slot list of size `N = K+M`, replicating metadata to all slots while striping user data per slot.
 
 ### Step 2: The Loop

--- a/nil-website/public/whitepaper.md
+++ b/nil-website/public/whitepaper.md
@@ -101,6 +101,8 @@ NilStore supports two redundancy modes conceptually:
     *   In **StripeReplica (Mode 2)**, the chain assigns an ordered slot list of size `N = K+M` (e.g., 8+4). Metadata MDUs are replicated to all slots, while user data MDUs are striped per slot.
 3.  **Upload:** User uploads data.
 
+*Devnet note:* A gateway relay/faucet can sponsor gas for demos, but it is disabled by default in mainnet-parity mode. Production flows are wallet-signed; the gateway is optional.
+
 ### Step 2: The Liveness Loop
 *   **Scenario 1 (Viral):** Users swarm the file via retrieval sessions. SPs signal saturation. Chain checks `MaxSpend`.
     *   In **Mode 1**, the chain increases `Deal.CurrentReplication` and assigns additional Providers to store full replicas.

--- a/nil-website/website-spec.md
+++ b/nil-website/website-spec.md
@@ -148,7 +148,7 @@ type ServiceStatus = 'ok' | 'warn' | 'error';
 interface StatusSummary {
   lcd: ServiceStatus;      // Cosmos REST API
   evm: ServiceStatus;      // EVM JSON-RPC
-  faucet: ServiceStatus;   // Token Faucet
+  faucet: ServiceStatus;   // Token Faucet (dev-only; hidden when disabled)
   chainIdMatch: ServiceStatus; // Web3 Wallet vs App Config
   height?: number;         // Current block height
   networkName?: string;    // Chain ID from node

--- a/nil_gateway/nil-gateway-spec.md
+++ b/nil_gateway/nil-gateway-spec.md
@@ -201,6 +201,7 @@ To facilitate the "Store Wars" Devnet without a full WASM client, `nil_gateway` 
 1.  **The "Faucet Relayer":**
     *   The gateway can relay user‑signed intents (e.g., `create-deal-from-evm`, `update-deal-content-evm`) and submit provider proofs using a local key.
     *   This acts as a "Meta-Transaction" layer, sponsoring gas for web users while keeping user authorization in MetaMask.
+    *   **Dev-only:** this path is disabled by default. Enable with `NIL_ENABLE_TX_RELAY=1`; optional auto-funding uses `NIL_AUTO_FAUCET_EVM=1` (or `NIL_AUTO_FAUCET=1`).
 
 2.  **Triple Proof Generation:**
     *   Session‑proof submission uses on‑disk NilFS slabs to build `ChainedProof` objects for the requested blob range.
@@ -208,7 +209,8 @@ To facilitate the "Store Wars" Devnet without a full WASM client, `nil_gateway` 
     *   **Gap:** In a production "Thick Client", the browser would generate or verify these proofs locally. Here, the Gateway can generate and relay them, effectively simulating a "perfect" SP.
 
 3.  **Local Storage:**
-    *   The Gateway currently acts as the *sole* Storage Provider for the devnet web interface. It does not distribute data to other nodes; it merely simulates the lifecycle of a storage deal backed by its local filesystem.
+    *   The Gateway can act as a Storage Provider for local devnet flows, but it is **not** required to be the sole provider.
+    *   When configured with multiple providers, the gateway uploads Mode 2 shards to the assigned slots and can reconstruct missing shards on fetch.
 
 ## 5. Future Roadmap
 

--- a/whitepaper.md
+++ b/whitepaper.md
@@ -95,6 +95,8 @@ NilStore supports two redundancy modes conceptually:
 
 Clients may run fully in-browser using WASM and OPFS for local slab storage, or use the Go gateway/S3 adapter and CLI. The gateway is optional routing + caching infrastructure and never signs on behalf of the user; all on-chain actions require a wallet signature.
 
+*Devnet note:* a faucet-backed relay can be enabled for demos (sponsoring gas while preserving MetaMask authorization), but it is disabled by default in the mainnet-parity posture.
+
 ### Step 1: Ingestion & Placement
 1.  **Deal Creation:** User submits `MsgCreateDeal(Hint: "Hot", MaxSpend: 100 NIL)` which creates a thin-provisioned container.
 1.  **Commit Content:** After upload, the user commits the returned `manifest_root` via `MsgUpdateDealContent` (the Deal is empty until this commit).


### PR DESCRIPTION
## Summary
- align public whitepaper/litepaper and site specs with wallet-first devnet posture
- document dev-only relay/faucet flags in gateway spec
- clarify faucet status as dev-only in website spec

## Testing
- npm run lint (via pre-commit)
- npm run build (via pre-push)