### PR TITLE
Docs: website audit and cleanup

### DIFF
--- a/nil-website/src/components/Layout.tsx
+++ b/nil-website/src/components/Layout.tsx
@@ -32,6 +32,8 @@ export const Layout = () => {
       items: [
         { name: "Architecture", path: "/technology", description: "Deep dive into the protocol.", icon: <Cpu className="w-5 h-5" /> },
         { name: "Security", path: "/security", description: "Threat model and verification layers.", icon: <Shield className="w-5 h-5" /> },
+        { name: "Testnet Guide", path: "/testnet", description: "Wallet-first setup and local stack.", icon: <Terminal className="w-5 h-5" /> },
+        { name: "S3 Adapter", path: "/s3-adapter", description: "Web2 gateway and S3 API usage.", icon: <Terminal className="w-5 h-5" /> },
         { name: "Devnet Join", path: "/devnet", description: "Join a multi-provider devnet.", icon: <Terminal className="w-5 h-5" /> },
         { name: "FAQ", path: "/faq", description: "Common questions answered.", icon: <HelpCircle className="w-5 h-5" /> },
       ] 

--- a/nil-website/src/pages/S3AdapterDocs.tsx
+++ b/nil-website/src/pages/S3AdapterDocs.tsx
@@ -64,7 +64,9 @@ export const S3AdapterDocs = () => {
                 <div>aws --endpoint-url http://localhost:8080 s3 cp s3://deal-0/my_photo.jpg ./my_photo.jpg</div>
               </div>
               <p className="mt-2 text-xs text-muted-foreground">
-                Note: S3 upload currently requires a devnet deal that can be committed by the local gateway (faucet-authorized).
+                Devnet note: S3 uploads can auto-commit through the gateway relay when
+                <span className="font-mono"> NIL_ENABLE_TX_RELAY=1</span> (and optional faucet funding) are enabled.
+                In mainnet-parity mode, the gateway does not sign transactions; users must commit with a wallet.
               </p>
             </div>
 

--- a/nil-website/src/pages/TestnetDocs.tsx
+++ b/nil-website/src/pages/TestnetDocs.tsx
@@ -101,7 +101,7 @@ export const TestnetDocs = () => {
           <h2 className="text-2xl font-bold border-b pb-2 text-foreground">Web Flow (MetaMask + Deal)</h2>
           <p className="text-muted-foreground">
             All on-chain actions (create, update content, retrieval sessions) are signed by your wallet via the NilStore precompile.
-            If you want the "Get Testnet NIL" button, run the faucet and enable it in the UI with
+            The faucet is dev-only: if you want the "Get Testnet NIL" button, run the faucet and enable it in the UI with
             <code className="mx-1 px-1 py-0.5 rounded bg-secondary/60">VITE_ENABLE_FAUCET=1</code>.
           </p>
           <p className="text-sm text-muted-foreground">
@@ -145,7 +145,7 @@ export const TestnetDocs = () => {
             </div>
             <div className="mt-6 pt-4 border-t border-indigo-500/20">
                 <p className="text-sm text-gray-400 mb-2">
-                    <strong>Tip:</strong> Click "Connect Wallet" in the top-right corner of this site to auto-add this network to MetaMask. The UI now drives faucet and storage-deal submission end-to-end.
+                    <strong>Tip:</strong> Click "Connect Wallet" in the top-right corner of this site to auto-add this network to MetaMask. The UI drives wallet-signed transactions; relay/faucet are optional dev helpers.
                 </p>
             </div>
           </div>
@@ -176,12 +176,12 @@ export const TestnetDocs = () => {
                     2. Request Funds
                 </h3>
                 <p className="text-sm text-muted-foreground">
-                    Click below to receive 10 NIL testnet tokens directly to your connected wallet (EVM or Cosmos).
+                    If enabled, the faucet will send testnet tokens to your connected wallet (EVM or Cosmos).
                 </p>
                 <div className="p-4 bg-secondary/10 rounded-xl border border-border/50 flex flex-col items-center justify-center gap-2">
                     <FaucetWidget />
                     <p className="text-xs text-muted-foreground mt-2 text-center">
-                        Works with both 0x... and nil1... addresses.
+                        Works with both 0x... and nil1... addresses when the faucet is enabled.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add Testnet guide + S3 adapter links to main nav
- clarify dev-only faucet/relay wording in Testnet and S3 adapter docs

## Testing
- npm run lint (via pre-commit)
- npm run build (via pre-push)