### PR TITLE
PR9: devnet economics knobs (genesis overrides + dynamic pricing enable)

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -131,10 +131,11 @@ Checklist:
 
 ---
 
-### PR8 — Dynamic pricing experiments (storage + retrieval) (CURRENT)
+### PR8 — Dynamic pricing experiments (storage + retrieval) (MERGED)
 
 - Branch: `codex/dynamic-pricing-mvp`
 - Goal: Add a testable first version of dynamic pricing without destabilizing the devnet.
+- PR: https://github.com/Nil-Store/nil-store/pull/64
 - Test gate:
   - `cd nilchain && go test ./...`
   - `./e2e_retrieval_fees.sh`
@@ -147,3 +148,17 @@ Checklist:
 Notes (MVP design):
 - Epoch-derived signals only (no oracle): storage utilization + prior-epoch retrieval demand.
 - Bounded, opt-in controller: min/max bounds + optional per-epoch step clamp; disabled by default.
+
+---
+
+### PR9 — Devnet economics knobs (genesis overrides + dynamic pricing enable) (CURRENT)
+
+- Branch: `codex/dynamic-pricing-devnet-wiring`
+- Goal: Make trusted devnet economics configurable (and make dynamic pricing easy to toggle on for experiments).
+- Test gate:
+  - `bash -n scripts/run_devnet_alpha_multi_sp.sh`
+
+Checklist:
+- [x] Add genesis override env vars in `scripts/run_devnet_alpha_multi_sp.sh` for pricing + dynamic pricing params.
+- [x] Document the overrides + example launch command in `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md`.
+- [x] Add a monitoring check for pricing params in `docs/TRUSTED_DEVNET_MONITORING_CHECKLIST.md`.

--- a/docs/TRUSTED_DEVNET_MONITORING_CHECKLIST.md
+++ b/docs/TRUSTED_DEVNET_MONITORING_CHECKLIST.md
@@ -14,6 +14,8 @@ This is a **minimal** checklist for keeping the Feb 2026 trusted devnet healthy.
   - `curl -sf http://127.0.0.1:8080/health >/dev/null`
 - Faucet is healthy (if enabled):
   - `curl -sf http://127.0.0.1:8081/health >/dev/null`
+- Pricing params are sane (and dynamic pricing status is intentional):
+  - `curl -sf http://127.0.0.1:1317/nilchain/nilchain/v1/params | jq '.params.dynamic_pricing_enabled,.params.storage_price,.params.retrieval_price_per_blob'`
 
 ## Hub — resource / network checks
 
@@ -42,4 +44,3 @@ This is a **minimal** checklist for keeping the Feb 2026 trusted devnet healthy.
 - **Chain stuck**: check disk full first, then `nilchaind` logs for consensus errors; restart only after disk/IO is healthy.
 - **Provider missing**: re-check funding for provider key (gas), endpoint multiaddr reachability, and `NIL_GATEWAY_SP_AUTH` match.
 - **Fetch failing**: confirm sessions are opening on-chain and clients are sending `X-Nil-Session-Id` (sessions are required by default).
-

--- a/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
+++ b/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
@@ -36,6 +36,33 @@ Use HTTPS subdomains (reverse-proxied to localhost ports):
 - `https://faucet.<domain>` → `http://127.0.0.1:8081` (faucet)
 - `https://web.<domain>` → static website build
 
+## Economics knobs (soft launch)
+
+Nilchain module params are stored in genesis under `app_state.nilchain.params` and can be patched at init-time
+by `scripts/run_devnet_alpha_multi_sp.sh` via env vars.
+
+Recommended soft-launch defaults:
+- Keep costs **low but non-zero**: set a small `deal_creation_fee`, non-zero `base_retrieval_fee`, and either:
+  - set a static non-zero `storage_price`, or
+  - enable the (bounded) dynamic pricing controller.
+
+Supported genesis overrides (all optional):
+- Static pricing:
+  - `NIL_DEAL_CREATION_FEE` (coin, e.g. `10stake`)
+  - `NIL_STORAGE_PRICE` (LegacyDec string, e.g. `0.00000000001`)
+  - `NIL_BASE_RETRIEVAL_FEE` (coin, e.g. `1stake`)
+  - `NIL_RETRIEVAL_PRICE_PER_BLOB` (coin, e.g. `1stake`)
+- Dynamic pricing (devnet experiment; disabled by default):
+  - `NIL_DYNAMIC_PRICING_ENABLED=1`
+  - Storage: `NIL_STORAGE_PRICE_MIN`, `NIL_STORAGE_PRICE_MAX`, `NIL_STORAGE_TARGET_UTILIZATION_BPS`
+  - Retrieval: `NIL_RETRIEVAL_PRICE_PER_BLOB_MIN`, `NIL_RETRIEVAL_PRICE_PER_BLOB_MAX`, `NIL_RETRIEVAL_TARGET_BLOBS_PER_EPOCH`
+  - Clamp: `NIL_DYNAMIC_PRICING_MAX_STEP_BPS` (0 = no clamp)
+
+Notes:
+- When `NIL_DYNAMIC_PRICING_ENABLED=1` and a `*_MIN` value is provided, the init script defaults the current
+  price (`storage_price` / `retrieval_price_per_blob`) to the min unless explicitly set.
+- These are just genesis-time knobs; governance can update params later if desired.
+
 ## One-time: hub bootstrap (fastest path)
 
 The quickest way to get a working hub is to bring up a hub-only stack once (no local providers) and then switch to systemd.
@@ -43,6 +70,20 @@ The quickest way to get a working hub is to bring up a hub-only stack once (no l
 1) Start hub-only devnet once:
 
 ```bash
+PROVIDER_COUNT=0 START_WEB=0 ./scripts/run_devnet_alpha_multi_sp.sh start
+```
+
+Example (enable bounded dynamic pricing at startup):
+
+```bash
+NIL_DYNAMIC_PRICING_ENABLED=1 \
+NIL_DYNAMIC_PRICING_MAX_STEP_BPS=500 \
+NIL_STORAGE_PRICE_MIN=0.00000000001 \
+NIL_STORAGE_PRICE_MAX=0.00000000010 \
+NIL_STORAGE_TARGET_UTILIZATION_BPS=8000 \
+NIL_RETRIEVAL_PRICE_PER_BLOB_MIN=1stake \
+NIL_RETRIEVAL_PRICE_PER_BLOB_MAX=5stake \
+NIL_RETRIEVAL_TARGET_BLOBS_PER_EPOCH=1000 \
 PROVIDER_COUNT=0 START_WEB=0 ./scripts/run_devnet_alpha_multi_sp.sh start
 ```
 

--- a/scripts/run_devnet_alpha_multi_sp.sh
+++ b/scripts/run_devnet_alpha_multi_sp.sh
@@ -232,6 +232,7 @@ ensure_metadata() {
   python3 - "$genesis" <<'PY' || true
 import json, sys
 import os
+import re
 path = sys.argv[1]
 data = json.load(open(path))
 bank = data.get("app_state", {}).get("bank", {})
@@ -277,29 +278,114 @@ data["app_state"]["evm"] = evm
 # Optional devnet overrides for nilchain params (useful for fast CI/E2E loops).
 nilchain = data.get("app_state", {}).get("nilchain", {})
 params = nilchain.get("params", {}) if isinstance(nilchain, dict) else {}
-overrides = {
-    "month_len_blocks": os.getenv("NIL_MONTH_LEN_BLOCKS"),
-    "epoch_len_blocks": os.getenv("NIL_EPOCH_LEN_BLOCKS"),
-    "quota_bps_per_epoch_hot": os.getenv("NIL_QUOTA_BPS_PER_EPOCH_HOT"),
-    "quota_bps_per_epoch_cold": os.getenv("NIL_QUOTA_BPS_PER_EPOCH_COLD"),
-    "quota_min_blobs": os.getenv("NIL_QUOTA_MIN_BLOBS"),
-    "quota_max_blobs": os.getenv("NIL_QUOTA_MAX_BLOBS"),
-    "credit_cap_bps": os.getenv("NIL_CREDIT_CAP_BPS"),
-    "evict_after_missed_epochs": os.getenv("NIL_EVICT_AFTER_MISSED_EPOCHS"),
-}
-for key, raw in overrides.items():
+default_denom = (os.getenv("NIL_DENOM") or "stake").strip() or "stake"
+
+def set_uint_param(key, env_key):
+    raw = os.getenv(env_key)
     if raw is None:
-        continue
+        return
     raw = raw.strip()
     if raw == "":
-        continue
+        return
     try:
         val = int(raw, 10)
     except Exception:
-        continue
+        return
     if val < 0:
-        continue
+        return
     params[key] = str(val)
+
+def set_dec_param(key, env_key):
+    raw = os.getenv(env_key)
+    if raw is None:
+        return False
+    raw = raw.strip()
+    if raw == "":
+        return False
+    if not re.match(r"^[0-9]+(\.[0-9]+)?$", raw):
+        return False
+    params[key] = raw
+    return True
+
+def parse_coin(raw, fallback_denom):
+    if raw is None:
+        return None
+    raw = raw.strip()
+    if raw == "":
+        return None
+
+    if raw.startswith("{"):
+        try:
+            obj = json.loads(raw)
+        except Exception:
+            return None
+        denom = (obj.get("denom") or "").strip() or fallback_denom
+        amount = (obj.get("amount") or "").strip()
+        if not re.match(r"^[0-9]+$", amount):
+            return None
+        return {"denom": denom, "amount": amount}
+
+    m = re.match(r"^([0-9]+)([a-zA-Z][a-zA-Z0-9/:._-]*)?$", raw)
+    if not m:
+        return None
+    amount = m.group(1)
+    denom = m.group(2) or fallback_denom
+    return {"denom": denom, "amount": amount}
+
+def set_coin_param(key, env_key):
+    coin = parse_coin(os.getenv(env_key), default_denom)
+    if coin is None:
+        return False
+    params[key] = coin
+    return True
+
+def set_bool_param(key, env_key):
+    raw = os.getenv(env_key)
+    if raw is None:
+        return None
+    raw = raw.strip().lower()
+    if raw in ("1", "true", "t", "yes", "y", "on"):
+        params[key] = True
+        return True
+    if raw in ("0", "false", "f", "no", "n", "off"):
+        params[key] = False
+        return False
+    return None
+
+# Existing uint64 overrides.
+set_uint_param("month_len_blocks", "NIL_MONTH_LEN_BLOCKS")
+set_uint_param("epoch_len_blocks", "NIL_EPOCH_LEN_BLOCKS")
+set_uint_param("quota_bps_per_epoch_hot", "NIL_QUOTA_BPS_PER_EPOCH_HOT")
+set_uint_param("quota_bps_per_epoch_cold", "NIL_QUOTA_BPS_PER_EPOCH_COLD")
+set_uint_param("quota_min_blobs", "NIL_QUOTA_MIN_BLOBS")
+set_uint_param("quota_max_blobs", "NIL_QUOTA_MAX_BLOBS")
+set_uint_param("credit_cap_bps", "NIL_CREDIT_CAP_BPS")
+set_uint_param("evict_after_missed_epochs", "NIL_EVICT_AFTER_MISSED_EPOCHS")
+
+# Pricing knobs (optional, but useful for trusted devnet economics).
+storage_price_set = set_dec_param("storage_price", "NIL_STORAGE_PRICE")
+storage_price_min_set = set_dec_param("storage_price_min", "NIL_STORAGE_PRICE_MIN")
+storage_price_max_set = set_dec_param("storage_price_max", "NIL_STORAGE_PRICE_MAX")
+set_uint_param("storage_target_utilization_bps", "NIL_STORAGE_TARGET_UTILIZATION_BPS")
+
+base_retrieval_fee_set = set_coin_param("base_retrieval_fee", "NIL_BASE_RETRIEVAL_FEE")
+retrieval_price_set = set_coin_param("retrieval_price_per_blob", "NIL_RETRIEVAL_PRICE_PER_BLOB")
+retrieval_price_min_set = set_coin_param("retrieval_price_per_blob_min", "NIL_RETRIEVAL_PRICE_PER_BLOB_MIN")
+retrieval_price_max_set = set_coin_param("retrieval_price_per_blob_max", "NIL_RETRIEVAL_PRICE_PER_BLOB_MAX")
+set_uint_param("retrieval_target_blobs_per_epoch", "NIL_RETRIEVAL_TARGET_BLOBS_PER_EPOCH")
+
+deal_creation_fee_set = set_coin_param("deal_creation_fee", "NIL_DEAL_CREATION_FEE")
+
+dynamic_enabled = set_bool_param("dynamic_pricing_enabled", "NIL_DYNAMIC_PRICING_ENABLED")
+set_uint_param("dynamic_pricing_max_step_bps", "NIL_DYNAMIC_PRICING_MAX_STEP_BPS")
+
+# If dynamic pricing is enabled and a min is provided, default the current price
+# to the min so genesis doesn't start at 0 (storage) or out of range (retrieval).
+if dynamic_enabled is True:
+    if storage_price_min_set and not storage_price_set:
+        params["storage_price"] = params.get("storage_price_min")
+    if retrieval_price_min_set and not retrieval_price_set:
+        params["retrieval_price_per_blob"] = params.get("retrieval_price_per_blob_min")
 if isinstance(nilchain, dict):
     nilchain["params"] = params
     data["app_state"]["nilchain"] = nilchain


### PR DESCRIPTION
Adds genesis-time env var overrides to scripts/run_devnet_alpha_multi_sp.sh for static pricing and bounded dynamic pricing experiments. Updates trusted devnet docs with the new knobs + an example launch command, and adds a monitoring check for pricing params.

Test gate:
- bash -n scripts/run_devnet_alpha_multi_sp.sh