### PR TITLE
PR10: secure faucet (auth token) + remove stale endpoint

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -151,10 +151,11 @@ Notes (MVP design):
 
 ---
 
-### PR9 — Devnet economics knobs (genesis overrides + dynamic pricing enable) (CURRENT)
+### PR9 — Devnet economics knobs (genesis overrides + dynamic pricing enable) (MERGED)
 
 - Branch: `codex/dynamic-pricing-devnet-wiring`
 - Goal: Make trusted devnet economics configurable (and make dynamic pricing easy to toggle on for experiments).
+- PR: https://github.com/Nil-Store/nil-store/pull/65
 - Test gate:
   - `bash -n scripts/run_devnet_alpha_multi_sp.sh`
 
@@ -162,3 +163,18 @@ Checklist:
 - [x] Add genesis override env vars in `scripts/run_devnet_alpha_multi_sp.sh` for pricing + dynamic pricing params.
 - [x] Document the overrides + example launch command in `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md`.
 - [x] Add a monitoring check for pricing params in `docs/TRUSTED_DEVNET_MONITORING_CHECKLIST.md`.
+
+---
+
+### PR10 — Faucet access control (auth token) + remove stale endpoints (CURRENT)
+
+- Branch: `codex/faucet-auth-token`
+- Goal: Make the devnet faucet truly “collaborator-only” and reduce exposed surface area.
+- Test gate:
+  - `cd nil_faucet && go test ./...`
+
+Checklist:
+- [x] Add optional auth token (`NIL_FAUCET_AUTH_TOKEN`) required via `X-Nil-Faucet-Auth`.
+- [x] Improve rate limiting IP parsing (use forwarded headers / host-only).
+- [x] Remove stale `/create-deal` endpoint from `nil_faucet`.
+- [x] Update trusted devnet docs + systemd env template with the auth knob.

--- a/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
+++ b/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
@@ -129,10 +129,15 @@ Collaborators must have funds for gas (and any protocol fees). For the current d
 - EVM gas denom is `aatom` (see `nilchain` params / genesis).
 - The faucet can send both `aatom` and `stake` (default `NIL_AMOUNT`).
 
+Faucet access control (recommended for invite-only):
+- Deploy behind reverse-proxy auth, and/or set `NIL_FAUCET_AUTH_TOKEN` on the faucet service.
+  - When set, requests MUST include `X-Nil-Faucet-Auth: <token>`.
+
 Faucet request (example):
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \
+  -H "X-Nil-Faucet-Auth: <token>" \
   -d '{"address":"nil1..."}' \
   https://faucet.<domain>/faucet
 ```

--- a/nil_faucet/main.go
+++ b/nil_faucet/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -19,14 +21,17 @@ import (
 
 // Config (overridable via env)
 var (
-	chainID   = envDefault("NIL_CHAIN_ID", "test-1")
-	homeDir   = envDefault("NIL_HOME", "../.nilchain")
-	amount    = envDefault("NIL_AMOUNT", "1000000000000000000aatom,1000000stake")
-	denom     = envDefault("NIL_DENOM", "stake")
-	gasPrices = envDefault("NIL_GAS_PRICES", "0.001aatom")
-	cooldown  = time.Duration(envInt("NIL_COOLDOWN_SECONDS", 30)) * time.Second
+	chainID     = envDefault("NIL_CHAIN_ID", "test-1")
+	homeDir     = envDefault("NIL_HOME", "../.nilchain")
+	amount      = envDefault("NIL_AMOUNT", "1000000000000000000aatom,1000000stake")
+	denom       = envDefault("NIL_DENOM", "stake")
+	gasPrices   = envDefault("NIL_GAS_PRICES", "0.001aatom")
+	cooldown    = time.Duration(envInt("NIL_COOLDOWN_SECONDS", 30)) * time.Second
 	nilchaindBin = envDefault("NILCHAIND_BIN", "nilchaind")
 	cmdTimeout   = time.Duration(envInt("NIL_CMD_TIMEOUT_SECONDS", 20)) * time.Second
+
+	// Optional: when set, POST endpoints require X-Nil-Faucet-Auth header.
+	authToken = envDefault("NIL_FAUCET_AUTH_TOKEN", "")
 )
 
 var (
@@ -38,19 +43,9 @@ type FaucetRequest struct {
 	Address string `json:"address"`
 }
 
-type DealRequest struct {
-	Creator         string `json:"creator"`
-	Cid             string `json:"cid"`
-	Size            uint64 `json:"size"`
-	Duration        uint64 `json:"duration"`
-	InitialEscrow   string `json:"initialEscrow"`
-	MaxMonthlySpend string `json:"maxMonthlySpend"`
-}
-
 func main() {
 	r := mux.NewRouter()
 	r.HandleFunc("/faucet", RequestFunds).Methods("POST", "OPTIONS")
-	r.HandleFunc("/create-deal", CreateDeal).Methods("POST", "OPTIONS")
 	r.HandleFunc("/health", HealthCheck).Methods("GET")
 
 	// Enable CORS
@@ -115,6 +110,9 @@ func RequestFunds(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "OPTIONS" {
 		return
 	}
+	if !authorizeRequest(w, r) {
+		return
+	}
 
 	var req FaucetRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -123,7 +121,7 @@ func RequestFunds(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Rate Limit (Simple IP based)
-	ip := r.RemoteAddr // In prod, use X-Forwarded-For
+	ip := clientIP(r)
 	mu.Lock()
 	if last, ok := lastRequest[ip]; ok {
 		if time.Since(last) < cooldown {
@@ -173,62 +171,42 @@ func HealthCheck(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("OK"))
 }
 
-func CreateDeal(w http.ResponseWriter, r *http.Request) {
-	setCORS(w)
-	if r.Method == "OPTIONS" {
-		return
-	}
-
-	var req DealRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "Invalid request", http.StatusBadRequest)
-		return
-	}
-
-	if req.Creator == "" || req.Cid == "" || req.Size == 0 || req.Duration == 0 {
-		http.Error(w, "Missing fields", http.StatusBadRequest)
-		return
-	}
-
-	log.Printf("CreateDeal for %s cid=%s size=%d duration=%d", req.Creator, req.Cid, req.Size, req.Duration)
-
-	ctx, cancel := context.WithTimeout(r.Context(), cmdTimeout)
-	defer cancel()
-	cmd := execNilchaind(ctx, "tx", "nilchain", "create-deal",
-		req.Cid,
-		fmt.Sprintf("%d", req.Size),
-		fmt.Sprintf("%d", req.Duration),
-		req.InitialEscrow,
-		req.MaxMonthlySpend,
-		"--chain-id", chainID,
-		"--from", "faucet",
-		"--yes",
-		"--keyring-backend", "test",
-		"--home", homeDir,
-		"--gas-prices", gasPrices,
-		"--gas", "auto",
-		"--gas-adjustment", "1.4",
-		"--broadcast-mode", "block",
-	)
-
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Printf("CreateDeal failed: %s", string(output))
-		http.Error(w, fmt.Sprintf("Tx failed: %v", err), http.StatusInternalServerError)
-		return
-	}
-
-	log.Printf("CreateDeal success: %s", string(output))
-	_ = json.NewEncoder(w).Encode(map[string]string{
-		"status":  "success",
-		"tx_hash": "check faucet logs",
-	})
-}
-
 func setCORS(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-Nil-Faucet-Auth")
+}
+
+func authorizeRequest(w http.ResponseWriter, r *http.Request) bool {
+	if authToken == "" {
+		return true
+	}
+	given := strings.TrimSpace(r.Header.Get("X-Nil-Faucet-Auth"))
+	if given == "" || subtle.ConstantTimeCompare([]byte(given), []byte(authToken)) != 1 {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return false
+	}
+	return true
+}
+
+func clientIP(r *http.Request) string {
+	if xff := strings.TrimSpace(r.Header.Get("X-Forwarded-For")); xff != "" {
+		parts := strings.Split(xff, ",")
+		if len(parts) > 0 {
+			ip := strings.TrimSpace(parts[0])
+			if ip != "" {
+				return ip
+			}
+		}
+	}
+	if xrip := strings.TrimSpace(r.Header.Get("X-Real-IP")); xrip != "" {
+		return xrip
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err == nil && host != "" {
+		return host
+	}
+	return r.RemoteAddr
 }
 
 var txHashRe = regexp.MustCompile(`txhash:\s*([A-Fa-f0-9]+)`)

--- a/ops/systemd/env/nil-faucet.env
+++ b/ops/systemd/env/nil-faucet.env
@@ -13,7 +13,9 @@ NIL_GAS_PRICES=0.001aatom
 # Rate limiting
 NIL_COOLDOWN_SECONDS=30
 
+# Optional auth (recommended): when set, requests must include `X-Nil-Faucet-Auth: $NIL_FAUCET_AUTH_TOKEN`.
+NIL_FAUCET_AUTH_TOKEN=<set-me>
+
 # Binaries
 NILCHAIND_BIN=/opt/nilstore/nilchain/nilchaind
 NIL_FAUCET_BIN=/opt/nilstore/nil_faucet/nil_faucet
-


### PR DESCRIPTION
Adds optional faucet auth (NIL_FAUCET_AUTH_TOKEN required via X-Nil-Faucet-Auth header) and improves rate limiting IP parsing (X-Forwarded-For / host-only RemoteAddr). Removes the stale /create-deal endpoint from nil_faucet and updates trusted devnet docs + systemd env template.

Test gate:
- cd nil_faucet && go test ./...