### PR TITLE
PR6: Trusted devnet soft launch pack

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -85,10 +85,11 @@ Checklist:
 
 ---
 
-### PR5 — Allowlist access control test vectors (chain) (CURRENT)
+### PR5 — Allowlist access control test vectors (chain) (MERGED)
 
 - Branch: `codex/allowlist-merkle-tests`
 - Goal: Turn allowlist logic from “implemented” into “proven”.
+- PR: https://github.com/Nil-Store/nil-store/pull/61
 - Test gate:
   - `cd nilchain && go test ./...`
 
@@ -98,7 +99,7 @@ Checklist:
 
 ---
 
-### PR6 — Trusted devnet “soft launch” pack (ops + onboarding)
+### PR6 — Trusted devnet “soft launch” pack (ops + onboarding) (CURRENT)
 
 - Branch: `codex/devnet-soft-launch-pack`
 - Goal: Make onboarding a collaborator a **30-minute task**, not an archeological dig.
@@ -106,10 +107,10 @@ Checklist:
   - `scripts/run_devnet_alpha_multi_sp.sh start` (local smoke)
 
 Checklist:
-- [ ] Write `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` (roles, endpoints, funding, troubleshooting).
-- [ ] Add systemd unit templates + env-file templates for hub services.
-- [ ] Add a “remote SP join” quickstart (based on `DEVNET_MULTI_PROVIDER.md`, but simplified).
-- [ ] Add basic monitoring checklist (disk, RAM, ports, logs, chain height).
+- [x] Write `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` (roles, endpoints, funding, troubleshooting).
+- [x] Add systemd unit templates + env-file templates for hub services.
+- [x] Add a “remote SP join” quickstart (based on `DEVNET_MULTI_PROVIDER.md`, but simplified).
+- [x] Add basic monitoring checklist (disk, RAM, ports, logs, chain height).
 
 ---
 

--- a/DEVNET_MULTI_PROVIDER.md
+++ b/DEVNET_MULTI_PROVIDER.md
@@ -2,6 +2,10 @@
 
 This guide is for running a shared devnet where multiple people can join as Storage Providers (SPs) and the hub routes deals to them.
 
+If you are onboarding trusted collaborators for a long-lived soft launch, start with:
+- `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md`
+- `docs/REMOTE_SP_JOIN_QUICKSTART.md`
+
 ## Mental Model
 
 - **Hub** runs: `nilchaind` (RPC/LCD/EVM), `nil_faucet`, **gateway-router** (`nil_gateway` in router mode), and optionally `nil-website`.
@@ -91,4 +95,3 @@ Create a deal, upload a file, and downloads will route through the hub gateway t
   - ensure both router + provider share the same `NIL_GATEWAY_SP_AUTH`
 - Remote provider submitting txs to the wrong node:
   - set `NIL_NODE=tcp://<hub-host>:26657` (provider gateway uses this for `nilchaind tx/query`)
-

--- a/DOCS.md
+++ b/DOCS.md
@@ -44,6 +44,9 @@ This repo contains a mix of **normative protocol spec**, **RFC drafts**, **imple
 - `README.md`: How to run/build/test the repo.
 - `HAPPY_PATH.md`: Local devnet “happy path” runbook.
 - `DEVNET_MULTI_PROVIDER.md`: How to run a multi-provider devnet and join as a remote provider.
+- `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md`: Trusted collaborator devnet soft launch pack (hub + remote providers).
+- `docs/REMOTE_SP_JOIN_QUICKSTART.md`: Remote provider join quickstart (fast path).
+- `docs/TRUSTED_DEVNET_MONITORING_CHECKLIST.md`: Minimal monitoring checklist for the soft launch.
 
 ## Agent Runbooks
 

--- a/docs/REMOTE_SP_JOIN_QUICKSTART.md
+++ b/docs/REMOTE_SP_JOIN_QUICKSTART.md
@@ -1,0 +1,93 @@
+# Remote Storage Provider (SP) Join — Quickstart
+
+This is the **fast path** for a trusted collaborator to join a shared devnet as a Storage Provider.
+
+If you want the full guide, see `DEVNET_MULTI_PROVIDER.md`.
+
+## What you need from the hub operator
+
+- Hub RPC: `tcp://<hub-host>:26657`
+- Hub LCD: `http://<hub-host>:1317`
+- Shared chain ID: `<chain-id>`
+- Shared router↔provider auth token: `NIL_GATEWAY_SP_AUTH=...`
+
+## Provider machine prerequisites
+
+- This repo checked out
+- Go + Rust toolchains installed
+- A public reachable provider endpoint (recommended: inbound TCP port + HTTP; HTTPS is optional for this soft launch)
+
+## Step-by-step
+
+### 1) Create your provider key (local keyring)
+
+```bash
+PROVIDER_KEY=provider1 ./scripts/run_devnet_provider.sh init
+```
+
+This prints your provider address (`nil1...`).
+
+### 2) Get funded for gas
+
+Ask the hub operator to send you some `aatom` (gas) via the faucet or a direct bank send.
+
+### 3) Pick an endpoint multiaddr
+
+For the simplest join, register an IP+port endpoint:
+
+- `/ip4/<your-public-ip>/tcp/8091/http`
+
+Set it:
+
+```bash
+export PROVIDER_ENDPOINT="/ip4/<your-public-ip>/tcp/8091/http"
+```
+
+If you need HTTPS/DNS-based endpoints, see `docs/networking/PROVIDER_ENDPOINTS.md`.
+
+### 4) Register your provider on-chain
+
+```bash
+export HUB_NODE="tcp://<hub-host>:26657"
+export HUB_LCD="http://<hub-host>:1317"
+export CHAIN_ID="<chain-id>"
+export PROVIDER_KEY="provider1"
+
+./scripts/run_devnet_provider.sh register
+```
+
+### 5) Start your provider gateway
+
+```bash
+export NIL_GATEWAY_SP_AUTH="<shared-from-hub>"
+export NIL_LCD_BASE="$HUB_LCD"
+export NIL_NODE="$HUB_NODE"
+export NIL_CHAIN_ID="$CHAIN_ID"
+export PROVIDER_KEY="provider1"
+export PROVIDER_LISTEN=":8091"
+
+./scripts/run_devnet_provider.sh start
+```
+
+### 6) Verify
+
+On the provider:
+
+```bash
+curl -sf http://127.0.0.1:8091/health
+```
+
+From the hub (or anywhere with LCD access):
+
+```bash
+curl -sf "$HUB_LCD/nilchain/nilchain/v1/providers" | jq '.providers | length'
+```
+
+## Common failures
+
+- Provider not visible on LCD:
+  - the `register-provider` tx likely failed (often: not enough `aatom` for gas)
+- Router can’t reach provider:
+  - firewall/NAT; ensure your `PROVIDER_ENDPOINT` is reachable **from the hub**
+  - confirm `NIL_GATEWAY_SP_AUTH` matches the hub router
+

--- a/docs/TESTNET_READINESS_REPORT.md
+++ b/docs/TESTNET_READINESS_REPORT.md
@@ -92,5 +92,4 @@ go test ./...
 ## What remains / known gaps
 
 - Mode1 does not yet have explicit make-before-break churn state (drain/rotation schedulers are Mode2-only).
-- Mode2 Stripe Playwright E2E asserts “downloaded bytes exist”, but does not yet assert byte-for-byte equality with the upload (`nil-website/tests/mode2-stripe.spec.ts`).
-  - Tracked in `AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md` (PR4).
+- Mode2 Stripe Playwright E2E asserts **byte-for-byte equality** between uploaded and downloaded payloads (`nil-website/tests/mode2-stripe.spec.ts`).

--- a/docs/TRUSTED_DEVNET_MONITORING_CHECKLIST.md
+++ b/docs/TRUSTED_DEVNET_MONITORING_CHECKLIST.md
@@ -1,0 +1,45 @@
+# Trusted Devnet Monitoring Checklist (Soft Launch)
+
+This is a **minimal** checklist for keeping the Feb 2026 trusted devnet healthy.
+
+## Hub (VPS) — daily checks
+
+- Chain is producing blocks:
+  - `curl -s http://127.0.0.1:26657/status | jq '.result.sync_info.latest_block_height,.result.sync_info.catching_up'`
+- LCD is responsive:
+  - `curl -sf http://127.0.0.1:1317/cosmos/base/tendermint/v1beta1/node_info >/dev/null`
+- EVM JSON-RPC is responsive:
+  - `curl -sf -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' http://127.0.0.1:8545 >/dev/null`
+- Router gateway is healthy:
+  - `curl -sf http://127.0.0.1:8080/health >/dev/null`
+- Faucet is healthy (if enabled):
+  - `curl -sf http://127.0.0.1:8081/health >/dev/null`
+
+## Hub — resource / network checks
+
+- Disk: `df -h` (watch the chain home + gateway upload dirs)
+- RAM: `free -h`
+- Open ports (hub-local): `ss -lntp | rg '(:26657|:1317|:8545|:8080|:8081)'`
+- Reverse-proxy/TLS (if used): confirm each public subdomain returns 200s (and CORS headers where needed).
+
+## Hub — logs
+
+- `journalctl -u nilchaind -S today --no-pager | tail -n 200`
+- `journalctl -u nil-gateway-router -S today --no-pager | tail -n 200`
+- `journalctl -u nil-faucet -S today --no-pager | tail -n 200`
+
+## Providers (remote SPs) — daily checks
+
+- Provider gateway is healthy:
+  - `curl -sf http://127.0.0.1:<PORT>/health >/dev/null`
+- Provider is visible on-chain (from hub):
+  - `curl -sf http://127.0.0.1:1317/nilchain/nilchain/v1/providers/<nil1...> | jq '.provider.endpoints'`
+- Router can reach provider endpoint (from hub):
+  - `curl -sf <provider-public-url>/health >/dev/null`
+
+## When something breaks (quick triage)
+
+- **Chain stuck**: check disk full first, then `nilchaind` logs for consensus errors; restart only after disk/IO is healthy.
+- **Provider missing**: re-check funding for provider key (gas), endpoint multiaddr reachability, and `NIL_GATEWAY_SP_AUTH` match.
+- **Fetch failing**: confirm sessions are opening on-chain and clients are sending `X-Nil-Session-Id` (sessions are required by default).
+

--- a/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
+++ b/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
@@ -1,0 +1,118 @@
+# Trusted Devnet Soft Launch (Feb 2026)
+
+Goal: onboard **10–20 trusted collaborators** (invite-only) to run Storage Providers (SPs) and to test end-to-end flows (create deal → upload → commit → retrieve) for **2–3 weeks**.
+
+This doc is written for the **hub operator** and **remote providers**.
+
+Related:
+- Provider endpoint types: `docs/networking/PROVIDER_ENDPOINTS.md`
+- Remote SP join quickstart: `docs/REMOTE_SP_JOIN_QUICKSTART.md`
+- Monitoring checklist: `docs/TRUSTED_DEVNET_MONITORING_CHECKLIST.md`
+
+## Architecture (locked for soft launch)
+
+- **Hub (VPS)** runs:
+  - `nilchaind` (CometBFT RPC + LCD + EVM JSON-RPC)
+  - `nil_gateway` in **router** mode
+  - `nil_faucet` (enabled, rate-limited; collaborator-only)
+  - `nil-website` (static build behind HTTPS)
+- **Providers (remote SPs)** run:
+  - `nil_gateway` in **provider** mode (one per SP)
+- **Users** interact via:
+  - Website + MetaMask (wallet-first), or curl for debugging
+
+Security posture:
+- This is **trusted** and **invite-only** (not Sybil resistant).
+- The router↔provider channel uses a shared secret (`NIL_GATEWAY_SP_AUTH`). Treat it like a password.
+
+## Public endpoints (recommended)
+
+Use HTTPS subdomains (reverse-proxied to localhost ports):
+
+- `https://rpc.<domain>` → `http://127.0.0.1:26657` (CometBFT RPC)
+- `https://lcd.<domain>` → `http://127.0.0.1:1317` (LCD REST)
+- `https://evm.<domain>` → `http://127.0.0.1:8545` (EVM JSON-RPC)
+- `https://gateway.<domain>` → `http://127.0.0.1:8080` (router gateway)
+- `https://faucet.<domain>` → `http://127.0.0.1:8081` (faucet)
+- `https://web.<domain>` → static website build
+
+## One-time: hub bootstrap (fastest path)
+
+The quickest way to get a working hub is to bring up a hub-only stack once (no local providers) and then switch to systemd.
+
+1) Start hub-only devnet once:
+
+```bash
+PROVIDER_COUNT=0 START_WEB=0 ./scripts/run_devnet_alpha_multi_sp.sh start
+```
+
+2) Copy out (and store safely):
+- The printed `SP Auth` token (router↔provider secret). Also saved at `_artifacts/devnet_alpha_multi_sp/sp_auth.txt`.
+- The chain home directory used by the script (printed as `Home:`).
+
+3) Stop the script-managed processes:
+
+```bash
+PROVIDER_COUNT=0 START_WEB=0 ./scripts/run_devnet_alpha_multi_sp.sh stop
+```
+
+Important: `run_devnet_alpha_multi_sp.sh start` **re-initializes** its chain home on every start. Do not use it as a long-running “service manager” for the soft launch.
+
+## Hub: long-running (systemd templates)
+
+Systemd templates live in `ops/systemd/`.
+
+Minimum units to run on the hub:
+- `ops/systemd/nilchaind.service`
+- `ops/systemd/nil-gateway-router.service`
+- `ops/systemd/nil-faucet.service` (optional but recommended for collaborators)
+
+Use the env templates under `ops/systemd/env/` and make sure:
+- All hub services share the same `NIL_HOME` (chain home directory).
+- `nil-gateway-router` and all providers share the same `NIL_GATEWAY_SP_AUTH`.
+
+## Provider onboarding
+
+Send each collaborator:
+- Hub endpoints (rpc/lcd/evm/gateway/faucet)
+- The chain ID(s)
+- The shared router↔provider auth token (`NIL_GATEWAY_SP_AUTH`)
+
+Then have them follow:
+
+- `docs/REMOTE_SP_JOIN_QUICKSTART.md`
+
+## Faucet / funding (collaborators)
+
+Collaborators must have funds for gas (and any protocol fees). For the current devnet profile:
+- EVM gas denom is `aatom` (see `nilchain` params / genesis).
+- The faucet can send both `aatom` and `stake` (default `NIL_AMOUNT`).
+
+Faucet request (example):
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"address":"nil1..."}' \
+  https://faucet.<domain>/faucet
+```
+
+## Collaborator “first file” smoke
+
+For a collaborator validating their SP is actually participating:
+
+1) Use the website to upload a file.
+2) Retrieve it back (byte-for-byte).
+3) If retrieval fails, grab:
+   - the hub `X-Nil-Provider` response header (who served the bytes)
+   - the provider’s `/health` response
+   - the hub router logs around the request
+
+## Troubleshooting (hub)
+
+- Provider doesn’t show up on `/nilchain/nilchain/v1/providers`:
+  - the registration tx likely failed (fund provider key for gas)
+- Router can’t reach provider:
+  - endpoint multiaddr not reachable from hub (firewall/NAT)
+  - `NIL_GATEWAY_SP_AUTH` mismatch between router and provider
+- Fetch fails with “missing X-Nil-Session-Id”:
+  - sessions are **required by default** (`NIL_REQUIRE_ONCHAIN_SESSION=1`)

--- a/ops/systemd/README.md
+++ b/ops/systemd/README.md
@@ -1,0 +1,46 @@
+# systemd templates (Trusted Devnet Soft Launch)
+
+These are **templates** for running a long-lived hub + remote SP devnet using systemd.
+
+Files:
+- `ops/systemd/*.service`: unit templates
+- `ops/systemd/env/*.env`: EnvironmentFile templates (copy to `/etc/nilstore/*.env`)
+
+## Quick usage
+
+1) Copy units:
+
+```bash
+sudo cp ops/systemd/*.service /etc/systemd/system/
+sudo systemctl daemon-reload
+```
+
+2) Copy env templates and edit paths/secrets:
+
+```bash
+sudo mkdir -p /etc/nilstore
+sudo cp ops/systemd/env/*.env /etc/nilstore/
+sudoedit /etc/nilstore/nil-gateway-router.env
+```
+
+3) Enable + start (hub):
+
+```bash
+sudo systemctl enable --now nilchaind nil-gateway-router nil-faucet
+```
+
+4) Tail logs:
+
+```bash
+journalctl -u nilchaind -f
+```
+
+## Notes
+
+- These templates assume you checked the repo out at `/opt/nilstore`. Adjust as needed.
+- The router↔provider auth token **must match** across the hub router and all providers:
+  - `NIL_GATEWAY_SP_AUTH=...`
+- If you run a reverse proxy for HTTPS subdomains, configure CORS to allow the website origin to call:
+  - `gateway.*` (upload/fetch)
+  - `lcd.*` / `evm.*` (wallet RPC)
+

--- a/ops/systemd/env/nil-faucet.env
+++ b/ops/systemd/env/nil-faucet.env
@@ -1,0 +1,19 @@
+# Hub faucet service (nil_faucet)
+
+NIL_ROOT_DIR=/opt/nilstore
+
+NIL_HOME=/var/lib/nilstore/nilchaind
+NIL_CHAIN_ID=<set-me>
+
+# Token + fees
+NIL_DENOM=stake
+NIL_AMOUNT=1000000000000000000aatom,100000000stake
+NIL_GAS_PRICES=0.001aatom
+
+# Rate limiting
+NIL_COOLDOWN_SECONDS=30
+
+# Binaries
+NILCHAIND_BIN=/opt/nilstore/nilchain/nilchaind
+NIL_FAUCET_BIN=/opt/nilstore/nil_faucet/nil_faucet
+

--- a/ops/systemd/env/nil-gateway-provider.env
+++ b/ops/systemd/env/nil-gateway-provider.env
@@ -1,0 +1,32 @@
+# Provider gateway (nil_gateway in provider mode)
+
+NIL_ROOT_DIR=/opt/nilstore
+
+# Networking
+NIL_LISTEN_ADDR=:8091
+
+# Chain connectivity
+NIL_CHAIN_ID=<set-me>
+NIL_NODE=tcp://<hub-host>:26657
+NIL_LCD_BASE=http://<hub-host>:1317
+NIL_GAS_PRICES=0.001aatom
+
+# Provider identity (must exist in the keyring at NIL_HOME)
+NIL_HOME=/var/lib/nilstore/provider/nilchaind
+NIL_PROVIDER_KEY=provider1
+
+# Storage
+NIL_UPLOAD_DIR=/var/lib/nilstore/nil_gateway/provider/uploads
+NIL_SESSION_DB_PATH=/var/lib/nilstore/nil_gateway/provider/sessions.db
+
+# Shared secret between router and providers
+NIL_GATEWAY_SP_AUTH=<set-me>
+
+# Binaries + assets
+NIL_GATEWAY_BIN=/opt/nilstore/nil_gateway/nil_gateway
+NILCHAIND_BIN=/opt/nilstore/nilchain/nilchaind
+NIL_CLI_BIN=/opt/nilstore/nil_cli/target/release/nil_cli
+NIL_TRUSTED_SETUP=/opt/nilstore/nilchain/trusted_setup.txt
+
+# Optional: disable libp2p server for the soft launch (simpler networking).
+NIL_P2P_ENABLED=0

--- a/ops/systemd/env/nil-gateway-router.env
+++ b/ops/systemd/env/nil-gateway-router.env
@@ -1,0 +1,38 @@
+# Hub router gateway (nil_gateway in router mode)
+
+NIL_ROOT_DIR=/opt/nilstore
+
+# Mode
+NIL_GATEWAY_ROUTER=1
+
+# Networking
+NIL_LISTEN_ADDR=:8080
+
+# Chain connectivity
+NIL_CHAIN_ID=<set-me>
+NIL_NODE=tcp://127.0.0.1:26657
+NIL_LCD_BASE=http://127.0.0.1:1317
+NIL_FAUCET_BASE=http://127.0.0.1:8081
+NIL_GAS_PRICES=0.001aatom
+NIL_HOME=/var/lib/nilstore/nilchaind
+
+# Storage (router temp dir)
+NIL_UPLOAD_DIR=/var/lib/nilstore/nil_gateway/router
+NIL_SESSION_DB_PATH=/var/lib/nilstore/nil_gateway/router/sessions.db
+
+# Critical shared secret between router and providers
+NIL_GATEWAY_SP_AUTH=<set-me>
+
+# Binaries + assets
+NIL_GATEWAY_BIN=/opt/nilstore/nil_gateway/nil_gateway
+NILCHAIND_BIN=/opt/nilstore/nilchain/nilchaind
+NIL_CLI_BIN=/opt/nilstore/nil_cli/target/release/nil_cli
+NIL_TRUSTED_SETUP=/opt/nilstore/nilchain/trusted_setup.txt
+
+# Testnet/mainnet posture defaults
+NIL_REQUIRE_ONCHAIN_SESSION=1
+NIL_ENABLE_TX_RELAY=0
+
+# Optional: disable libp2p server for the soft launch (simpler networking).
+NIL_P2P_ENABLED=0
+

--- a/ops/systemd/env/nilchaind.env
+++ b/ops/systemd/env/nilchaind.env
@@ -1,0 +1,21 @@
+# Hub chain daemon (nilchaind)
+
+# Repo root (used by some helpers to resolve relative assets).
+NIL_ROOT_DIR=/opt/nilstore
+
+# Chain home directory (MUST be persistent for a multi-week devnet).
+NIL_HOME=/var/lib/nilstore/nilchaind
+
+# Binary paths (build these once and keep stable).
+NILCHAIND_BIN=/opt/nilstore/nilchain/nilchaind
+
+# Chain settings
+NIL_CHAIN_ID=<set-me>
+NIL_GAS_PRICES=0.001aatom
+
+# Networking
+NIL_RPC_LADDR=tcp://0.0.0.0:26657
+
+# App toggles
+NIL_DISABLE_EVM_MEMPOOL=0
+

--- a/ops/systemd/nil-faucet.service
+++ b/ops/systemd/nil-faucet.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=NilStore devnet faucet (nil_faucet)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/nilstore/nil-faucet.env
+WorkingDirectory=/opt/nilstore
+ExecStart=${NIL_FAUCET_BIN}
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/systemd/nil-gateway-provider.service
+++ b/ops/systemd/nil-gateway-provider.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=NilStore provider gateway (nil_gateway)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/nilstore/nil-gateway-provider.env
+WorkingDirectory=/opt/nilstore
+ExecStart=${NIL_GATEWAY_BIN}
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/systemd/nil-gateway-router.service
+++ b/ops/systemd/nil-gateway-router.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=NilStore router gateway (nil_gateway)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/nilstore/nil-gateway-router.env
+WorkingDirectory=/opt/nilstore
+ExecStart=${NIL_GATEWAY_BIN}
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/systemd/nilchaind.service
+++ b/ops/systemd/nilchaind.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=NilStore devnet chain daemon (nilchaind)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/nilstore/nilchaind.env
+WorkingDirectory=/opt/nilstore
+ExecStart=${NILCHAIND_BIN} start --home ${NIL_HOME} --rpc.laddr ${NIL_RPC_LADDR} --minimum-gas-prices ${NIL_GAS_PRICES} --api.enable
+Restart=on-failure
+RestartSec=2
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Implements PR6 from AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md.

- Adds trusted devnet soft launch doc + monitoring checklist.
- Adds remote SP join quickstart.
- Adds systemd unit + env-file templates for hub/provider services.
- Updates docs index + multi-provider guide pointers.

Test gate:
- scripts/run_devnet_alpha_multi_sp.sh start