### PR TITLE
PR11: website faucet auth token (collaborator UX)

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -166,10 +166,11 @@ Checklist:
 
 ---
 
-### PR10 — Faucet access control (auth token) + remove stale endpoints (CURRENT)
+### PR10 — Faucet access control (auth token) + remove stale endpoints (MERGED)
 
 - Branch: `codex/faucet-auth-token`
 - Goal: Make the devnet faucet truly “collaborator-only” and reduce exposed surface area.
+- PR: https://github.com/Nil-Store/nil-store/pull/66
 - Test gate:
   - `cd nil_faucet && go test ./...`
 
@@ -178,3 +179,19 @@ Checklist:
 - [x] Improve rate limiting IP parsing (use forwarded headers / host-only).
 - [x] Remove stale `/create-deal` endpoint from `nil_faucet`.
 - [x] Update trusted devnet docs + systemd env template with the auth knob.
+
+---
+
+### PR11 — Website faucet auth token (collaborator UX) (CURRENT)
+
+- Branch: `codex/website-faucet-auth-token`
+- Goal: Allow token-protected faucet funding from the website UI (without baking secrets into the build).
+- Test gate:
+  - `npm -C nil-website run test:unit`
+  - `npm -C nil-website run build`
+
+Checklist:
+- [x] Add localStorage-backed faucet auth token helper.
+- [x] Send `X-Nil-Faucet-Auth` header from `useFaucet` when token is set.
+- [x] Add UI input (Dashboard + First File wizard + Testnet Docs) for collaborators to paste/save/clear the token.
+- [x] Update trusted devnet docs with the UI token flow.

--- a/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
+++ b/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
@@ -142,6 +142,10 @@ curl -X POST -H "Content-Type: application/json" \
   https://faucet.<domain>/faucet
 ```
 
+Website UI (optional):
+- If you enable faucet funding in the web build (`VITE_ENABLE_FAUCET=1`), collaborators can paste the token into the UI
+  (Dashboard / First File wizard) and then use the “Get Testnet NIL” button.
+
 ## Collaborator “first file” smoke
 
 For a collaborator validating their SP is actually participating:

--- a/nil-website/src/components/Dashboard.tsx
+++ b/nil-website/src/components/Dashboard.tsx
@@ -14,6 +14,7 @@ import { appConfig } from '../config'
 import { DealDetail } from './DealDetail'
 import { StatusBar } from './StatusBar'
 import { FileSharder } from './FileSharder'
+import { FaucetAuthTokenInput } from './FaucetAuthTokenInput'
 import { buildServiceHint, parseServiceHint } from '../lib/serviceHint'
 import { maybeWrapNilceZstd } from '../lib/nilce'
 import { injectedConnector } from '../lib/web3Config'
@@ -2168,6 +2169,11 @@ export function Dashboard() {
               {faucetTx ? (
                 <div className="mt-2 text-[11px] text-muted-foreground">
                   Faucet tx: <span className="font-mono text-foreground">{faucetTx.slice(0, 10)}…</span>
+                </div>
+              ) : null}
+              {appConfig.faucetEnabled ? (
+                <div className="mt-3">
+                  <FaucetAuthTokenInput />
                 </div>
               ) : null}
             </div>

--- a/nil-website/src/components/FaucetAuthTokenInput.tsx
+++ b/nil-website/src/components/FaucetAuthTokenInput.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react'
+import { getFaucetAuthToken, setFaucetAuthToken } from '../lib/faucetAuthToken'
+
+export function FaucetAuthTokenInput({ className = '' }: { className?: string }) {
+  const [token, setToken] = useState('')
+  const [visible, setVisible] = useState(false)
+  const [hasSavedToken, setHasSavedToken] = useState(false)
+
+  useEffect(() => {
+    const saved = getFaucetAuthToken()
+    setToken(saved ?? '')
+    setHasSavedToken(Boolean(saved))
+  }, [])
+
+  const handleSave = () => {
+    const trimmed = token.trim()
+    setFaucetAuthToken(trimmed ? trimmed : null)
+    const saved = getFaucetAuthToken()
+    setToken(saved ?? '')
+    setHasSavedToken(Boolean(saved))
+  }
+
+  const handleClear = () => {
+    setFaucetAuthToken(null)
+    setToken('')
+    setHasSavedToken(false)
+  }
+
+  return (
+    <div className={`rounded-xl border border-border bg-secondary/10 p-4 ${className}`}>
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Faucet access token</div>
+          <div className="mt-1 text-[11px] text-muted-foreground">
+            Only needed if the faucet responds with <span className="font-mono">Unauthorized</span>. Stored in your browser
+            only.
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => setVisible((v) => !v)}
+          className="text-xs font-semibold text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {visible ? 'Hide' : 'Show'}
+        </button>
+      </div>
+      <div className="mt-3 flex flex-col sm:flex-row gap-2">
+        <input
+          value={token}
+          type={visible ? 'text' : 'password'}
+          placeholder={hasSavedToken ? 'Token saved' : 'Paste token (optional)'}
+          onChange={(e) => setToken(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              handleSave()
+            }
+          }}
+          className="w-full rounded-md border border-border bg-background/70 px-3 py-2 text-sm font-mono"
+        />
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!token.trim()}
+            className="inline-flex items-center justify-center rounded-md bg-primary px-3 py-2 text-xs font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:opacity-50 disabled:pointer-events-none"
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={handleClear}
+            disabled={!hasSavedToken}
+            className="inline-flex items-center justify-center rounded-md border border-border bg-background/60 px-3 py-2 text-xs font-semibold text-muted-foreground transition-colors hover:bg-secondary/50 disabled:opacity-50 disabled:pointer-events-none"
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/nil-website/src/hooks/useFaucet.ts
+++ b/nil-website/src/hooks/useFaucet.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { ethToNil } from '../lib/address'
 import { appConfig } from '../config'
+import { getFaucetAuthToken } from '../lib/faucetAuthToken'
 
 export function useFaucet() {
   const [loading, setLoading] = useState(false)
@@ -25,9 +26,15 @@ export function useFaucet() {
         let lastError: Error | null = null
 
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            const token = getFaucetAuthToken()
+            const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+            if (token) {
+                headers['X-Nil-Faucet-Auth'] = token
+            }
+
             const response = await fetch(`${appConfig.apiBase}/faucet`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers,
                 body: JSON.stringify({ address: targetAddress })
             })
 
@@ -47,6 +54,10 @@ export function useFaucet() {
             }
 
             const errText = await response.text().catch(() => '')
+            if (response.status === 401) {
+                const msg = (errText || 'Unauthorized').trim()
+                throw new Error(`${msg}. Set the Faucet access token in the UI (if required).`)
+            }
             if (response.status === 429) {
                 const retryAfter = response.headers.get('retry-after')
                 const retrySeconds = retryAfter ? Number.parseFloat(retryAfter) : NaN

--- a/nil-website/src/lib/faucetAuthToken.test.ts
+++ b/nil-website/src/lib/faucetAuthToken.test.ts
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { FAUCET_AUTH_TOKEN_STORAGE_KEY, getFaucetAuthToken, setFaucetAuthToken } from './faucetAuthToken'
+
+class FakeStorage {
+  private readonly store = new Map<string, string>()
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value)
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key)
+  }
+}
+
+test('faucet auth token is trimmed and stored in localStorage', () => {
+  const original = (globalThis as any).localStorage
+  const fake = new FakeStorage()
+
+  try {
+    (globalThis as any).localStorage = fake
+
+    assert.equal(getFaucetAuthToken(), null)
+
+    setFaucetAuthToken('  secret  ')
+    assert.equal(fake.getItem(FAUCET_AUTH_TOKEN_STORAGE_KEY), 'secret')
+    assert.equal(getFaucetAuthToken(), 'secret')
+
+    setFaucetAuthToken('   ')
+    assert.equal(getFaucetAuthToken(), null)
+  } finally {
+    (globalThis as any).localStorage = original
+  }
+})

--- a/nil-website/src/lib/faucetAuthToken.ts
+++ b/nil-website/src/lib/faucetAuthToken.ts
@@ -1,0 +1,27 @@
+export const FAUCET_AUTH_TOKEN_STORAGE_KEY = 'nilstore.faucetAuthToken'
+
+export function getFaucetAuthToken(): string | null {
+  try {
+    const raw = globalThis.localStorage?.getItem(FAUCET_AUTH_TOKEN_STORAGE_KEY) ?? ''
+    const trimmed = raw.trim()
+    return trimmed ? trimmed : null
+  } catch {
+    return null
+  }
+}
+
+export function setFaucetAuthToken(token: string | null): void {
+  try {
+    const storage = globalThis.localStorage
+    if (!storage) return
+    const trimmed = String(token ?? '').trim()
+    if (!trimmed) {
+      storage.removeItem(FAUCET_AUTH_TOKEN_STORAGE_KEY)
+      return
+    }
+    storage.setItem(FAUCET_AUTH_TOKEN_STORAGE_KEY, trimmed)
+  } catch {
+    // Ignore storage write errors (private mode, disabled storage, etc.).
+  }
+}
+

--- a/nil-website/src/pages/FirstFile.tsx
+++ b/nil-website/src/pages/FirstFile.tsx
@@ -7,6 +7,7 @@ import { AlertCircle, CheckCircle2, Coins, Download, HardDrive, Rocket, Upload }
 import { appConfig } from '../config'
 import { StatusBar } from '../components/StatusBar'
 import { ConnectWallet } from '../components/ConnectWallet'
+import { FaucetAuthTokenInput } from '../components/FaucetAuthTokenInput'
 import { useNetwork } from '../hooks/useNetwork'
 import { useFaucet } from '../hooks/useFaucet'
 import { useCreateDeal } from '../hooks/useCreateDeal'
@@ -393,23 +394,26 @@ export function FirstFile() {
             Faucet is disabled in this build. Fund your wallet externally, then continue.
           </div>
         ) : (
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-            <button
-              type="button"
-              onClick={() => void handleRequestFunds()}
-              disabled={!isConnected || faucetLoading}
-              className="inline-flex items-center gap-2 rounded-lg border border-border bg-yellow-500/10 px-4 py-2 text-sm font-semibold text-yellow-700 dark:text-yellow-200 hover:bg-yellow-500/20 transition-colors disabled:opacity-60"
-            >
-              <Coins className="w-4 h-4" />
-              {faucetLoading ? 'Requesting…' : 'Request faucet funds'}
-            </button>
-            <div className="text-xs text-muted-foreground">
-              {faucetTx ? (
-                <span className="font-mono">Faucet tx: {faucetTx.slice(0, 10)}… ({faucetTxStatus})</span>
-              ) : (
-                <span>Balance: {balanceLabel}</span>
-              )}
+          <div className="space-y-3">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+              <button
+                type="button"
+                onClick={() => void handleRequestFunds()}
+                disabled={!isConnected || faucetLoading}
+                className="inline-flex items-center gap-2 rounded-lg border border-border bg-yellow-500/10 px-4 py-2 text-sm font-semibold text-yellow-700 dark:text-yellow-200 hover:bg-yellow-500/20 transition-colors disabled:opacity-60"
+              >
+                <Coins className="w-4 h-4" />
+                {faucetLoading ? 'Requesting…' : 'Request faucet funds'}
+              </button>
+              <div className="text-xs text-muted-foreground">
+                {faucetTx ? (
+                  <span className="font-mono">Faucet tx: {faucetTx.slice(0, 10)}… ({faucetTxStatus})</span>
+                ) : (
+                  <span>Balance: {balanceLabel}</span>
+                )}
+              </div>
             </div>
+            <FaucetAuthTokenInput />
           </div>
         )}
       </section>

--- a/nil-website/src/pages/TestnetDocs.tsx
+++ b/nil-website/src/pages/TestnetDocs.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { useAccount } from "wagmi";
 import { FileSharder } from "../components/FileSharder";
 import { FaucetWidget } from "../components/FaucetWidget";
+import { FaucetAuthTokenInput } from "../components/FaucetAuthTokenInput";
 import { appConfig } from "../config";
 import { ethToNil } from "../lib/address";
 import { lcdFetchDeals } from "../api/lcdClient";
@@ -180,6 +181,7 @@ export const TestnetDocs = () => {
                 </p>
                 <div className="p-4 bg-secondary/10 rounded-xl border border-border/50 flex flex-col items-center justify-center gap-2">
                     <FaucetWidget />
+                    {appConfig.faucetEnabled ? <FaucetAuthTokenInput className="w-full" /> : null}
                     <p className="text-xs text-muted-foreground mt-2 text-center">
                         Works with both 0x... and nil1... addresses when the faucet is enabled.
                     </p>


### PR DESCRIPTION
## Why
Trusted devnet faucet is now optionally token-protected (`NIL_FAUCET_AUTH_TOKEN`). Collaborators should still be able to fund wallets from the website UI *without* baking secrets into the build.

## What changed
- Added a localStorage-backed faucet auth token helper (`nil-website/src/lib/faucetAuthToken.ts`).
- `useFaucet` sends `X-Nil-Faucet-Auth` when a token is set.
- Added a small UI control to paste/save/clear the token:
  - Dashboard (Testnet funds card)
  - First File wizard (Fund step)
  - Testnet Docs page
- Updated `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` to mention the UI token flow.
- Updated `AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md` (mark PR10 merged; add PR11).

## Test
- `npm -C nil-website run test:unit`
- `npm -C nil-website run build`

## Notes
- The token is stored only in the user's browser (localStorage).
