### PR TITLE
Docs: sync gap matrix + onboarding runbooks

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -1,0 +1,138 @@
+# AGENTS TODO — Project Review → Spec/Doc Sync → Trusted Devnet Soft Launch (Feb 2026)
+
+Last updated: 2026-02-04
+
+This file is a **repo-tracked, PR-by-PR TODO list** for getting NilStore to a
+**trusted-collaborator devnet soft launch** (hub VPS + remote SPs).
+
+Conventions:
+- One PR per section (small, reviewable, test-gated).
+- Branch names use the `codex/` prefix.
+- Before pushing, run the **Test gate** listed for that PR.
+- After merging a PR, come back and check it off in a follow-up PR.
+
+## Launch profile (decisions locked)
+
+- Devnet type: **Trusted devnet** (hub on VPS + remote SPs)
+- Collaborators: **10–20**, invite-only; run for **2–3 weeks**
+- Economics posture: **low-cost but non-zero** (no “free infinite”)
+- Endpoints: **HTTPS subdomains** (e.g. `rpc.*`, `lcd.*`, `gateway.*`, `web.*`, `faucet.*`)
+- Deploy style: **systemd** services + static website build
+- Faucet: **enabled** (rate-limited; collaborator-only)
+
+## PR plan
+
+### PR1 — Docs reality check + gap matrix (CURRENT)
+
+- Branch: `codex/docs-review-gap-matrix`
+- Goal: Make it obvious **what exists**, **what CI proves**, and **what is still a gap**.
+- Test gate:
+  - `bash -n install.sh`
+
+Checklist:
+- [ ] Add this TODO file.
+- [ ] Update `docs/GAP_REPORT_REPO_ANCHORED.md` to match repo reality + CI coverage.
+- [ ] Fix doc index and onboarding docs (`DOCS.md`, `HAPPY_PATH.md`, `docs/TESTNET_READINESS_REPORT.md`).
+- [ ] Update repo-anchored agent runbook (`docs/AGENTS_RUNBOOK_REPO_ANCHORED.md`).
+- [ ] Replace Ignite boilerplate chain readme (`nilchain/readme.md`).
+- [ ] Fix `install.sh` CLI binary name (`nil_cli` vs `nil-cli`).
+
+---
+
+### PR2 — Spec-critical invariants (hard caps + safety rails)
+
+- Branch: `codex/spec-invariants-hard-caps`
+- Goal: Close the most dangerous “spec says enforced, code doesn’t” gaps.
+- Test gate:
+  - `go test ./nilchain/...`
+
+Checklist:
+- [ ] Enforce `MAX_DEAL_BYTES` cap in `MsgUpdateDealContent*` (spec + RFC requirement).
+- [ ] Add unit tests for cap enforcement and error messages.
+- [ ] Update `spec.md`/RFC cross-links only if needed (keep spec normative; track implementation status in gap report).
+
+---
+
+### PR3 — Wallet-first local E2E (no relay, no hidden signer)
+
+- Branch: `codex/e2e-wallet-first-no-relay`
+- Goal: Prove “no relay” posture works for real flows (not just docs).
+- Test gate:
+  - `scripts/e2e_browser_smoke_no_gateway.sh`
+  - (optional) `scripts/e2e_browser_libp2p_relay.sh`
+
+Checklist:
+- [ ] Add/extend an E2E script that runs with `NIL_ENABLE_TX_RELAY=0` and still completes create/commit/open-session/fetch.
+- [ ] Document the exact env var profile in `HAPPY_PATH.md` + `docs/TESTNET_READINESS_REPORT.md`.
+
+---
+
+### PR4 — Mode2 stripe integrity: byte-for-byte retrieval assertion
+
+- Branch: `codex/mode2-stripe-bytes-assert`
+- Goal: Upgrade the Mode2 Stripe E2E signal from “downloaded something” to “downloaded the right bytes”.
+- Test gate:
+  - `scripts/e2e_mode2_stripe_multi_sp.sh`
+
+Checklist:
+- [ ] Update `nil-website/tests/mode2-stripe.spec.ts` to assert downloaded bytes (or hash) == uploaded.
+- [ ] Ensure the test continues to work with chunked/ranged gateway fetches.
+
+---
+
+### PR5 — Allowlist access control test vectors (chain)
+
+- Branch: `codex/allowlist-merkle-tests`
+- Goal: Turn allowlist logic from “implemented” into “proven”.
+- Test gate:
+  - `go test ./nilchain/...`
+
+Checklist:
+- [ ] Add unit tests for `OpenRetrievalSessionSponsored` allowlist proof verification (valid + invalid paths).
+- [ ] Add deterministic merkle test vectors (keccak leaves, indices, paths).
+
+---
+
+### PR6 — Trusted devnet “soft launch” pack (ops + onboarding)
+
+- Branch: `codex/devnet-soft-launch-pack`
+- Goal: Make onboarding a collaborator a **30-minute task**, not an archeological dig.
+- Test gate:
+  - `scripts/run_devnet_alpha_multi_sp.sh start` (local smoke)
+
+Checklist:
+- [ ] Write `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` (roles, endpoints, funding, troubleshooting).
+- [ ] Add systemd unit templates + env-file templates for hub services.
+- [ ] Add a “remote SP join” quickstart (based on `DEVNET_MULTI_PROVIDER.md`, but simplified).
+- [ ] Add basic monitoring checklist (disk, RAM, ports, logs, chain height).
+
+---
+
+### PR7 — Website onboarding overhaul (collaborator UX)
+
+- Branch: `codex/website-onboarding-overhaul`
+- Goal: A collaborator can store and retrieve a file with minimal context.
+- Test gate:
+  - `npm -C nil-website run test:unit`
+  - `npm -C nil-website run build`
+
+Checklist:
+- [ ] Guided “First File” flow (connect → fund → alloc → upload → commit → retrieve).
+- [ ] Prominent environment/status panel (chain/gateway/provider health).
+- [ ] Copy-paste “share this with the devs” diagnostics bundle.
+
+---
+
+### PR8 — Dynamic pricing experiments (storage + retrieval)
+
+- Branch: `codex/dynamic-pricing-mvp`
+- Goal: Add a testable first version of dynamic pricing without destabilizing the devnet.
+- Test gate:
+  - `go test ./nilchain/...`
+  - `./e2e_retrieval_fees.sh`
+
+Checklist:
+- [ ] Define the minimal on-chain signal(s) (params vs. oracle vs. epoch-derived).
+- [ ] Implement pricing update mechanism + bounds.
+- [ ] Add simulation harness + invariants (no negative fees, monotonicity caps, etc.).
+

--- a/DOCS.md
+++ b/DOCS.md
@@ -54,3 +54,4 @@ This repo contains a mix of **normative protocol spec**, **RFC drafts**, **imple
 ## Planning / Tracking
 
 - `MAINNET_GAP_TRACKER.md`: Tracked gaps between current implementation and the long-term Mainnet plan.
+- `AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md`: PR-by-PR TODO list for the Feb 2026 trusted devnet soft launch.

--- a/HAPPY_PATH.md
+++ b/HAPPY_PATH.md
@@ -1,60 +1,64 @@
-# Context for Next Agent: NilStore Network Phase 3 Implementation
+# Local “Happy Path” Runbook
 
-## Current Status
-We are currently in **Phase 3: Code Implementation** of the NilStore Network development roadmap. We have just completed a major architectural pivot in the specification (Phase 1) and a comprehensive audit (Phase 2).
+This is the fastest way to prove the stack works **locally** (what CI uses) and
+to understand the intended devnet posture.
 
-### Recent Accomplishments
-1.  **Specification Overhaul (v2.6):**
-    *   **Unified Liveness:** Merged "Storage" and "Retrieval" markets. User retrievals now count as storage proofs.
-    *   **Performance Market:** Replaced strict "PoDE" timing checks with a **Block-Tiered Reward** system (Platinum/Gold/Silver).
-    *   **System-Defined Placement:** Deterministic slotting (`Hash(Deal+Block)`) to prevent Sybil attacks.
-    *   **Stripe-Aligned Elasticity:** Scaling now happens in units of `n=12` shards to ensure balanced throughput.
-    *   **MDU Architecture:** Standardized on **8 MiB Mega-Data Units** composed of 64 x 128 KiB KZG blobs.
-2.  **Codebase Updates:**
-    *   **`nil_core` (Rust):** Removed deprecated `argon2` logic. Added `rs-merkle` and `blake2` for MDU Merkle root computation. Updated FFI bindings to support MDU-centric verification.
-    *   **`nilchain` (Go):** 
-        *   Defined new Protobuf types (`Deal`, `Provider`, `KzgProof`, `RetrievalReceipt`) in `types.proto`.
-        *   Updated `tx.proto` with `MsgRegisterProvider`, `MsgCreateDeal`, `MsgProveLiveness`, `MsgSignalSaturation`.
-        *   Implemented `AssignProviders` logic in `Keeper` (Deterministic Placement).
-        *   Implemented `MsgCreateDeal` handler (Escrow deduction, Deal creation).
-        *   Implemented `MsgRegisterProvider` handler.
-        *   Implemented `MsgProveLiveness` handler (Unified verification, Tiered Rewards, Bandwidth payment).
-        *   Implemented `MsgSignalSaturation` handler (Saturation check, Budget check, Stripe-Aligned scaling).
+If you want a deeper manual checklist, use `docs/manual-devnet-runbook.md`.
 
-## Outstanding Tasks (Immediate To-Dos)
+## Option A — Scripted lifecycle (CI smoke)
 
-The next agent should focus on **verifying and refining the implementation**.
+Runs: stack start → create deal → upload → commit → open retrieval session → fetch → stop.
 
-### 1. Build & Verify
-*   **Run `ignite generate proto-go`**: Ensure all Protobuf updates are correctly generated.
-*   **Fix Compile Errors**: The recent large commits to `msg_server.go` likely introduced imports or type mismatches (e.g., `crypto_ffi` package usage).
-*   **Unit Tests**: Create `msg_server_test.go` to test:
-    *   `CreateDeal`: Verify deterministic placement produces distinct providers.
-    *   `ProveLiveness`: Verify tiered reward calculation (mock block heights).
-    *   `SignalSaturation`: Verify budget checks and replica counts.
+```bash
+scripts/e2e_lifecycle.sh
+```
 
-### 2. Core Cryptography (Rust)
-*   **Verify MDU Logic**: Ensure `nil_core` correctly computes Merkle roots for 64-blob batches.
-*   **FFI Integration**: The Go `crypto_ffi` package is calling Rust functions. Ensure the `libnil_core.a` is built and linked correctly for `go test` to pass.
+Notes:
+- This script **enables gateway tx relay + faucet** for convenience:
+  - `NIL_ENABLE_TX_RELAY=1`
+  - `NIL_START_FAUCET=1`
 
-### 3. End-to-End Simulation
-*   Run a simulated "Deal Lifecycle":
-    1.  Register 20 Providers.
-    2.  Create a Deal.
-    3.  Submit a "Platinum" Proof (immediate block).
-    4.  Check Provider Balance (should increase).
-    5.  Submit a "Fail" Proof (late block).
-    6.  Check Provider Balance (should not increase).
+## Option B — Scripted lifecycle (no local gateway)
 
-## Key Architectural References
-*   **`spec.md`**: Detailed normative spec (protocol + system constraints in §5).
-*   **`whitepaper.md`**: High-level unified economy logic.
+Same as Option A, but forces a “gateway absent” profile (direct SP fallback paths).
 
-## Prompt for Next Agent
-"You are resuming the implementation of the NilStore Network in Phase 3. The previous agent has implemented the core Message Handlers for `CreateDeal`, `ProveLiveness`, and `SignalSaturation` in `nilchain/x/nilchain/keeper/msg_server.go`, and updated the Rust `nil_core` cryptography library to support MDU Merkle proofs.
+```bash
+scripts/e2e_lifecycle_no_gateway.sh
+```
 
-Your goal is to **stabilize and verify** this code.
-1.  Run the build (`go build ./...` in `nilchain`). Fix any syntax errors or missing imports in the new `msg_server.go` code.
-2.  Create a unit test suite for the Keeper methods to verify the logic (Placement, Tiers, Rewards) works as intended.
-3.  Ensure the Rust FFI binding is correctly linked and callable from Go tests.
-4.  Once stable, document the 'Happy Path' execution trace."
+## Option C — Browser wallet-first E2E (Playwright)
+
+These are “wallet-first” flows (no gateway tx relay). They install an in-page
+E2E wallet when `VITE_E2E=1`.
+
+```bash
+# Upload falls back to direct SP (gateway absent)
+scripts/e2e_browser_smoke_no_gateway.sh
+
+# Retrieval uses libp2p relay transport
+scripts/e2e_browser_libp2p_relay.sh
+
+# Mode2 StripeReplica: 12 providers + gateway router + browser sharding
+scripts/e2e_mode2_stripe_multi_sp.sh
+```
+
+## Option D — Manual stack + manual steps
+
+```bash
+scripts/run_local_stack.sh start
+```
+
+Then follow: `docs/manual-devnet-runbook.md`.
+
+Stop the stack:
+
+```bash
+scripts/run_local_stack.sh stop
+```
+
+## Common “why did fetch fail?”
+
+- `missing X-Nil-Session-Id`: sessions are **required by default** on byte-serving
+  endpoints (`NIL_REQUIRE_ONCHAIN_SESSION=1`).
+- If you want legacy behavior (dev-only), you must explicitly opt-in:
+  - `NIL_UNSAFE_ALLOW_LEGACY_DOWNLOAD_SESSION=1` (do not use for testnet posture)

--- a/docs/AGENTS_RUNBOOK_REPO_ANCHORED.md
+++ b/docs/AGENTS_RUNBOOK_REPO_ANCHORED.md
@@ -44,9 +44,9 @@ In this repo, provider byte-serving endpoints are implemented in `nil_gateway/` 
 
 - HTTP router + handlers:
   - `nil_gateway/main.go`
-    - `GatewayFetch` (user-facing download path; supports `X-Nil-Session-Id` today but does not require it by default)
-    - `SpFetchShard` (provider shard fetch; currently no on-chain session gating)
-    - multiple devnet-only flows that sign txs using the `faucet` key (wallet-first parity work remains)
+    - `GatewayFetch` (user-facing download path; **requires** `X-Nil-Session-Id` by default via `NIL_REQUIRE_ONCHAIN_SESSION=1`)
+    - `SpFetchShard` (provider shard fetch; validates on-chain session + Mode2 slot/range constraints when sessions are required)
+    - dev-only tx relay flows (`NIL_ENABLE_TX_RELAY=0` by default; CI lifecycle scripts enable it explicitly)
   - `nil_gateway/router_proxy.go` (gateway proxy/router for provider requests)
   - `nil_gateway/p2p_server.go` (P2P requests; forwards `X-Nil-Session-Id` when present)
 
@@ -56,6 +56,7 @@ In this repo, provider byte-serving endpoints are implemented in `nil_gateway/` 
   - `nil-website/src/components/Dashboard.tsx` (create deal, faucet UX, upload/commit, retrieval flows)
   - `nil-website/src/hooks/useFaucet.ts` (browser-triggered faucet calls; should be dev-only in wallet-first mode)
   - `nil-website/src/hooks/useTransportRouter.ts` (adds `X-Nil-Session-Id` when downloading)
+  - `nil-website/src/lib/e2eWallet.ts` (Playwright: injects an in-page “wallet” when `VITE_E2E=1`)
 - Web contract doc:
   - `nil-website/website-spec.md`
 
@@ -181,4 +182,3 @@ Where to implement:
 
 Test gates:
 - chain unit tests + e2e “epoch progression” scripts (to be added)
-

--- a/docs/GAP_REPORT_REPO_ANCHORED.md
+++ b/docs/GAP_REPORT_REPO_ANCHORED.md
@@ -1,71 +1,108 @@
-# Gap Report (Repo-Anchored): NilStore Autonomous Runbook v2
+# Gap Report (Repo-Anchored): NilStore (Spec ↔ Code ↔ CI)
 
-Last updated: 2026-01-24
+Last updated: 2026-02-04
 
 This is the repo-specific gap matrix required by `docs/AGENTS_AUTONOMOUS_RUNBOOK.md`.
-It is intentionally “requirements-first”: each row links the runbook/RFC requirement to the *current* implementation and the concrete place to change it.
+It is intentionally **requirements-first**: each row links a spec/RFC requirement to:
+- the *current* implementation (repo-anchored refs),
+- the concrete CI/test signal that proves it works,
+- and what is **not** proven yet.
 
 Legend:
-- **Status**: DONE / PARTIAL / NOT STARTED
-- **Primary refs**: where to look in code today
-- **Test gate**: the minimum bar for considering the item “landed”
+- **Status**: DONE / PARTIAL / MISSING
+  - **DONE**: implemented + has at least one deterministic test gate in CI.
+  - **PARTIAL**: implemented, but missing invariants and/or missing test coverage.
+  - **MISSING**: spec/RFC requirement not implemented (or not wired end-to-end).
+
+## CI: what is actually exercised (today)
+
+- Unit tests
+  - Chain: `go test ./nilchain/...`
+  - Gateway: `go test ./nil_gateway/...`
+  - Rust: `cargo test` in `nil_core`, `nil_cli`, `nil_p2p`, `nil_mock_l1`
+  - Web: `nil-website` build + unit tests + lint
+- E2E scripts (run in CI)
+  - Lifecycle: `scripts/e2e_lifecycle.sh` (+ `scripts/e2e_lifecycle_no_gateway.sh`) — uses **gateway tx relay** for deterministic runs.
+  - Retrieval fees: `e2e_retrieval_fees.sh`
+  - Retrieval sessions (CLI): `e2e_open_retrieval_session_cli.sh`, `e2e_open_retrieval_session_mode2_cli.sh`
+  - Multi-SP regression: `scripts/ci_e2e_gateway_retrieval_multi_sp.sh`
+- Browser E2E (Playwright; wallet-first via in-page E2E wallet)
+  - `scripts/e2e_browser_smoke_no_gateway.sh`
+  - `scripts/e2e_browser_libp2p_relay.sh`
+  - `scripts/e2e_mode2_stripe_multi_sp.sh`
+
+## CI does NOT prove (be explicit)
+
+- WAN / multi-host devnet behavior (real latency, NAT, TLS, firewalling)
+- Long-running durability (restarts, reorgs, disk corruption, GC/compaction)
+- Dynamic pricing (storage or retrieval) beyond current parameterized fees
+- Adversarial cryptoeconomic behavior (griefing, strategic downtime, bribery)
+- Comprehensive security review / external audit
+
+## Phase 0 — Spec/code divergences to close before “trusted devnet soft launch”
+
+| Requirement | Status | Spec/RFC anchor | Current implementation (refs) | CI proof | Not proven / gap | Planned fix |
+|---|---:|---|---|---|---|---|
+| Enforce `MAX_DEAL_BYTES` hard cap (avoid unbounded state bloat) | MISSING | `spec.md` (“Hard Cap: 512 GiB”); `rfcs/rfc-data-granularity-and-economics.md` | No explicit cap enforcement in `nilchain/x/nilchain/keeper/msg_server.go` (`MsgUpdateDealContent*`) | N/A | Spec/RFC claim is not enforced; a malicious client can commit arbitrarily large `size_bytes` | PR2 (`codex/spec-invariants-hard-caps`) |
+| Mode2 Stripe retrieval: verify downloaded bytes == uploaded bytes | PARTIAL | `rfcs/rfc-blob-alignment-and-striping.md` | Mode2 flows implemented end-to-end, but Playwright asserts only “downloaded something” | `scripts/e2e_mode2_stripe_multi_sp.sh` | No byte-for-byte assertion in `nil-website/tests/mode2-stripe.spec.ts` | PR4 (`codex/mode2-stripe-bytes-assert`) |
+| Allowlist retrieval policy verification has test vectors | PARTIAL | `rfcs/rfc-retrieval-access-control-public-deals-and-vouchers.md` | Allowlist verification is implemented in `nilchain/x/nilchain/keeper/msg_server.go` (`OpenRetrievalSessionSponsored`) | N/A | No unit tests covering keccak merkle proofs; easiest place to regress | PR5 (`codex/allowlist-merkle-tests`) |
+| NilCE round-trip semantics are end-to-end and documented | PARTIAL | `rfcs/rfc-content-encoding-and-compression.md` | Upload-side wrapping + header parsing helpers exist in `nil_gateway/` (opt-in `NIL_NILCE=1`) | `go test ./nil_gateway/...` (NilCE unit tests) | Not required by CI E2E; fetch path does not currently auto-decode to match original bytes for Web2-style users | Defer (track separately if needed for launch) |
 
 ## Phase 1 — Deal expiry + renewal (ExtendDeal)
 
-| Requirement | Status | Current implementation (refs) | Gap / Notes | Planned fix (where) | Test gate |
-|---|---:|---|---|---|---|
-| Deal has an explicit `end_block` term bound | DONE | `nilchain/proto/nilchain/nilchain/v1/types.proto` (Deal.end_block); `nilchain/x/nilchain/keeper/msg_server.go` sets it on create | Term exists but is not enforced consistently | N/A | Covered indirectly by existing keeper tests |
-| Reject `UpdateDealContent*` once `height >= end_block` | NOT STARTED | `nilchain/x/nilchain/keeper/msg_server.go` (`UpdateDealContent`, `UpdateDealContentFromEvm`) has no expiry checks | Deals can be mutated after expiry | Add `if ctx.BlockHeight() >= deal.EndBlock { ... }` in both handlers | `go test ./nilchain/...` + new unit tests |
-| Reject `OpenRetrievalSession` once `height >= end_block` and enforce `expires_at <= end_block` | NOT STARTED | `nilchain/x/nilchain/keeper/msg_server.go` (`OpenRetrievalSession`) does not check deal term | Sessions can outlive paid term; sessions can open on expired deals | Add term checks in `OpenRetrievalSession` (and future open msgs) | existing retrieval session keeper tests + new expiry cases |
-| Reject `ProveLiveness` once `height >= end_block` | NOT STARTED | `nilchain/x/nilchain/keeper/msg_server.go` (`ProveLiveness`) does not check deal term | Providers can keep earning/claiming after expiry (depends on reward logic) | Add deal ACTIVE guard early in `ProveLiveness` | `go test ./nilchain/...` + new unit test |
-| Implement `MsgExtendDeal` with spot pricing at extension time | NOT STARTED | No `MsgExtendDeal` proto or handler | Renewal flow missing | Add proto in `nilchain/proto/.../tx.proto`; implement in `nilchain/x/nilchain/keeper/msg_server.go` | new keeper unit tests + extend an e2e script |
-| Prevent “duration overcharge after renewal” via `pricing_anchor_block` | NOT STARTED | Term deposit uses `duration := deal.EndBlock - deal.StartBlock` for new bytes | Renewals would overcharge bytes added after renewal | Add `Deal.pricing_anchor_block` + modify term deposit duration to use `EndBlock - PricingAnchorBlock` for *new bytes* | new keeper unit tests around updates-before/after renewal |
-| Provider/gateway treat expired deals as gone; GC after `end_block + grace` | NOT STARTED | Gateway can read local shards without consulting deal term (`nil_gateway/main.go` `SpFetchShard`) | Serving expired deals breaks “no sessions after expiry” story and retention horizon | Add chain term checks in `GatewayFetch`/`SpFetchShard`; add GC worker (or document ops) | extend `./scripts/e2e_lifecycle.sh` with expiry + fetch failure |
+| Requirement | Status | Current implementation (refs) | CI proof | Not proven / gap |
+|---|---:|---|---|---|
+| Deal has an explicit `end_block` term bound | DONE | `nilchain/proto/nilchain/nilchain/v1/types.proto` (Deal.end_block); set in `MsgCreateDeal*` handlers (`nilchain/x/nilchain/keeper/msg_server.go`) | `go test ./nilchain/...` | — |
+| Reject `UpdateDealContent*` once `height >= end_block` | DONE | `nilchain/x/nilchain/keeper/msg_server.go` (`UpdateDealContent`, `UpdateDealContentFromEvm`) | `go test ./nilchain/...` | — |
+| Reject retrieval session opens once `height >= end_block` and enforce `expires_at <= end_block` | DONE | `nilchain/x/nilchain/keeper/msg_server.go` (`OpenRetrievalSession`, `OpenRetrievalSessionSponsored`, `OpenProtocolRetrievalSession`) | `go test ./nilchain/...` | — |
+| Reject liveness/retrieval proofs once `height >= end_block` | DONE | `nilchain/x/nilchain/keeper/msg_server.go` (`ProveLiveness`, retrieval proof paths) | `go test ./nilchain/...` | — |
+| Implement `MsgExtendDeal` with spot pricing at extension time | DONE | `nilchain/proto/nilchain/nilchain/v1/tx.proto` + `nilchain/x/nilchain/keeper/msg_server.go` (`ExtendDeal`) | `nilchain/x/nilchain/keeper/msg_server_extend_deal_test.go` | — |
+| Prevent renewal overcharge via `pricing_anchor_block` | DONE | `nilchain/proto/.../types.proto` (Deal.pricing_anchor_block); duration uses anchor in `msg_server.go` | `nilchain/x/nilchain/keeper/msg_server_extend_deal_test.go` | — |
+| Refuse serving expired deals on data plane | DONE | `nil_gateway/main.go` (`GatewayFetch`, `SpFetchShard`) fetch deal meta and reject expired deals | `go test ./nil_gateway/...` + CI E2E scripts | Disk GC after grace is not implemented (ops/process gap) |
 
 ## Phase 2 — Mandatory retrieval sessions for all served bytes
 
-| Requirement | Status | Current implementation (refs) | Gap / Notes | Planned fix (where) | Test gate |
-|---|---:|---|---|---|---|
-| Data-plane requests MUST include `X-Nil-Session-Id` | PARTIAL | `nil_gateway/main.go` `GatewayFetch` parses `X-Nil-Session-Id`; CORS allows the header | Header is optional today; SP fetch (`SpFetchShard`) does not require it | Enforce header presence on any byte-serving endpoint in `nil_gateway/main.go` | add/extend e2e to assert out-of-session reads fail |
-| Validate session is `OPEN`, unexpired, and bound to (deal, provider/slot, manifest_root) | PARTIAL | Chain session open validates manifest/provider/range (`nilchain/.../msg_server.go`); gateway has on-chain session aware flow for some fetches | Need “always-on” validation on serve path (including SP endpoints) | Centralize “session validate + range validate” helper in `nil_gateway/` and enforce everywhere | gateway unit tests + multi-SP e2e |
-| Enforce blob alignment + subset-of-session-range only (batching preserved) | PARTIAL | Chain enforces blob-range invariants at open (Mode 2 slot confinement); gateway supports ranged fetch behavior | Need enforce on serve path (esp. `SpFetchShard`); ensure batching is supported without over-constraining | Implement in gateway/provider read path; document accepted segmentation | e2e segmented vs batched download tests |
+| Requirement | Status | Current implementation (refs) | CI proof | Not proven / gap |
+|---|---:|---|---|---|
+| Data-plane requests MUST include `X-Nil-Session-Id` | DONE | `nil_gateway/main.go`: `NIL_REQUIRE_ONCHAIN_SESSION=1` default; enforced in `GatewayFetch` and `SpFetchShard` | `nil_gateway/session_enforcement_test.go`; `e2e_open_retrieval_session_cli.sh` | — |
+| Validate session is `OPEN`, unexpired, and bound to (deal, provider/slot, manifest_root) | DONE | `nil_gateway/main.go` (`SpFetchShard` validates deal+root+status+expiry); chain validates on open | `nil_gateway/session_enforcement_test.go`; `nilchain/x/nilchain/keeper/msg_server_retrieval_sessions_test.go` | Gateway-wide “all endpoints” auditing is not automated (human review needed when adding new byte-serving endpoints) |
+| Enforce Mode2 slot confinement + subset-of-session-range (batching preserved) | DONE | Chain range invariants in `nilchain/x/nilchain/keeper/msg_server.go`; gateway enforces slot mapping in `SpFetchShard` | `e2e_open_retrieval_session_mode2_cli.sh`; keeper tests | — |
 
 ## Phase 3 — Retrieval policies + sponsored/public sessions
 
-| Requirement | Status | Current implementation (refs) | Gap / Notes | Planned fix (where) | Test gate |
-|---|---:|---|---|---|---|
-| Deal retrieval policy fields (OwnerOnly/Allowlist/Voucher/Public) | NOT STARTED | No retrieval policy fields in `types.proto` | Only “owner-only” is enforced implicitly by `OpenRetrievalSession` | Add fields to `nilchain/proto/.../types.proto`; default to OwnerOnly for existing deals | keeper unit tests + protobuf regen |
-| `MsgOpenRetrievalSession` remains owner-only and owner-paid (frozen semantics) | DONE | `nilchain/x/nilchain/keeper/msg_server.go` enforces `msg.Creator == deal.Owner` and debits deal escrow | Must stay unchanged | N/A | existing keeper tests |
-| Implement requester-paid `MsgOpenRetrievalSessionSponsored` | NOT STARTED | No msg/handler | Needed so public/3p retrieval can’t drain deal escrow | Add proto + handler; add session funding fields; refund routing to payer | new unit tests + e2e public deal retrieval |
-| Implement allowlist verification (merkle root + proof) | NOT STARTED | No allowlist fields/logic | | Add merkle root field + proof verification in sponsored open | unit tests with test vectors |
-| Implement voucher (EIP-712 signature) + one-time nonce anti-replay | NOT STARTED | Chain has nonces for `OpenRetrievalSession` but not vouchers | Voucher replay prevention needs explicit nonce tracking | Add voucher nonce storage keyed by (deal, signer) or (deal, voucher-id) | unit tests + e2e replay attempt |
+| Requirement | Status | Current implementation (refs) | CI proof | Not proven / gap |
+|---|---:|---|---|---|
+| Deal retrieval policy fields (OwnerOnly/Allowlist/Voucher/Public) | DONE | `nilchain/proto/nilchain/nilchain/v1/types.proto` (RetrievalPolicy); `MsgUpdateDealRetrievalPolicy` in `tx.proto` + `msg_server.go` | `go test ./nilchain/...` | — |
+| `MsgOpenRetrievalSession` remains owner-only and owner-paid (frozen semantics) | DONE | `nilchain/x/nilchain/keeper/msg_server.go` (`OpenRetrievalSession`) | `nilchain/x/nilchain/keeper/msg_server_retrieval_sessions_test.go` | — |
+| Implement requester-paid `MsgOpenRetrievalSessionSponsored` | DONE | `nilchain/x/nilchain/keeper/msg_server.go` (`OpenRetrievalSessionSponsored`) | `nilchain/x/nilchain/keeper/msg_server_sponsored_sessions_test.go` | — |
+| Implement allowlist verification (merkle root + proof) | PARTIAL | Implemented in `OpenRetrievalSessionSponsored`, but no tests | N/A | Missing deterministic test vectors (see Phase 0) |
+| Implement voucher (EIP-712 signature) + one-time nonce anti-replay | DONE | `OpenRetrievalSessionSponsored` + voucher nonce tracking in keeper | `nilchain/x/nilchain/keeper/msg_server_sponsored_sessions_test.go` | — |
 
 ## Phase 4 — Protocol retrieval hooks (audit/repair) + audit budget
 
-| Requirement | Status | Current implementation (refs) | Gap / Notes | Planned fix (where) | Test gate |
-|---|---:|---|---|---|---|
-| Implement `MsgOpenProtocolRetrievalSession` | NOT STARTED | No msg/handler | Required for audits + repairs on restricted deals | Add proto + handler; deterministic auth rules | unit tests + multi-SP repair e2e |
-| Deterministic protocol auth: repair sessions only for `pending_provider` of REPAIRING slot | PARTIAL | Mode 2 repair concepts exist in `nilchain/x/nilchain/keeper/slashing_repair_test.go` and slot rules in `ProveLiveness` | Repair traffic is not session-accounted yet | Implement protocol open checks against slot state | `./scripts/e2e_deputy_ghost_repair_multi_sp.sh` extension |
-| Audit budget mint/caps + spending for protocol sessions | NOT STARTED | No dedicated audit budget module/accounting | Needed to fund audit traffic without draining users | Implement per RFC under `nilchain/x/nilchain/keeper/` and params | chain unit tests + epoch simulation |
+| Requirement | Status | Current implementation (refs) | CI proof | Not proven / gap |
+|---|---:|---|---|---|
+| Implement `MsgOpenProtocolRetrievalSession` | DONE | `nilchain/proto/.../tx.proto` + `nilchain/x/nilchain/keeper/msg_server.go` | `nilchain/x/nilchain/keeper/msg_server_protocol_sessions_test.go` | — |
+| Deterministic protocol auth (repair sessions only for pending provider of repairing slot) | DONE | `OpenProtocolRetrievalSession` REPAIR auth + Mode2 slot checks in keeper | `nilchain/x/nilchain/keeper/msg_server_protocol_sessions_test.go` | Multi-host repair flows are not yet validated (CI is single-machine) |
+| Audit budget mint/caps + spending for protocol sessions | DONE | `nilchain/x/nilchain/keeper/epoch_audit.go` + protocol budget module accounting | `nilchain/x/nilchain/keeper/epoch_audit_test.go` | — |
 
 ## Phase 5 — Compression-aware content pipeline (NilCEv1)
 
-| Requirement | Status | Current implementation (refs) | Gap / Notes | Planned fix (where) | Test gate |
-|---|---:|---|---|---|---|
-| Compress plaintext pre-encryption and store ciphertext bytes (pricing on stored size) | NOT STARTED | `nil_core/src/layout.rs` defines compression flags, but gateway does not implement NilCEv1 pipeline | End-to-end compression behavior missing | Implement NilCEv1 header + zstd/gzip in `nil_gateway/` and WASM pipeline | unit tests + browser smoke |
-| Decompress post-decrypt on retrieval | NOT STARTED | No NilCEv1 decode path | | Implement decode in gateway/wasm; ensure partial reads fetch header blobs | unit tests around header parsing |
+| Requirement | Status | Current implementation (refs) | CI proof | Not proven / gap |
+|---|---:|---|---|---|
+| Optional compression-aware uploads (NilCE v1 header + zstd) | PARTIAL | `nil_gateway/nilce.go` + `nil_gateway/main.go` (`NIL_NILCE=1`) | `nil_gateway/nilce_test.go` | No CI E2E coverage; retrieval semantics are “return stored bytes” (no auto-decode) |
 
 ## Phase 6 — Wallet-first UX (no relay/faucet dependency outside dev)
 
-| Requirement | Status | Current implementation (refs) | Gap / Notes | Planned fix (where) | Test gate |
-|---|---:|---|---|---|---|
-| MetaMask-signed transactions for create/commit/open/confirm/cancel/extend | PARTIAL | EVM bridge msgs exist (`MsgCreateDealFromEvm`, `MsgUpdateDealContentFromEvm`); UI still uses faucet UX flows | Many write paths still rely on faucet/gateway signing in devnet | Remove/flag faucet flows; add missing EVM-msg equivalents where needed | playwright smoke in “no faucet” mode |
-| Disable tx relay + faucet by default (dev-only opt-in) | NOT STARTED | `nil_gateway/main.go` contains faucet signing and “creator has no balance” checks; website has `useFaucet` | Mainnet parity posture not default | Add explicit env flags (`ENABLE_TX_RELAY`, `NIL_AUTO_FAUCET_EVM` etc) and default off | e2e smoke with flags disabled |
+| Requirement | Status | Current implementation (refs) | CI proof | Not proven / gap |
+|---|---:|---|---|---|
+| Disable tx relay by default (dev-only opt-in) | DONE | `nil_gateway/main.go`: `NIL_ENABLE_TX_RELAY=0` default; `scripts/run_local_stack.sh` defaults relay off | CI jobs still enable relay for `scripts/e2e_lifecycle.sh` | Add a dedicated “no relay” CLI E2E if desired (wallet-first is already covered in browser E2E) |
+| Wallet-first chain writes (browser) | DONE | `nil-website/src/lib/e2eWallet.ts` injects E2E wallet for Playwright when `VITE_E2E=1` | Playwright suites listed above | Human UX polish for real MetaMask + remote RPC endpoints is still needed for soft launch |
 
-## Phase 7 — Economics (base rewards, draining, quotas hardening)
+## Phase 7 — Economics (rewards, draining, retrieval fees)
 
-| Requirement | Status | Current implementation (refs) | Gap / Notes | Planned fix (where) | Test gate |
-|---|---:|---|---|---|---|
-| Base reward pool mint/distribution | COMPLETE | `nilchain/x/nilchain/keeper/base_rewards.go` (epoch rent → mint → per-provider distribution) | — | — | `nilchain/x/nilchain/keeper/base_rewards_test.go` |
-| Provider draining / exit | COMPLETE | `nilchain/x/nilchain/keeper/draining.go`, `nilchain/x/nilchain/keeper/msg_provider_draining.go` | — | — | `nilchain/x/nilchain/keeper/draining_test.go` |
-| Quotas/credits exclude expired deals + exclude REPAIRING for rewards | COMPLETE | Expiry checks in `slashing.go`/`base_rewards.go`; REPAIRING excluded in `slashing.go` and reward weights | — | — | `nilchain/x/nilchain/keeper/slashing_repair_test.go` |
+| Requirement | Status | Current implementation (refs) | CI proof | Not proven / gap |
+|---|---:|---|---|---|
+| Base reward pool mint/distribution | DONE | `nilchain/x/nilchain/keeper/base_rewards.go` | `nilchain/x/nilchain/keeper/base_rewards_test.go` | — |
+| Provider draining / exit | DONE | `nilchain/x/nilchain/keeper/draining.go`, `nilchain/x/nilchain/keeper/msg_provider_draining.go` | `nilchain/x/nilchain/keeper/draining_test.go` | — |
+| Retrieval fees (base + per-blob) settlement | DONE | `nilchain/x/nilchain/keeper/msg_server_retrieval_fees_test.go` | `e2e_retrieval_fees.sh` | “Dynamic” pricing is not implemented (separate track) |

--- a/docs/TESTNET_READINESS_REPORT.md
+++ b/docs/TESTNET_READINESS_REPORT.md
@@ -38,6 +38,11 @@ Runs a full lifecycle test (stack start -> create deal -> upload -> commit -> fe
 ./scripts/e2e_lifecycle.sh
 ```
 
+Notes:
+- This script is intentionally “dev convenient”: it enables the gateway tx relay and faucet so
+  the run is deterministic and does not require a real wallet UX.
+- “Wallet-first / no relay” posture is covered by the Playwright suites (see below).
+
 ## Manual devnet runbook
 
 For a choreography that mirrors the automated suites but is executed manually (create/upload/commit/fetch, multi-SP proofs, deputy repair, economic checks), follow `docs/manual-devnet-runbook.md`. Keep it in sync with the scripts listed above so the steps remain accurate as the system evolves.
@@ -59,9 +64,10 @@ All items below are expected to be verifiable via the unit tests and/or the e2e 
   - Audit budget + task derivation tests: `nilchain/x/nilchain/keeper/epoch_audit_test.go`
   - Protocol session open/consume tests: `nilchain/x/nilchain/keeper/msg_server_protocol_sessions_test.go`
 - Compression round-trip:
-  - Gateway NilCE compression flag support is exercised by gateway upload/fetch flows; verify via `scripts/e2e_lifecycle.sh` using a compressible file.
+  - NilCE v1 is **opt-in** (`NIL_NILCE=0` by default). The encode/decode helpers are unit-tested in `nil_gateway/nilce_test.go`.
+  - CI does not currently require NilCE-enabled end-to-end coverage.
 - Wallet-first chain writes (MetaMask/EVM signed intents; no relayer required):
-  - EVM bridge/precompile flows are exercised by `scripts/e2e_lifecycle.sh` (EVM-signed create + commit).
+  - Covered by Playwright E2E flows (in-page E2E wallet when `VITE_E2E=1`), not by `scripts/e2e_lifecycle.sh`.
 
 ## Provider draining / controlled churn (Phase 7)
 
@@ -86,3 +92,5 @@ go test ./...
 ## What remains / known gaps
 
 - Mode1 does not yet have explicit make-before-break churn state (drain/rotation schedulers are Mode2-only).
+- Mode2 Stripe Playwright E2E asserts “downloaded bytes exist”, but does not yet assert byte-for-byte equality with the upload (`nil-website/tests/mode2-stripe.spec.ts`).
+- `MAX_DEAL_BYTES` hard cap is described in `spec.md` / `rfcs/rfc-data-granularity-and-economics.md` but is not enforced in `MsgUpdateDealContent*` today (tracked in `docs/GAP_REPORT_REPO_ANCHORED.md`).

--- a/install.sh
+++ b/install.sh
@@ -55,11 +55,11 @@ cd nil_faucet
 go build -o ../bin/nil_faucet main.go
 cd ..
 
-# 6. Build nil-cli
-echo "🛠️  Building nil-cli..."
+# 6. Build nil_cli
+echo "🛠️  Building nil_cli..."
 cd nil_cli
 cargo build --release
-cp target/release/nil-cli ../bin/
+cp target/release/nil_cli ../bin/
 cd ..
 
 echo "-------------------------------------------"
@@ -75,4 +75,4 @@ echo "To start a P2P storage node:"
 echo "  ./bin/nil_p2p --port 9000"
 echo ""
 echo "To verify installation:"
-echo "  ./bin/nil-cli --help"
+echo "  ./bin/nil_cli --help"

--- a/nilchain/readme.md
+++ b/nilchain/readme.md
@@ -1,50 +1,62 @@
-# nilchain
-**nilchain** is a blockchain built using Cosmos SDK and Tendermint and created with [Ignite CLI](https://ignite.com/cli).
+# nilchain (NilStore L1)
 
-## Get started
+`nilchain` is the Cosmos SDK + Ethermint chain for NilStore. It tracks Deals,
+Providers, retrieval sessions, rewards, Mode2 slot state, and audit/repair flows.
 
-```
-ignite chain serve
-```
+Canonical protocol spec: `../spec.md` and `../rfcs/`.
 
-`serve` command installs dependencies, builds, initializes, and starts your blockchain in development.
+## Quick start (recommended)
 
-### Configure
+Use the repo orchestrators instead of Ignite:
 
-Your blockchain in development can be configured with `config.yml`. To learn more, see the [Ignite CLI docs](https://docs.ignite.com).
-
-### Web Frontend
-
-Additionally, Ignite CLI offers a frontend scaffolding feature (based on Vue) to help you quickly build a web frontend for your blockchain:
-
-Use: `ignite scaffold vue`
-This command can be run within your scaffolded blockchain project.
-
-
-For more information see the [monorepo for Ignite front-end development](https://github.com/ignite/web).
-
-## Release
-To release a new version of your blockchain, create and push a new tag with `v` prefix. A new draft release with the configured targets will be created.
-
-```
-git tag v0.1
-git push origin v0.1
+```bash
+../scripts/run_local_stack.sh start
+../scripts/run_local_stack.sh stop
 ```
 
-After a draft release is created, make your final changes from the release page and publish it.
+For a full CI-style lifecycle: `../scripts/e2e_lifecycle.sh`.
 
-### Install
-To install the latest version of your blockchain node's binary, execute the following command on your machine:
+## Build
 
+Requirements:
+- Go 1.22+
+- Rust (stable)
+
+Build the native crypto library first (used via cgo/FFI):
+
+```bash
+cd ../nil_core
+cargo build --release
 ```
-curl https://get.ignite.com/username/nilchain@latest! | sudo bash
+
+Build `nilchaind`:
+
+```bash
+cd ../nilchain
+export CGO_LDFLAGS="-L$(pwd)/../nil_core/target/release -lnil_core -ldl -lpthread -lm"
+go build -o ../bin/nilchaind ./cmd/nilchaind
 ```
-`username/nilchain` should match the `username` and `repo_name` of the Github repository to which the source code was pushed. Learn more about [the install process](https://github.com/ignite/installer).
 
-## Learn more
+Notes:
+- The trusted setup is `nilchain/trusted_setup.txt`. Many local scripts export
+  `KZG_TRUSTED_SETUP` automatically; if you run manually, set it explicitly.
+- On Linux, set `LD_LIBRARY_PATH` to include `../nil_core/target/release`.
+- On macOS, set `DYLD_LIBRARY_PATH` to include `../nil_core/target/release`.
 
-- [Ignite CLI](https://ignite.com/cli)
-- [Tutorials](https://docs.ignite.com/guide)
-- [Ignite CLI docs](https://docs.ignite.com)
-- [Cosmos SDK docs](https://docs.cosmos.network)
-- [Developer Chat](https://discord.com/invite/ignitecli)
+## Tests
+
+```bash
+go test ./...
+```
+
+If tests fail to load `libnil_core`, set:
+
+```bash
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$(pwd)/../nil_core/target/release"
+```
+
+## Code map
+
+- Protos: `proto/nilchain/nilchain/v1/*.proto`
+- Module implementation: `x/nilchain/`
+- Rust FFI bindings used by Go: `x/crypto_ffi/`

--- a/notes/agent_context_phase3_legacy.md
+++ b/notes/agent_context_phase3_legacy.md
@@ -1,0 +1,69 @@
+# Legacy Agent Context (formerly `HAPPY_PATH.md`)
+
+This file preserves historical “context for next agent” notes that were previously
+stored in `HAPPY_PATH.md`. The filename was misleading — it was not a runnable
+happy-path runbook.
+
+---
+
+# Context for Next Agent: NilStore Network Phase 3 Implementation
+
+## Current Status
+We are currently in **Phase 3: Code Implementation** of the NilStore Network development roadmap. We have just completed a major architectural pivot in the specification (Phase 1) and a comprehensive audit (Phase 2).
+
+### Recent Accomplishments
+1.  **Specification Overhaul (v2.6):**
+    *   **Unified Liveness:** Merged "Storage" and "Retrieval" markets. User retrievals now count as storage proofs.
+    *   **Performance Market:** Replaced strict "PoDE" timing checks with a **Block-Tiered Reward** system (Platinum/Gold/Silver).
+    *   **System-Defined Placement:** Deterministic slotting (`Hash(Deal+Block)`) to prevent Sybil attacks.
+    *   **Stripe-Aligned Elasticity:** Scaling now happens in units of `n=12` shards to ensure balanced throughput.
+    *   **MDU Architecture:** Standardized on **8 MiB Mega-Data Units** composed of 64 x 128 KiB KZG blobs.
+2.  **Codebase Updates:**
+    *   **`nil_core` (Rust):** Removed deprecated `argon2` logic. Added `rs-merkle` and `blake2` for MDU Merkle root computation. Updated FFI bindings to support MDU-centric verification.
+    *   **`nilchain` (Go):** 
+        *   Defined new Protobuf types (`Deal`, `Provider`, `KzgProof`, `RetrievalReceipt`) in `types.proto`.
+        *   Updated `tx.proto` with `MsgRegisterProvider`, `MsgCreateDeal`, `MsgProveLiveness`, `MsgSignalSaturation`.
+        *   Implemented `AssignProviders` logic in `Keeper` (Deterministic Placement).
+        *   Implemented `MsgCreateDeal` handler (Escrow deduction, Deal creation).
+        *   Implemented `MsgRegisterProvider` handler.
+        *   Implemented `MsgProveLiveness` handler (Unified verification, Tiered Rewards, Bandwidth payment).
+        *   Implemented `MsgSignalSaturation` handler (Saturation check, Budget check, Stripe-Aligned scaling).
+
+## Outstanding Tasks (Immediate To-Dos)
+
+The next agent should focus on **verifying and refining the implementation**.
+
+### 1. Build & Verify
+*   **Run `ignite generate proto-go`**: Ensure all Protobuf updates are correctly generated.
+*   **Fix Compile Errors**: The recent large commits to `msg_server.go` likely introduced imports or type mismatches (e.g., `crypto_ffi` package usage).
+*   **Unit Tests**: Create `msg_server_test.go` to test:
+    *   `CreateDeal`: Verify deterministic placement produces distinct providers.
+    *   `ProveLiveness`: Verify tiered reward calculation (mock block heights).
+    *   `SignalSaturation`: Verify budget checks and replica counts.
+
+### 2. Core Cryptography (Rust)
+*   **Verify MDU Logic**: Ensure `nil_core` correctly computes Merkle roots for 64-blob batches.
+*   **FFI Integration**: The Go `crypto_ffi` package is calling Rust functions. Ensure the `libnil_core.a` is built and linked correctly for `go test` to pass.
+
+### 3. End-to-End Simulation
+*   Run a simulated "Deal Lifecycle":
+    1.  Register 20 Providers.
+    2.  Create a Deal.
+    3.  Submit a "Platinum" Proof (immediate block).
+    4.  Check Provider Balance (should increase).
+    5.  Submit a "Fail" Proof (late block).
+    6.  Check Provider Balance (should not increase).
+
+## Key Architectural References
+*   **`spec.md`**: Detailed normative spec (protocol + system constraints in §5).
+*   **`whitepaper.md`**: High-level unified economy logic.
+
+## Prompt for Next Agent
+"You are resuming the implementation of the NilStore Network in Phase 3. The previous agent has implemented the core Message Handlers for `CreateDeal`, `ProveLiveness`, and `SignalSaturation` in `nilchain/x/nilchain/keeper/msg_server.go`, and updated the Rust `nil_core` cryptography library to support MDU Merkle proofs.
+
+Your goal is to **stabilize and verify** this code.
+1.  Run the build (`go build ./...` in `nilchain`). Fix any syntax errors or missing imports in the new `msg_server.go` code.
+2.  Create a unit test suite for the Keeper methods to verify the logic (Placement, Tiers, Rewards) works as intended.
+3.  Ensure the Rust FFI binding is correctly linked and callable from Go tests.
+4.  Once stable, document the 'Happy Path' execution trace."
+


### PR DESCRIPTION
## Summary
- Added `AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md` (PR-by-PR launch TODO).
- Updated repo-anchored gap matrix to reflect current implementation + CI coverage.
- Fixed onboarding docs (`HAPPY_PATH.md`, `DOCS.md`, `docs/TESTNET_READINESS_REPORT.md`).
- Updated agent runbook mapping (`docs/AGENTS_RUNBOOK_REPO_ANCHORED.md`).
- Replaced Ignite boilerplate with `nilchain`-specific readme.
- Fixed `install.sh` to copy the correct CLI binary (`nil_cli`).

## Test
- `bash -n install.sh`
