### PR TITLE
PR4: Mode2 stripe byte-for-byte retrieval + shard auth

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -1,6 +1,6 @@
 # AGENTS TODO — Project Review → Spec/Doc Sync → Trusted Devnet Soft Launch (Feb 2026)
 
-Last updated: 2026-02-04
+Last updated: 2026-02-05
 
 This file is a **repo-tracked, PR-by-PR TODO list** for getting NilStore to a
 **trusted-collaborator devnet soft launch** (hub VPS + remote SPs).
@@ -55,10 +55,11 @@ Checklist:
 
 ---
 
-### PR3 — Wallet-first local E2E (no relay, no hidden signer) (CURRENT)
+### PR3 — Wallet-first local E2E (no relay, no hidden signer) (MERGED)
 
 - Branch: `codex/e2e-wallet-first-no-relay`
 - Goal: Prove “no relay” posture works for real flows (not just docs).
+- PR: https://github.com/Nil-Store/nil-store/pull/59
 - Test gate:
   - `scripts/e2e_browser_libp2p_relay.sh`
   - (optional) `scripts/e2e_browser_smoke_no_gateway.sh`
@@ -69,7 +70,7 @@ Checklist:
 
 ---
 
-### PR4 — Mode2 stripe integrity: byte-for-byte retrieval assertion
+### PR4 — Mode2 stripe integrity: byte-for-byte retrieval assertion (CURRENT)
 
 - Branch: `codex/mode2-stripe-bytes-assert`
 - Goal: Upgrade the Mode2 Stripe E2E signal from “downloaded something” to “downloaded the right bytes”.
@@ -77,8 +78,9 @@ Checklist:
   - `scripts/e2e_mode2_stripe_multi_sp.sh`
 
 Checklist:
-- [ ] Update `nil-website/tests/mode2-stripe.spec.ts` to assert downloaded bytes (or hash) == uploaded.
-- [ ] Ensure the test continues to work with chunked/ranged gateway fetches.
+- [x] Update `nil-website/tests/mode2-stripe.spec.ts` to assert downloaded bytes (or hash) == uploaded.
+- [x] Ensure the test continues to work with chunked/ranged gateway fetches.
+- [x] Fix Mode2 provider→provider shard fetches: `/sp/shard` requires `X‑Nil‑Gateway‑Auth` and no longer enforces the user session range across the full shard leaf interval (router still enforces user sessions on `/gateway/fetch`).
 
 ---
 

--- a/nil-website/tests/mode2-stripe.spec.ts
+++ b/nil-website/tests/mode2-stripe.spec.ts
@@ -86,6 +86,14 @@ test.describe('mode2 stripe', () => {
     let fetchCalls = 0
     const chunkPromises: Promise<void>[] = []
     const chunkBytes: Array<{ start: number; bytes: Buffer }> = []
+    const fetchEvents: Array<{
+      url: string
+      origin: string
+      status: number
+      provider: string
+      range: string
+      bodyLen: number
+    }> = []
     page.on('response', (resp) => {
       const url = resp.url()
       if (!url.includes('/gateway/fetch/')) return
@@ -97,6 +105,23 @@ test.describe('mode2 stripe', () => {
       const p = (async () => {
         try {
           const body = await resp.body()
+          const headers = resp.headers()
+          const provider = String(headers['x-nil-provider'] || headers['X-Nil-Provider'] || '')
+          let origin = ''
+          try {
+            origin = new URL(url).origin
+          } catch (err) {
+            void err
+            origin = ''
+          }
+          fetchEvents.push({
+            url,
+            origin,
+            status: resp.status(),
+            provider,
+            range: typeof range === 'string' ? range : '',
+            bodyLen: body.length,
+          })
           chunkBytes.push({ start, bytes: Buffer.from(body) })
         } catch (err) {
           void err
@@ -123,6 +148,9 @@ test.describe('mode2 stripe', () => {
     await downloadBtn.click()
 
     await expect(page.getByText(/Receipt submitted on-chain|Receipt failed/i)).toBeVisible({ timeout: 360_000 })
+    const routeEl = page.getByTestId('transport-route')
+    const routeAttempts = (await routeEl.getAttribute('data-transport-attempts').catch(() => null)) || ''
+    const routeFailure = (await routeEl.getAttribute('data-transport-failure').catch(() => null)) || ''
 
     await expect.poll(() => fetchCalls, { timeout: 60_000 }).toBeGreaterThanOrEqual(expectedChunks)
 
@@ -168,6 +196,32 @@ test.describe('mode2 stripe', () => {
     const maxExpected = fileBytes.length
     expect(downloaded.length).toBeGreaterThan(0)
     expect(downloaded.length).toBeLessThanOrEqual(maxExpected)
+    const expectedHash = crypto.createHash('sha256').update(fileBytes).digest('hex')
+    const actualHash = crypto.createHash('sha256').update(downloaded).digest('hex')
+    if (downloaded.length !== fileBytes.length || actualHash !== expectedHash) {
+      console.log(
+        JSON.stringify(
+          {
+            routeAttempts,
+            routeFailure,
+            fetchEvents: fetchEvents
+              .slice()
+              .sort((a, b) => a.range.localeCompare(b.range))
+              .map((e) => ({
+                origin: e.origin,
+                status: e.status,
+                provider: e.provider,
+                range: e.range,
+                bodyLen: e.bodyLen,
+              })),
+          },
+          null,
+          2,
+        ),
+      )
+    }
+    expect(downloaded.length).toBe(fileBytes.length)
+    expect(actualHash).toBe(expectedHash)
   })
 
   test('mode2 append keeps prior files', async ({ page }) => {

--- a/nil-website/website-spec.md
+++ b/nil-website/website-spec.md
@@ -377,7 +377,7 @@ The website depends on the following services (configured in `config.ts`):
 ### Key Endpoints
 *   `POST /gateway/upload`: `FormData{file, owner, deal_id?, max_user_mdus?, file_path?}` -> `{manifest_root, size_bytes, file_size_bytes, total_mdus, witness_mdus, file_path, filename}` (legacy aliases: `cid`, `allocated_length`).
 *   `POST /sp/upload_shard`: Raw shard bytes with headers `X-Nil-Deal-ID`, `X-Nil-Mdu-Index`, `X-Nil-Slot`, `X-Nil-Manifest-Root` (Mode 2).
-*   `GET /sp/shard?deal_id=...&manifest_root=...&mdu_index=...&slot=...`: Streams a stored shard (Mode 2).
+*   `GET /sp/shard?deal_id=...&manifest_root=...&mdu_index=...&slot=...`: Streams a stored shard (Mode 2; internal provider↔provider only; requires `X‑Nil‑Gateway‑Auth`).
 *   `GET /gateway/slab/{manifest_root}?deal_id=...&owner=...`: Returns slab segment ranges + counts (MDU #0 / Witness / User).
 *   `GET /gateway/list-files/{manifest_root}?deal_id=...&owner=...`: `{ manifest_root, total_size_bytes, files:[{path,size_bytes,start_offset,flags}] }` (deduplicated: latest non-tombstone record per path).
 *   `GET /gateway/plan-retrieval-session/{manifest_root}?deal_id=...&owner=...&file_path=...`: Returns blob-range plan for retrieval sessions.

--- a/nil_gateway/main.go
+++ b/nil_gateway/main.go
@@ -5399,12 +5399,9 @@ func SpFetchShard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if requireOnchainSession {
-		raw := strings.TrimSpace(r.Header.Get("X-Nil-Session-Id"))
-		if raw == "" {
-			writeJSONError(w, http.StatusBadRequest, "missing X-Nil-Session-Id", "")
-			return
-		}
+	if !isGatewayAuthorized(r) {
+		writeJSONError(w, http.StatusForbidden, "forbidden", "missing or invalid gateway auth")
+		return
 	}
 
 	q := r.URL.Query()
@@ -5442,112 +5439,8 @@ func SpFetchShard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if requireOnchainSession {
-		sessionKey, _, err := parseSessionIDHex(strings.TrimSpace(r.Header.Get("X-Nil-Session-Id")))
-		if err != nil {
-			writeJSONError(w, http.StatusBadRequest, "invalid X-Nil-Session-Id", err.Error())
-			return
-		}
-		sess, err := fetchRetrievalSession(sessionKey)
-		if err != nil {
-			if errors.Is(err, ErrSessionNotFound) {
-				writeJSONError(w, http.StatusNotFound, "retrieval session not found on chain", "")
-				return
-			}
-			writeJSONError(w, http.StatusInternalServerError, "failed to fetch retrieval session", err.Error())
-			return
-		}
-		if sess.DealId != dealID {
-			writeJSONError(w, http.StatusBadRequest, "session deal_id mismatch", "")
-			return
-		}
-		if len(sess.ManifestRoot) != 48 || !bytes.Equal(sess.ManifestRoot, parsed.Bytes[:]) {
-			writeJSONError(w, http.StatusBadRequest, "session manifest_root mismatch", "")
-			return
-		}
-		if sess.Status != types.RetrievalSessionStatus_RETRIEVAL_SESSION_STATUS_OPEN {
-			writeJSONError(w, http.StatusConflict, "session not OPEN", fmt.Sprintf("status: %s", sess.Status))
-			return
-		}
-
-		h, herr := fetchLatestHeight(r.Context(), lcdBase)
-		if herr != nil {
-			writeJSONError(w, http.StatusInternalServerError, "failed to fetch chain height", herr.Error())
-			return
-		}
-		meta, derr := fetchDealMeta(dealID)
-		if derr != nil {
-			writeJSONError(w, http.StatusInternalServerError, "failed to fetch deal", derr.Error())
-			return
-		}
-		if meta.EndBlock != 0 && h >= meta.EndBlock {
-			writeJSONError(w, http.StatusGone, "deal expired", fmt.Sprintf("end_block=%d", meta.EndBlock))
-			return
-		}
-		if sess.ExpiresAt != 0 && h > sess.ExpiresAt {
-			writeJSONError(w, http.StatusForbidden, "session expired", "")
-			return
-		}
-		if meta.EndBlock != 0 && sess.ExpiresAt != 0 && sess.ExpiresAt > meta.EndBlock {
-			writeJSONError(w, http.StatusForbidden, "session outlives deal term", "")
-			return
-		}
-
-		serviceHint, serr := fetchDealServiceHintFromLCD(r.Context(), dealID)
-		if serr != nil {
-			log.Printf("SpFetchShard: failed to fetch service hint: %v", serr)
-			serviceHint = ""
-		}
-		stripe, serr := stripeParamsFromHint(serviceHint)
-		if serr != nil {
-			writeJSONError(w, http.StatusBadRequest, "invalid deal service hint", serr.Error())
-			return
-		}
-		if stripe.mode != 2 || stripe.rows == 0 || stripe.leafCount == 0 {
-			writeJSONError(w, http.StatusBadRequest, "SpFetchShard only supported for Mode 2 deals", "")
-			return
-		}
-		startLeaf, overflow := mulUint64(slot, stripe.rows)
-		if overflow {
-			writeJSONError(w, http.StatusBadRequest, "invalid slot mapping", "start_leaf overflow")
-			return
-		}
-		if stripe.rows == 0 {
-			writeJSONError(w, http.StatusBadRequest, "invalid stripe params", "rows is zero")
-			return
-		}
-		endLeaf := startLeaf + stripe.rows - 1
-		if endLeaf < startLeaf {
-			writeJSONError(w, http.StatusBadRequest, "invalid slot mapping", "end_leaf overflow")
-			return
-		}
-		reqStart, overflow := addUint64(mduIndex*stripe.leafCount, startLeaf)
-		if overflow {
-			writeJSONError(w, http.StatusBadRequest, "invalid request range", "start_global overflow")
-			return
-		}
-		reqEnd, overflow := addUint64(mduIndex*stripe.leafCount, endLeaf)
-		if overflow {
-			writeJSONError(w, http.StatusBadRequest, "invalid request range", "end_global overflow")
-			return
-		}
-		sessStart, overflow := addUint64(sess.StartMduIndex*stripe.leafCount, uint64(sess.StartBlobIndex))
-		if overflow {
-			writeJSONError(w, http.StatusBadRequest, "invalid session range", "start_global overflow")
-			return
-		}
-		sessEnd := sessStart + sess.BlobCount - 1
-		if sessEnd < sessStart {
-			writeJSONError(w, http.StatusBadRequest, "invalid session range", "end_global overflow")
-			return
-		}
-		if reqStart < sessStart || reqEnd > sessEnd {
-			writeJSONError(w, http.StatusForbidden, "range outside session", "open a session that covers this shard range")
-			return
-		}
-	}
 	rootDir := dealScopedDir(dealID, parsed)
-	filename := fmt.Sprintf("mdu_%s_slot_%d.bin", mduIndexStr, slot)
+	filename := fmt.Sprintf("mdu_%d_slot_%d.bin", mduIndex, slot)
 	path := filepath.Join(rootDir, filename)
 
 	f, err := os.Open(path)

--- a/nil_gateway/mode2_reconstruct.go
+++ b/nil_gateway/mode2_reconstruct.go
@@ -195,6 +195,7 @@ func fetchShardFromProvider(ctx context.Context, baseURL string, dealID uint64, 
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set(gatewayAuthHeader, gatewayToProviderAuthToken())
 	if strings.TrimSpace(sessionID) != "" {
 		req.Header.Set("X-Nil-Session-Id", sessionID)
 	}

--- a/nil_gateway/nil-gateway-spec.md
+++ b/nil_gateway/nil-gateway-spec.md
@@ -148,10 +148,11 @@ These endpoints support the `nil-website` "Thin Client" flow.
     *   **Logic:** Provider submits `MsgSubmitRetrievalSessionProof` on-chain.
     *   **Role:** Canonical proof submission path.
 
-*   **`GET /sp/shard`** *(Mode 2 Provider API)*
+*   **`GET /sp/shard`** *(Mode 2 Provider API; internal)*
+    *   **Headers:** `X‑Nil‑Gateway‑Auth: <shared token>` (**required**).
     *   **Query Params:** `deal_id`, `manifest_root`, `mdu_index`, `slot`.
     *   **Logic:** Streams `mdu_<index>_slot_<slot>.bin` from the provider’s storage root.
-    *   **Role:** Used by gateways/clients to reconstruct Mode 2 MDUs when local shards are missing.
+    *   **Role:** Provider‑to‑provider shard reads used to reconstruct Mode 2 MDUs when local shards are missing. Browsers should fetch bytes via `/gateway/fetch/...` instead.
 
 *   **`POST /gateway/prove-retrieval`** *(Devnet helper; subject to change)*
     *   **Input (target):** JSON `{ "deal_id": 123, "epoch_id": 1, "manifest_root": "0x...", "file_path": "video.mp4" }`.

--- a/nil_gateway/session_enforcement_test.go
+++ b/nil_gateway/session_enforcement_test.go
@@ -187,15 +187,15 @@ func TestGatewayFetch_RequiresOnchainSession_WhenEnabled(t *testing.T) {
 	}
 }
 
-func TestSpFetchShard_RequiresOnchainSession_WhenEnabled(t *testing.T) {
+func TestSpFetchShard_RequiresGatewayAuth(t *testing.T) {
 	requireOnchainSessionForTest(t, true)
 
 	r := testRouter()
 	req := httptest.NewRequest(http.MethodGet, "/sp/shard?deal_id=1&mdu_index=2&slot=0&manifest_root=0x"+strings.Repeat("11", 48), nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 missing session, got %d (%s)", w.Code, w.Body.String())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 forbidden, got %d (%s)", w.Code, w.Body.String())
 	}
 }
 


### PR DESCRIPTION
Upgrades Mode2 E2E to assert byte-for-byte retrieval; fixes provider-to-provider reconstruction by requiring X-Nil-Gateway-Auth for /sp/shard and bypassing user-session leaf-range checks (user sessions still enforced on /gateway/fetch). Test gate: scripts/e2e_mode2_stripe_multi_sp.sh