### PR TITLE
PR5: Allowlist merkle proof tests

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -70,10 +70,11 @@ Checklist:
 
 ---
 
-### PR4 — Mode2 stripe integrity: byte-for-byte retrieval assertion (CURRENT)
+### PR4 — Mode2 stripe integrity: byte-for-byte retrieval assertion (MERGED)
 
 - Branch: `codex/mode2-stripe-bytes-assert`
 - Goal: Upgrade the Mode2 Stripe E2E signal from “downloaded something” to “downloaded the right bytes”.
+- PR: https://github.com/Nil-Store/nil-store/pull/60
 - Test gate:
   - `scripts/e2e_mode2_stripe_multi_sp.sh`
 
@@ -84,7 +85,7 @@ Checklist:
 
 ---
 
-### PR5 — Allowlist access control test vectors (chain)
+### PR5 — Allowlist access control test vectors (chain) (CURRENT)
 
 - Branch: `codex/allowlist-merkle-tests`
 - Goal: Turn allowlist logic from “implemented” into “proven”.
@@ -92,8 +93,8 @@ Checklist:
   - `cd nilchain && go test ./...`
 
 Checklist:
-- [ ] Add unit tests for `OpenRetrievalSessionSponsored` allowlist proof verification (valid + invalid paths).
-- [ ] Add deterministic merkle test vectors (keccak leaves, indices, paths).
+- [x] Add unit tests for `OpenRetrievalSessionSponsored` allowlist proof verification (valid + invalid paths).
+- [x] Add deterministic merkle test vectors (keccak leaves, indices, paths).
 
 ---
 

--- a/nilchain/x/nilchain/keeper/msg_server_sponsored_sessions_test.go
+++ b/nilchain/x/nilchain/keeper/msg_server_sponsored_sessions_test.go
@@ -7,6 +7,7 @@ import (
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	gethCommon "github.com/ethereum/go-ethereum/common"
 	gethCrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
@@ -23,6 +24,40 @@ func signVoucher(t *testing.T, voucher *types.VoucherAuth, chainID uint64, privK
 	sig, err := gethCrypto.Sign(digest, privKey)
 	require.NoError(t, err)
 	return sig
+}
+
+func keccakMerkleProofDuplicateLast(leaves []gethCommon.Hash, leafIndex uint32) (gethCommon.Hash, [][]byte) {
+	if len(leaves) == 0 {
+		return gethCommon.Hash{}, nil
+	}
+
+	layer := make([]gethCommon.Hash, len(leaves))
+	copy(layer, leaves)
+	idx := int(leafIndex)
+	path := make([][]byte, 0)
+
+	for len(layer) > 1 {
+		sibIdx := idx ^ 1
+		sibling := layer[idx]
+		if sibIdx < len(layer) {
+			sibling = layer[sibIdx]
+		}
+		path = append(path, sibling.Bytes())
+
+		next := make([]gethCommon.Hash, 0, (len(layer)+1)/2)
+		for i := 0; i < len(layer); i += 2 {
+			left := layer[i]
+			right := layer[i]
+			if i+1 < len(layer) {
+				right = layer[i+1]
+			}
+			next = append(next, gethCrypto.Keccak256Hash(left.Bytes(), right.Bytes()))
+		}
+		layer = next
+		idx /= 2
+	}
+
+	return layer[0], path
 }
 
 func TestSponsoredOpen_Public_DoesNotTouchDealEscrow(t *testing.T) {
@@ -310,4 +345,161 @@ func TestSponsoredOpen_Voucher_ReplayRejected(t *testing.T) {
 	require.NoError(t, open(1))
 	require.Error(t, open(2))
 	require.Contains(t, open(2).Error(), "voucher nonce replay rejected")
+}
+
+func TestSponsoredOpen_Allowlist_ProofVerification(t *testing.T) {
+	bank := newTrackingBankKeeper()
+	f := initFixtureWithBankKeeper(t, bank)
+	msgServer := keeper.NewMsgServerImpl(f.keeper)
+
+	ctx := sdk.UnwrapSDKContext(f.ctx).WithBlockHeight(5)
+	p := types.DefaultParams()
+	p.StoragePrice = math.LegacyNewDec(0)
+	p.BaseRetrievalFee = sdk.NewInt64Coin(sdk.DefaultBondDenom, 1)
+	p.RetrievalPricePerBlob = sdk.NewInt64Coin(sdk.DefaultBondDenom, 1)
+	require.NoError(t, f.keeper.Params.Set(ctx, p))
+
+	// Register minimal providers for Mode 2 (rs=2+1).
+	for i := 0; i < 3; i++ {
+		providerBz := make([]byte, 20)
+		copy(providerBz, []byte("provider_allow_v1___"))
+		providerBz[19] = byte('0' + i)
+		provider, _ := f.addressCodec.BytesToString(providerBz)
+		_, err := msgServer.RegisterProvider(ctx, &types.MsgRegisterProvider{
+			Creator:      provider,
+			Capabilities: "General",
+			TotalStorage: 100000000000,
+			Endpoints:    testProviderEndpoints,
+		})
+		require.NoError(t, err)
+	}
+
+	ownerBz := make([]byte, 20)
+	copy(ownerBz, []byte("owner_allow_v1_____"))
+	owner, _ := f.addressCodec.BytesToString(ownerBz)
+
+	resDeal, err := msgServer.CreateDeal(ctx, &types.MsgCreateDeal{
+		Creator:             owner,
+		DurationBlocks:      100,
+		ServiceHint:         "General:rs=2+1",
+		InitialEscrowAmount: math.NewInt(0),
+		MaxMonthlySpend:     math.NewInt(0),
+	})
+	require.NoError(t, err)
+
+	_, err = msgServer.UpdateDealContent(ctx, &types.MsgUpdateDealContent{
+		Creator:     owner,
+		DealId:      resDeal.DealId,
+		Cid:         validManifestCid,
+		Size_:       1,
+		TotalMdus:   2,
+		WitnessMdus: 0,
+	})
+	require.NoError(t, err)
+
+	sponsorBz := make([]byte, 20)
+	copy(sponsorBz, []byte("sponsor_allow_v1__"))
+	sponsor, _ := f.addressCodec.BytesToString(sponsorBz)
+	sponsorAddr, err := sdk.AccAddressFromBech32(sponsor)
+	require.NoError(t, err)
+	bank.setAccountBalance(sponsorAddr, sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100)))
+
+	otherA := make([]byte, 20)
+	copy(otherA, []byte("allow_a_v1________"))
+	otherAAddr, _ := f.addressCodec.BytesToString(otherA)
+	otherB := make([]byte, 20)
+	copy(otherB, []byte("allow_b_v1________"))
+	otherBAddr, _ := f.addressCodec.BytesToString(otherB)
+	otherC := make([]byte, 20)
+	copy(otherC, []byte("allow_c_v1________"))
+	otherCAddr, _ := f.addressCodec.BytesToString(otherC)
+
+	allowAddrs := []string{otherAAddr, sponsor, otherBAddr, otherCAddr}
+	leaves := make([]gethCommon.Hash, 0, len(allowAddrs))
+	for _, a := range allowAddrs {
+		addr, err := sdk.AccAddressFromBech32(a)
+		require.NoError(t, err)
+		leaves = append(leaves, gethCrypto.Keccak256Hash(addr.Bytes()))
+	}
+	root, merklePath := keccakMerkleProofDuplicateLast(leaves, 1)
+
+	_, err = msgServer.UpdateDealRetrievalPolicy(ctx, &types.MsgUpdateDealRetrievalPolicy{
+		Creator: owner,
+		DealId:  resDeal.DealId,
+		Policy: types.RetrievalPolicy{
+			Mode:          types.RetrievalPolicyMode_RETRIEVAL_POLICY_MODE_ALLOWLIST,
+			AllowlistRoot: root.Bytes(),
+		},
+	})
+	require.NoError(t, err)
+
+	baseMsg := &types.MsgOpenRetrievalSessionSponsored{
+		Creator:        sponsor,
+		DealId:         resDeal.DealId,
+		Provider:       resDeal.AssignedProviders[0],
+		ManifestRoot:   mustDecodeHexBytes(t, validManifestCid),
+		StartMduIndex:  1,
+		StartBlobIndex: 0,
+		BlobCount:      1,
+		Nonce:          1,
+		ExpiresAt:      20,
+		MaxTotalFee:    math.NewInt(0),
+	}
+
+	t.Run("missing proof rejected", func(t *testing.T) {
+		_, err := msgServer.OpenRetrievalSessionSponsored(ctx, baseMsg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "allowlist proof is required")
+	})
+
+	t.Run("invalid proof rejected", func(t *testing.T) {
+		badPath := make([][]byte, len(merklePath))
+		for i := range merklePath {
+			badPath[i] = append([]byte(nil), merklePath[i]...)
+		}
+		badPath[0][0] ^= 0x01
+
+		_, err := msgServer.OpenRetrievalSessionSponsored(ctx, &types.MsgOpenRetrievalSessionSponsored{
+			Auth: &types.MsgOpenRetrievalSessionSponsored_AllowlistProof{
+				AllowlistProof: &types.AllowlistProof{
+					LeafIndex:  1,
+					MerklePath: badPath,
+				},
+			},
+			Creator:        baseMsg.Creator,
+			DealId:         baseMsg.DealId,
+			Provider:       baseMsg.Provider,
+			ManifestRoot:   baseMsg.ManifestRoot,
+			StartMduIndex:  baseMsg.StartMduIndex,
+			StartBlobIndex: baseMsg.StartBlobIndex,
+			BlobCount:      baseMsg.BlobCount,
+			Nonce:          2,
+			ExpiresAt:      baseMsg.ExpiresAt,
+			MaxTotalFee:    baseMsg.MaxTotalFee,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid allowlist proof")
+	})
+
+	t.Run("valid proof accepted", func(t *testing.T) {
+		_, err := msgServer.OpenRetrievalSessionSponsored(ctx, &types.MsgOpenRetrievalSessionSponsored{
+			Auth: &types.MsgOpenRetrievalSessionSponsored_AllowlistProof{
+				AllowlistProof: &types.AllowlistProof{
+					LeafIndex:  1,
+					MerklePath: merklePath,
+				},
+			},
+			Creator:        baseMsg.Creator,
+			DealId:         baseMsg.DealId,
+			Provider:       baseMsg.Provider,
+			ManifestRoot:   baseMsg.ManifestRoot,
+			StartMduIndex:  baseMsg.StartMduIndex,
+			StartBlobIndex: baseMsg.StartBlobIndex,
+			BlobCount:      baseMsg.BlobCount,
+			Nonce:          3,
+			ExpiresAt:      baseMsg.ExpiresAt,
+			MaxTotalFee:    baseMsg.MaxTotalFee,
+		})
+		require.NoError(t, err)
+	})
 }

--- a/nilchain/x/nilchain/types/session_merkle_test.go
+++ b/nilchain/x/nilchain/types/session_merkle_test.go
@@ -1,0 +1,77 @@
+package types_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	gethCommon "github.com/ethereum/go-ethereum/common"
+	gethCrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+
+	"nilchain/x/nilchain/types"
+)
+
+func addrBytes(n byte) []byte {
+	b := make([]byte, 20)
+	b[19] = n
+	return b
+}
+
+func TestVerifyKeccakMerklePath_Vector4Leaves(t *testing.T) {
+	// Leaves are keccak(address_bytes). Internal hashing is keccak(left||right).
+	// Tree is built pairwise, duplicating the last node on odd levels.
+	l0 := gethCrypto.Keccak256Hash(addrBytes(1))
+	l1 := gethCrypto.Keccak256Hash(addrBytes(2))
+	l2 := gethCrypto.Keccak256Hash(addrBytes(3))
+	l3 := gethCrypto.Keccak256Hash(addrBytes(4))
+
+	// root = keccak(keccak(l0||l1) || keccak(l2||l3))
+	p0 := gethCrypto.Keccak256Hash(l0.Bytes(), l1.Bytes())
+	p1 := gethCrypto.Keccak256Hash(l2.Bytes(), l3.Bytes())
+	root := gethCrypto.Keccak256Hash(p0.Bytes(), p1.Bytes())
+
+	const expectedRootHex = "49690e544e5fcea5037854c7c7998244479aed8abc047c6640dcce15a2386356"
+	require.Equal(t, expectedRootHex, hex.EncodeToString(root.Bytes()))
+
+	// Proof for leaf index 2: [sibling=l3, sibling=p0]
+	path := [][]byte{
+		l3.Bytes(),
+		p0.Bytes(),
+	}
+	require.Equal(t, "a876da518a393dbd067dc72abfa08d475ed6447fca96d92ec3f9e7eba503ca61", hex.EncodeToString(path[0]))
+	require.Equal(t, "f95c14e6953c95195639e8266ab1a6850864d59a829da9f9b13602ee522f672b", hex.EncodeToString(path[1]))
+
+	require.True(t, types.VerifyKeccakMerklePath(root, l2, 2, path))
+	require.False(t, types.VerifyKeccakMerklePath(root, l2, 1, path))
+}
+
+func TestVerifyKeccakMerklePath_Vector3Leaves_DuplicateLast(t *testing.T) {
+	// Three leaves: last leaf is duplicated at the first level.
+	l0 := gethCrypto.Keccak256Hash(addrBytes(1))
+	l1 := gethCrypto.Keccak256Hash(addrBytes(2))
+	l2 := gethCrypto.Keccak256Hash(addrBytes(3))
+
+	// root = keccak(keccak(l0||l1) || keccak(l2||l2))
+	p0 := gethCrypto.Keccak256Hash(l0.Bytes(), l1.Bytes())
+	p1 := gethCrypto.Keccak256Hash(l2.Bytes(), l2.Bytes())
+	root := gethCrypto.Keccak256Hash(p0.Bytes(), p1.Bytes())
+
+	const expectedRootHex = "9b2beaffc72968fd3a694096468c78d0b800d436964d4cf55f8f708803cbb683"
+	require.Equal(t, expectedRootHex, hex.EncodeToString(root.Bytes()))
+
+	// Proof for leaf index 2: [sibling=l2 (duplicate), sibling=p0]
+	path := [][]byte{
+		l2.Bytes(),
+		p0.Bytes(),
+	}
+	require.Equal(t, "5b70e80538acdabd6137353b0f9d8d149f4dba91e8be2e7946e409bfdbe685b9", hex.EncodeToString(path[0]))
+	require.Equal(t, "f95c14e6953c95195639e8266ab1a6850864d59a829da9f9b13602ee522f672b", hex.EncodeToString(path[1]))
+
+	require.True(t, types.VerifyKeccakMerklePath(root, l2, 2, path))
+}
+
+func TestVerifyKeccakMerklePath_RejectsNon32ByteSibling(t *testing.T) {
+	root := gethCommon.HexToHash("0x" + hex.EncodeToString(make([]byte, 32)))
+	leaf := gethCrypto.Keccak256Hash([]byte("leaf"))
+	require.False(t, types.VerifyKeccakMerklePath(root, leaf, 0, [][]byte{{1, 2, 3}}))
+}


### PR DESCRIPTION
Adds deterministic keccak Merkle test vectors and keeper tests for OpenRetrievalSessionSponsored allowlist proof verification (valid/invalid). Test gate: cd nilchain && go test ./...