### PR TITLE
nilchain: enforce MAX_DEAL_BYTES hard cap

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -22,29 +22,30 @@ Conventions:
 
 ## PR plan
 
-### PR1 — Docs reality check + gap matrix (CURRENT)
+### PR1 — Docs reality check + gap matrix (MERGED)
 
 - Branch: `codex/docs-review-gap-matrix`
 - Goal: Make it obvious **what exists**, **what CI proves**, and **what is still a gap**.
+- PR: https://github.com/Nil-Store/nil-store/pull/57
 - Test gate:
   - `bash -n install.sh`
 
 Checklist:
-- [ ] Add this TODO file.
-- [ ] Update `docs/GAP_REPORT_REPO_ANCHORED.md` to match repo reality + CI coverage.
-- [ ] Fix doc index and onboarding docs (`DOCS.md`, `HAPPY_PATH.md`, `docs/TESTNET_READINESS_REPORT.md`).
-- [ ] Update repo-anchored agent runbook (`docs/AGENTS_RUNBOOK_REPO_ANCHORED.md`).
-- [ ] Replace Ignite boilerplate chain readme (`nilchain/readme.md`).
-- [ ] Fix `install.sh` CLI binary name (`nil_cli` vs `nil-cli`).
+- [x] Add this TODO file.
+- [x] Update `docs/GAP_REPORT_REPO_ANCHORED.md` to match repo reality + CI coverage.
+- [x] Fix doc index and onboarding docs (`DOCS.md`, `HAPPY_PATH.md`, `docs/TESTNET_READINESS_REPORT.md`).
+- [x] Update repo-anchored agent runbook (`docs/AGENTS_RUNBOOK_REPO_ANCHORED.md`).
+- [x] Replace Ignite boilerplate chain readme (`nilchain/readme.md`).
+- [x] Fix `install.sh` CLI binary name (`nil_cli` vs `nil-cli`).
 
 ---
 
-### PR2 — Spec-critical invariants (hard caps + safety rails)
+### PR2 — Spec-critical invariants (hard caps + safety rails) (CURRENT)
 
 - Branch: `codex/spec-invariants-hard-caps`
 - Goal: Close the most dangerous “spec says enforced, code doesn’t” gaps.
 - Test gate:
-  - `go test ./nilchain/...`
+  - `cd nilchain && go test ./...`
 
 Checklist:
 - [ ] Enforce `MAX_DEAL_BYTES` cap in `MsgUpdateDealContent*` (spec + RFC requirement).
@@ -85,7 +86,7 @@ Checklist:
 - Branch: `codex/allowlist-merkle-tests`
 - Goal: Turn allowlist logic from “implemented” into “proven”.
 - Test gate:
-  - `go test ./nilchain/...`
+  - `cd nilchain && go test ./...`
 
 Checklist:
 - [ ] Add unit tests for `OpenRetrievalSessionSponsored` allowlist proof verification (valid + invalid paths).
@@ -128,11 +129,10 @@ Checklist:
 - Branch: `codex/dynamic-pricing-mvp`
 - Goal: Add a testable first version of dynamic pricing without destabilizing the devnet.
 - Test gate:
-  - `go test ./nilchain/...`
+  - `cd nilchain && go test ./...`
   - `./e2e_retrieval_fees.sh`
 
 Checklist:
 - [ ] Define the minimal on-chain signal(s) (params vs. oracle vs. epoch-derived).
 - [ ] Implement pricing update mechanism + bounds.
 - [ ] Add simulation harness + invariants (no negative fees, monotonicity caps, etc.).
-

--- a/docs/GAP_REPORT_REPO_ANCHORED.md
+++ b/docs/GAP_REPORT_REPO_ANCHORED.md
@@ -17,7 +17,7 @@ Legend:
 ## CI: what is actually exercised (today)
 
 - Unit tests
-  - Chain: `go test ./nilchain/...`
+  - Chain: `cd nilchain && go test ./...`
   - Gateway: `go test ./nil_gateway/...`
   - Rust: `cargo test` in `nil_core`, `nil_cli`, `nil_p2p`, `nil_mock_l1`
   - Web: `nil-website` build + unit tests + lint
@@ -43,7 +43,7 @@ Legend:
 
 | Requirement | Status | Spec/RFC anchor | Current implementation (refs) | CI proof | Not proven / gap | Planned fix |
 |---|---:|---|---|---|---|---|
-| Enforce `MAX_DEAL_BYTES` hard cap (avoid unbounded state bloat) | MISSING | `spec.md` (“Hard Cap: 512 GiB”); `rfcs/rfc-data-granularity-and-economics.md` | No explicit cap enforcement in `nilchain/x/nilchain/keeper/msg_server.go` (`MsgUpdateDealContent*`) | N/A | Spec/RFC claim is not enforced; a malicious client can commit arbitrarily large `size_bytes` | PR2 (`codex/spec-invariants-hard-caps`) |
+| Enforce `MAX_DEAL_BYTES` hard cap (avoid unbounded state bloat) | DONE | `spec.md` (“Hard Cap: 512 GiB”); `rfcs/rfc-data-granularity-and-economics.md` | `nilchain/x/nilchain/types/types.go` (`MAX_DEAL_BYTES`); `nilchain/x/nilchain/keeper/msg_server.go` (`MsgUpdateDealContent*`) | `cd nilchain && go test ./...` (unit tests) | — | — |
 | Mode2 Stripe retrieval: verify downloaded bytes == uploaded bytes | PARTIAL | `rfcs/rfc-blob-alignment-and-striping.md` | Mode2 flows implemented end-to-end, but Playwright asserts only “downloaded something” | `scripts/e2e_mode2_stripe_multi_sp.sh` | No byte-for-byte assertion in `nil-website/tests/mode2-stripe.spec.ts` | PR4 (`codex/mode2-stripe-bytes-assert`) |
 | Allowlist retrieval policy verification has test vectors | PARTIAL | `rfcs/rfc-retrieval-access-control-public-deals-and-vouchers.md` | Allowlist verification is implemented in `nilchain/x/nilchain/keeper/msg_server.go` (`OpenRetrievalSessionSponsored`) | N/A | No unit tests covering keccak merkle proofs; easiest place to regress | PR5 (`codex/allowlist-merkle-tests`) |
 | NilCE round-trip semantics are end-to-end and documented | PARTIAL | `rfcs/rfc-content-encoding-and-compression.md` | Upload-side wrapping + header parsing helpers exist in `nil_gateway/` (opt-in `NIL_NILCE=1`) | `go test ./nil_gateway/...` (NilCE unit tests) | Not required by CI E2E; fetch path does not currently auto-decode to match original bytes for Web2-style users | Defer (track separately if needed for launch) |
@@ -52,10 +52,10 @@ Legend:
 
 | Requirement | Status | Current implementation (refs) | CI proof | Not proven / gap |
 |---|---:|---|---|---|
-| Deal has an explicit `end_block` term bound | DONE | `nilchain/proto/nilchain/nilchain/v1/types.proto` (Deal.end_block); set in `MsgCreateDeal*` handlers (`nilchain/x/nilchain/keeper/msg_server.go`) | `go test ./nilchain/...` | — |
-| Reject `UpdateDealContent*` once `height >= end_block` | DONE | `nilchain/x/nilchain/keeper/msg_server.go` (`UpdateDealContent`, `UpdateDealContentFromEvm`) | `go test ./nilchain/...` | — |
-| Reject retrieval session opens once `height >= end_block` and enforce `expires_at <= end_block` | DONE | `nilchain/x/nilchain/keeper/msg_server.go` (`OpenRetrievalSession`, `OpenRetrievalSessionSponsored`, `OpenProtocolRetrievalSession`) | `go test ./nilchain/...` | — |
-| Reject liveness/retrieval proofs once `height >= end_block` | DONE | `nilchain/x/nilchain/keeper/msg_server.go` (`ProveLiveness`, retrieval proof paths) | `go test ./nilchain/...` | — |
+| Deal has an explicit `end_block` term bound | DONE | `nilchain/proto/nilchain/nilchain/v1/types.proto` (Deal.end_block); set in `MsgCreateDeal*` handlers (`nilchain/x/nilchain/keeper/msg_server.go`) | `cd nilchain && go test ./...` | — |
+| Reject `UpdateDealContent*` once `height >= end_block` | DONE | `nilchain/x/nilchain/keeper/msg_server.go` (`UpdateDealContent`, `UpdateDealContentFromEvm`) | `cd nilchain && go test ./...` | — |
+| Reject retrieval session opens once `height >= end_block` and enforce `expires_at <= end_block` | DONE | `nilchain/x/nilchain/keeper/msg_server.go` (`OpenRetrievalSession`, `OpenRetrievalSessionSponsored`, `OpenProtocolRetrievalSession`) | `cd nilchain && go test ./...` | — |
+| Reject liveness/retrieval proofs once `height >= end_block` | DONE | `nilchain/x/nilchain/keeper/msg_server.go` (`ProveLiveness`, retrieval proof paths) | `cd nilchain && go test ./...` | — |
 | Implement `MsgExtendDeal` with spot pricing at extension time | DONE | `nilchain/proto/nilchain/nilchain/v1/tx.proto` + `nilchain/x/nilchain/keeper/msg_server.go` (`ExtendDeal`) | `nilchain/x/nilchain/keeper/msg_server_extend_deal_test.go` | — |
 | Prevent renewal overcharge via `pricing_anchor_block` | DONE | `nilchain/proto/.../types.proto` (Deal.pricing_anchor_block); duration uses anchor in `msg_server.go` | `nilchain/x/nilchain/keeper/msg_server_extend_deal_test.go` | — |
 | Refuse serving expired deals on data plane | DONE | `nil_gateway/main.go` (`GatewayFetch`, `SpFetchShard`) fetch deal meta and reject expired deals | `go test ./nil_gateway/...` + CI E2E scripts | Disk GC after grace is not implemented (ops/process gap) |
@@ -72,7 +72,7 @@ Legend:
 
 | Requirement | Status | Current implementation (refs) | CI proof | Not proven / gap |
 |---|---:|---|---|---|
-| Deal retrieval policy fields (OwnerOnly/Allowlist/Voucher/Public) | DONE | `nilchain/proto/nilchain/nilchain/v1/types.proto` (RetrievalPolicy); `MsgUpdateDealRetrievalPolicy` in `tx.proto` + `msg_server.go` | `go test ./nilchain/...` | — |
+| Deal retrieval policy fields (OwnerOnly/Allowlist/Voucher/Public) | DONE | `nilchain/proto/nilchain/nilchain/v1/types.proto` (RetrievalPolicy); `MsgUpdateDealRetrievalPolicy` in `tx.proto` + `msg_server.go` | `cd nilchain && go test ./...` | — |
 | `MsgOpenRetrievalSession` remains owner-only and owner-paid (frozen semantics) | DONE | `nilchain/x/nilchain/keeper/msg_server.go` (`OpenRetrievalSession`) | `nilchain/x/nilchain/keeper/msg_server_retrieval_sessions_test.go` | — |
 | Implement requester-paid `MsgOpenRetrievalSessionSponsored` | DONE | `nilchain/x/nilchain/keeper/msg_server.go` (`OpenRetrievalSessionSponsored`) | `nilchain/x/nilchain/keeper/msg_server_sponsored_sessions_test.go` | — |
 | Implement allowlist verification (merkle root + proof) | PARTIAL | Implemented in `OpenRetrievalSessionSponsored`, but no tests | N/A | Missing deterministic test vectors (see Phase 0) |

--- a/nilchain/x/nilchain/keeper/msg_server.go
+++ b/nilchain/x/nilchain/keeper/msg_server.go
@@ -557,6 +557,9 @@ func (k msgServer) UpdateDealContent(goCtx context.Context, msg *types.MsgUpdate
 	if height >= deal.EndBlock {
 		return nil, sdkerrors.ErrInvalidRequest.Wrapf("deal %d expired at end_block=%d", msg.DealId, deal.EndBlock)
 	}
+	if msg.Size_ > types.MAX_DEAL_BYTES {
+		return nil, sdkerrors.ErrInvalidRequest.Wrapf("size_bytes exceeds MAX_DEAL_BYTES (size=%d max=%d)", msg.Size_, types.MAX_DEAL_BYTES)
+	}
 
 	params := k.GetParams(ctx)
 
@@ -666,6 +669,9 @@ func (k msgServer) UpdateDealContentFromEvm(goCtx context.Context, msg *types.Ms
 	}
 	if intent.SizeBytes == 0 {
 		return nil, sdkerrors.ErrInvalidRequest.Wrap("Size cannot be zero")
+	}
+	if intent.SizeBytes > types.MAX_DEAL_BYTES {
+		return nil, sdkerrors.ErrInvalidRequest.Wrapf("size_bytes exceeds MAX_DEAL_BYTES (size=%d max=%d)", intent.SizeBytes, types.MAX_DEAL_BYTES)
 	}
 	if intent.TotalMdus == 0 {
 		return nil, sdkerrors.ErrInvalidRequest.Wrap("total_mdus must be non-zero")

--- a/nilchain/x/nilchain/keeper/msg_server_evmbdg_test.go
+++ b/nilchain/x/nilchain/keeper/msg_server_evmbdg_test.go
@@ -334,6 +334,69 @@ func TestUpdateDealContentFromEvm_AllowsLargeContent(t *testing.T) {
 	require.Equal(t, updateIntent.SizeBytes, deal.Size_)
 }
 
+func TestUpdateDealContentFromEvm_RejectsOverMaxDealBytes(t *testing.T) {
+	f := initFixture(t)
+	msgServer := keeper.NewMsgServerImpl(f.keeper)
+
+	for i := 0; i < int(types.DealBaseReplication); i++ {
+		addrBz := []byte("evm_overcapprov__" + string(rune('A'+i)))
+		addr, _ := f.addressCodec.BytesToString(addrBz)
+		_, err := msgServer.RegisterProvider(f.ctx, &types.MsgRegisterProvider{
+			Creator:      addr,
+			Capabilities: "General",
+			TotalStorage: 100000000000,
+			Endpoints:    testProviderEndpoints,
+		})
+		require.NoError(t, err)
+	}
+
+	privKey, err := gethCrypto.GenerateKey()
+	require.NoError(t, err)
+	evmAddr := gethCrypto.PubkeyToAddress(privKey.PublicKey)
+
+	chainID := sdk.UnwrapSDKContext(f.ctx).ChainID()
+	senderBz := []byte("relayer_overcap____")
+	sender, _ := f.addressCodec.BytesToString(senderBz)
+
+	createIntent := &types.EvmCreateDealIntent{
+		CreatorEvm:      evmAddr.Hex(),
+		DurationBlocks:  100,
+		ServiceHint:     "General",
+		InitialEscrow:   math.NewInt(1000000),
+		MaxMonthlySpend: math.NewInt(500000),
+		Nonce:           1,
+		ChainId:         chainID,
+	}
+	createSig := signCreateIntentEIP712(t, createIntent, privKey)
+
+	createRes, err := msgServer.CreateDealFromEvm(f.ctx, &types.MsgCreateDealFromEvm{
+		Sender:       sender,
+		Intent:       createIntent,
+		EvmSignature: createSig,
+	})
+	require.NoError(t, err)
+
+	updateIntent := &types.EvmUpdateContentIntent{
+		CreatorEvm:  evmAddr.Hex(),
+		DealId:      createRes.DealId,
+		Cid:         makeManifestRootHex(0xdd),
+		SizeBytes:   types.MAX_DEAL_BYTES + 1,
+		TotalMdus:   3,
+		WitnessMdus: 1,
+		Nonce:       2,
+		ChainId:     chainID,
+	}
+	updateSig := signUpdateIntentEIP712(t, updateIntent, privKey)
+
+	_, err = msgServer.UpdateDealContentFromEvm(f.ctx, &types.MsgUpdateDealContentFromEvm{
+		Sender:       sender,
+		Intent:       updateIntent,
+		EvmSignature: updateSig,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "MAX_DEAL_BYTES")
+}
+
 func TestCreateDealFromEvm_InvalidSignature(t *testing.T) {
 	f := initFixture(t)
 	msgServer := keeper.NewMsgServerImpl(f.keeper)

--- a/nilchain/x/nilchain/keeper/msg_server_update_deal_content_test.go
+++ b/nilchain/x/nilchain/keeper/msg_server_update_deal_content_test.go
@@ -157,6 +157,47 @@ func TestUpdateDealContent_AllowsLargeContent(t *testing.T) {
 	require.Equal(t, size, deal.Size_)
 }
 
+func TestUpdateDealContent_RejectsOverMaxDealBytes(t *testing.T) {
+	f := initFixture(t)
+	msgServer := keeper.NewMsgServerImpl(f.keeper)
+
+	for i := 0; i < int(types.DealBaseReplication); i++ {
+		addrBz := []byte(string(rune('A' + i)))
+		addr, _ := f.addressCodec.BytesToString(addrBz)
+		_, err := msgServer.RegisterProvider(f.ctx, &types.MsgRegisterProvider{
+			Creator:      addr,
+			Capabilities: "General",
+			TotalStorage: 100000000000,
+			Endpoints:    testProviderEndpoints,
+		})
+		require.NoError(t, err)
+	}
+
+	userBz := []byte("user_overcap_______")
+	user, _ := f.addressCodec.BytesToString(userBz)
+
+	resDeal, err := msgServer.CreateDeal(f.ctx, &types.MsgCreateDeal{
+		Creator:             user,
+		DurationBlocks:      1000,
+		ServiceHint:         "General",
+		InitialEscrowAmount: math.NewInt(1000000),
+		MaxMonthlySpend:     math.NewInt(1000000),
+	})
+	require.NoError(t, err)
+
+	size := uint64(types.MAX_DEAL_BYTES + 1)
+	_, err = msgServer.UpdateDealContent(f.ctx, &types.MsgUpdateDealContent{
+		Creator:     user,
+		DealId:      resDeal.DealId,
+		Cid:         validManifestCid,
+		Size_:       size,
+		TotalMdus:   3,
+		WitnessMdus: 1,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "MAX_DEAL_BYTES")
+}
+
 func TestUpdateDealContent_InvalidInput(t *testing.T) {
 	f := initFixture(t)
 	msgServer := keeper.NewMsgServerImpl(f.keeper)

--- a/nilchain/x/nilchain/types/types.go
+++ b/nilchain/x/nilchain/types/types.go
@@ -5,6 +5,7 @@ const (
 	SHARD_SIZE          = 1 * 1024 * 1024 // 1 MiB Shard
 	BLOB_SIZE           = 128 * 1024      // 128 KiB KZG Blob (EIP-4844)
 	BLOBS_PER_MDU       = MDU_SIZE / BLOB_SIZE // 64 Blobs per MDU
+	MAX_DEAL_BYTES      = 512 * 1024 * 1024 * 1024 // 512 GiB hard cap per Deal (spec guardrail)
 	DealBaseReplication = 12                // Base replication factor (n in RS(n,k))
 	ProofWindow         = 10                // Blocks allowed between proofs before slashing
 )


### PR DESCRIPTION
## Summary
- Enforces `MAX_DEAL_BYTES` (512 GiB) in `MsgUpdateDealContent` and `MsgUpdateDealContentFromEvm`.
- Adds unit tests for over-cap rejection (native + EVM intent).
- Updates `docs/GAP_REPORT_REPO_ANCHORED.md` and `AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md` to reflect the new invariant + correct test command.

## Test
- `cd nilchain && go test ./...`
