### PR TITLE
PR12: caddy reverse proxy templates (HTTPS subdomains)

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -182,10 +182,11 @@ Checklist:
 
 ---
 
-### PR11 — Website faucet auth token (collaborator UX) (CURRENT)
+### PR11 — Website faucet auth token (collaborator UX) (MERGED)
 
 - Branch: `codex/website-faucet-auth-token`
 - Goal: Allow token-protected faucet funding from the website UI (without baking secrets into the build).
+- PR: https://github.com/Nil-Store/nil-store/pull/67
 - Test gate:
   - `npm -C nil-website run test:unit`
   - `npm -C nil-website run build`
@@ -195,3 +196,17 @@ Checklist:
 - [x] Send `X-Nil-Faucet-Auth` header from `useFaucet` when token is set.
 - [x] Add UI input (Dashboard + First File wizard + Testnet Docs) for collaborators to paste/save/clear the token.
 - [x] Update trusted devnet docs with the UI token flow.
+
+---
+
+### PR12 — Caddy reverse proxy templates (HTTPS subdomains) (CURRENT)
+
+- Branch: `codex/caddy-reverse-proxy-templates`
+- Goal: Provide copy/paste TLS reverse proxy configs for hub + providers to match the soft-launch endpoint profile.
+- Test gate:
+  - `bash -n scripts/run_devnet_provider.sh`
+
+Checklist:
+- [x] Add hub/provider example Caddyfiles under `ops/caddy/`.
+- [x] Link templates from `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` + `ops/systemd/README.md`.
+- [x] Update remote SP join quickstart to mention HTTPS endpoint variants.

--- a/docs/REMOTE_SP_JOIN_QUICKSTART.md
+++ b/docs/REMOTE_SP_JOIN_QUICKSTART.md
@@ -6,8 +6,8 @@ If you want the full guide, see `DEVNET_MULTI_PROVIDER.md`.
 
 ## What you need from the hub operator
 
-- Hub RPC: `tcp://<hub-host>:26657`
-- Hub LCD: `http://<hub-host>:1317`
+- Hub RPC: `tcp://<hub-host>:26657` (or `https://rpc.<domain>`)
+- Hub LCD: `http://<hub-host>:1317` (or `https://lcd.<domain>`)
 - Shared chain ID: `<chain-id>`
 - Shared router↔provider auth token: `NIL_GATEWAY_SP_AUTH=...`
 
@@ -48,8 +48,8 @@ If you need HTTPS/DNS-based endpoints, see `docs/networking/PROVIDER_ENDPOINTS.m
 ### 4) Register your provider on-chain
 
 ```bash
-export HUB_NODE="tcp://<hub-host>:26657"
-export HUB_LCD="http://<hub-host>:1317"
+export HUB_NODE="tcp://<hub-host>:26657"  # or https://rpc.<domain>
+export HUB_LCD="http://<hub-host>:1317"   # or https://lcd.<domain>
 export CHAIN_ID="<chain-id>"
 export PROVIDER_KEY="provider1"
 
@@ -90,4 +90,3 @@ curl -sf "$HUB_LCD/nilchain/nilchain/v1/providers" | jq '.providers | length'
 - Router can’t reach provider:
   - firewall/NAT; ensure your `PROVIDER_ENDPOINT` is reachable **from the hub**
   - confirm `NIL_GATEWAY_SP_AUTH` matches the hub router
-

--- a/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
+++ b/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
@@ -36,6 +36,9 @@ Use HTTPS subdomains (reverse-proxied to localhost ports):
 - `https://faucet.<domain>` → `http://127.0.0.1:8081` (faucet)
 - `https://web.<domain>` → static website build
 
+Reverse proxy templates:
+- Caddy examples live in `ops/caddy/` (`ops/caddy/Caddyfile.hub.example` + `ops/caddy/Caddyfile.provider.example`).
+
 ## Economics knobs (soft launch)
 
 Nilchain module params are stored in genesis under `app_state.nilchain.params` and can be patched at init-time

--- a/ops/caddy/Caddyfile.hub.example
+++ b/ops/caddy/Caddyfile.hub.example
@@ -1,0 +1,36 @@
+{
+  # Optional: set your ACME email for certificate issuance.
+  # email you@example.com
+}
+
+# Hub reverse proxy (trusted devnet soft launch).
+#
+# Replace `example.com` with your domain and create the DNS records:
+#   rpc.example.com, lcd.example.com, evm.example.com, gateway.example.com, faucet.example.com, web.example.com
+
+rpc.example.com {
+  reverse_proxy 127.0.0.1:26657
+}
+
+lcd.example.com {
+  reverse_proxy 127.0.0.1:1317
+}
+
+evm.example.com {
+  reverse_proxy 127.0.0.1:8545
+}
+
+gateway.example.com {
+  reverse_proxy 127.0.0.1:8080
+}
+
+faucet.example.com {
+  reverse_proxy 127.0.0.1:8081
+}
+
+web.example.com {
+  root * /opt/nilstore/nil-website/dist
+  encode zstd gzip
+  file_server
+}
+

--- a/ops/caddy/Caddyfile.provider.example
+++ b/ops/caddy/Caddyfile.provider.example
@@ -1,0 +1,14 @@
+{
+  # Optional: set your ACME email for certificate issuance.
+  # email you@example.com
+}
+
+# Provider reverse proxy (remote SP).
+#
+# Replace `sp1.example.com` with a DNS name you control.
+# This proxies HTTPS :443 → local provider gateway (default :8091).
+
+sp1.example.com {
+  reverse_proxy 127.0.0.1:8091
+}
+

--- a/ops/caddy/README.md
+++ b/ops/caddy/README.md
@@ -1,0 +1,40 @@
+# Caddy reverse proxy templates (Trusted Devnet Soft Launch)
+
+These files are **optional** helpers for running the trusted devnet behind HTTPS subdomains.
+
+Why:
+- Give collaborators a single “copy/paste” set of endpoints (`https://rpc.*`, `https://lcd.*`, `https://evm.*`, etc.).
+- Avoid exposing a bunch of raw ports directly to the internet.
+
+## Hub (VPS)
+
+1) Install Caddy (package or official installer).
+2) Copy `ops/caddy/Caddyfile.hub.example` to `/etc/caddy/Caddyfile` and edit the domain names.
+3) Ensure the hub services are running on localhost:
+   - `nilchaind` RPC: `127.0.0.1:26657`
+   - LCD/API: `127.0.0.1:1317`
+   - EVM JSON-RPC: `127.0.0.1:8545`
+   - Router gateway: `127.0.0.1:8080`
+   - Faucet: `127.0.0.1:8081`
+4) Build the website once:
+
+```bash
+cd /opt/nilstore/nil-website
+npm ci
+npm run build
+```
+
+Then `web.<domain>` serves `/opt/nilstore/nil-website/dist`.
+
+## Provider (remote SP)
+
+If a provider wants a clean HTTPS endpoint on port 443:
+1) Run the provider gateway locally (e.g. `:8091`).
+2) Use `ops/caddy/Caddyfile.provider.example` and set a DNS name (e.g. `sp1.<domain>`).
+3) Register the provider endpoint multiaddr as:
+
+- `/dns4/sp1.<domain>/tcp/443/https`
+
+Notes:
+- Caddy automatically handles TLS and WebSockets for these reverse proxies.
+

--- a/ops/systemd/README.md
+++ b/ops/systemd/README.md
@@ -43,4 +43,4 @@ journalctl -u nilchaind -f
 - If you run a reverse proxy for HTTPS subdomains, configure CORS to allow the website origin to call:
   - `gateway.*` (upload/fetch)
   - `lcd.*` / `evm.*` (wallet RPC)
-
+- Caddy example configs live in `ops/caddy/`.


### PR DESCRIPTION
## Why
The trusted devnet soft-launch profile assumes HTTPS subdomains (rpc/lcd/evm/gateway/faucet/web), but we didn't have concrete reverse-proxy templates to make that setup a copy/paste operation.

## What changed
- Added Caddy example configs:
  - `ops/caddy/Caddyfile.hub.example`
  - `ops/caddy/Caddyfile.provider.example`
  - `ops/caddy/README.md`
- Linked the templates from `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` and `ops/systemd/README.md`.
- Updated `docs/REMOTE_SP_JOIN_QUICKSTART.md` to mention HTTPS endpoint variants.
- Updated `AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md` (mark PR11 merged; add PR12).

## Test
- `bash -n scripts/run_devnet_provider.sh`
