### PR TITLE
PR13: gap report sync (post PR12)

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -199,10 +199,11 @@ Checklist:
 
 ---
 
-### PR12 — Caddy reverse proxy templates (HTTPS subdomains) (CURRENT)
+### PR12 — Caddy reverse proxy templates (HTTPS subdomains) (MERGED)
 
 - Branch: `codex/caddy-reverse-proxy-templates`
 - Goal: Provide copy/paste TLS reverse proxy configs for hub + providers to match the soft-launch endpoint profile.
+- PR: https://github.com/Nil-Store/nil-store/pull/68
 - Test gate:
   - `bash -n scripts/run_devnet_provider.sh`
 
@@ -210,3 +211,60 @@ Checklist:
 - [x] Add hub/provider example Caddyfiles under `ops/caddy/`.
 - [x] Link templates from `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` + `ops/systemd/README.md`.
 - [x] Update remote SP join quickstart to mention HTTPS endpoint variants.
+
+---
+
+### PR13 — Gap report sync (post-PR12) (CURRENT)
+
+- Branch: `codex/gap-report-sync`
+- Goal: Keep `docs/GAP_REPORT_REPO_ANCHORED.md` aligned with merged PR reality (no stale “planned fix” refs).
+- PR: https://github.com/Nil-Store/nil-store/pull/69
+- Test gate:
+  - `bash -n install.sh`
+
+Checklist:
+- [x] Mark PR12 as merged in this tracker.
+- [x] Update `docs/GAP_REPORT_REPO_ANCHORED.md` to reflect current CI assertions (Mode2 byte equality + allowlist proof vectors).
+- [x] Add next PR skeleton(s) for remaining trusted-devnet soft-launch work.
+
+---
+
+### PR14 — Stabilize Mode2 Stripe E2E (CI determinism) (MERGED)
+
+- Branch: `codex/mode2-stripe-e2e-stability`
+- Goal: Make Mode2 Stripe E2E stable on shared CI runners (reduce background contention).
+- PR: https://github.com/Nil-Store/nil-store/pull/70
+- Test gate:
+  - `bash -n scripts/e2e_mode2_stripe_multi_sp.sh`
+
+Checklist:
+- [x] Disable the background system liveness prover during this E2E run (`NIL_DISABLE_SYSTEM_LIVENESS=1` default).
+- [x] Cap Mode2 upload parallelism (`NIL_MODE2_UPLOAD_PARALLELISM=16` default).
+- [x] Keep both knobs overrideable for local stress runs.
+
+---
+
+### PR15 — Hub VPS “blank box → running devnet” runbook (systemd + caddy + web build) (NEXT)
+
+- Branch: `codex/hub-vps-runbook`
+- Goal: Make hub deployment a copy/paste process (DNS → build → systemd → caddy → verify).
+- Test gate:
+  - `bash -n scripts/run_devnet_alpha_multi_sp.sh`
+
+Checklist:
+- [ ] Add a hub operator runbook section: required ports, DNS records, Caddy install + reload, and systemd enable/start order.
+- [ ] Document `nil-website` build env for HTTPS subdomains (`VITE_LCD_BASE`, `VITE_EVM_RPC`, `VITE_GATEWAY_BASE`, `VITE_API_BASE`, `VITE_COSMOS_CHAIN_ID`, `VITE_CHAIN_ID`).
+- [ ] Add a “MetaMask add network” snippet (RPC URL, chain id, currency, explorer placeholder).
+
+---
+
+### PR16 — Devnet healthcheck script (hub + provider) (TODO)
+
+- Branch: `codex/devnet-healthcheck-script`
+- Goal: Replace “tribal knowledge” monitoring with a single script that fails loudly when the devnet is unhealthy.
+- Test gate:
+  - `bash -n scripts/devnet_healthcheck.sh`
+
+Checklist:
+- [ ] Add `scripts/devnet_healthcheck.sh` (hub mode + provider mode) to validate RPC/LCD/EVM/gateway/faucet/health endpoints.
+- [ ] Wire the script into `docs/TRUSTED_DEVNET_MONITORING_CHECKLIST.md` as an optional daily check.

--- a/docs/GAP_REPORT_REPO_ANCHORED.md
+++ b/docs/GAP_REPORT_REPO_ANCHORED.md
@@ -35,6 +35,7 @@ Legend:
 
 - WAN / multi-host devnet behavior (real latency, NAT, TLS, firewalling)
 - Long-running durability (restarts, reorgs, disk corruption, GC/compaction)
+- Mode2 Stripe behavior under background `nil_gateway` system liveness prover load (CI disables it for determinism via `NIL_DISABLE_SYSTEM_LIVENESS=1`)
 - Dynamic pricing stability/tuning beyond bounded, unit-tested epoch adjustments (no long-running devnet evidence)
 - Adversarial cryptoeconomic behavior (griefing, strategic downtime, bribery)
 - Comprehensive security review / external audit
@@ -44,8 +45,8 @@ Legend:
 | Requirement | Status | Spec/RFC anchor | Current implementation (refs) | CI proof | Not proven / gap | Planned fix |
 |---|---:|---|---|---|---|---|
 | Enforce `MAX_DEAL_BYTES` hard cap (avoid unbounded state bloat) | DONE | `spec.md` (“Hard Cap: 512 GiB”); `rfcs/rfc-data-granularity-and-economics.md` | `nilchain/x/nilchain/types/types.go` (`MAX_DEAL_BYTES`); `nilchain/x/nilchain/keeper/msg_server.go` (`MsgUpdateDealContent*`) | `cd nilchain && go test ./...` (unit tests) | — | — |
-| Mode2 Stripe retrieval: verify downloaded bytes == uploaded bytes | PARTIAL | `rfcs/rfc-blob-alignment-and-striping.md` | Mode2 flows implemented end-to-end, but Playwright asserts only “downloaded something” | `scripts/e2e_mode2_stripe_multi_sp.sh` | No byte-for-byte assertion in `nil-website/tests/mode2-stripe.spec.ts` | PR4 (`codex/mode2-stripe-bytes-assert`) |
-| Allowlist retrieval policy verification has test vectors | PARTIAL | `rfcs/rfc-retrieval-access-control-public-deals-and-vouchers.md` | Allowlist verification is implemented in `nilchain/x/nilchain/keeper/msg_server.go` (`OpenRetrievalSessionSponsored`) | N/A | No unit tests covering keccak merkle proofs; easiest place to regress | PR5 (`codex/allowlist-merkle-tests`) |
+| Mode2 Stripe retrieval: verify downloaded bytes == uploaded bytes | DONE | `rfcs/rfc-blob-alignment-and-striping.md` | Playwright asserts sha256(downloaded) == sha256(uploaded) in `nil-website/tests/mode2-stripe.spec.ts` | `scripts/e2e_mode2_stripe_multi_sp.sh` | — | — |
+| Allowlist retrieval policy verification has test vectors | DONE | `rfcs/rfc-retrieval-access-control-public-deals-and-vouchers.md` | Allowlist verification in `nilchain/x/nilchain/keeper/msg_server.go` (`OpenRetrievalSessionSponsored`) + test vectors in `nilchain/x/nilchain/keeper/msg_server_sponsored_sessions_test.go` | `cd nilchain && go test ./...` | — | — |
 | NilCE round-trip semantics are end-to-end and documented | PARTIAL | `rfcs/rfc-content-encoding-and-compression.md` | Upload-side wrapping + header parsing helpers exist in `nil_gateway/` (opt-in `NIL_NILCE=1`) | `go test ./nil_gateway/...` (NilCE unit tests) | Not required by CI E2E; fetch path does not currently auto-decode to match original bytes for Web2-style users | Defer (track separately if needed for launch) |
 
 ## Phase 1 — Deal expiry + renewal (ExtendDeal)
@@ -75,7 +76,7 @@ Legend:
 | Deal retrieval policy fields (OwnerOnly/Allowlist/Voucher/Public) | DONE | `nilchain/proto/nilchain/nilchain/v1/types.proto` (RetrievalPolicy); `MsgUpdateDealRetrievalPolicy` in `tx.proto` + `msg_server.go` | `cd nilchain && go test ./...` | — |
 | `MsgOpenRetrievalSession` remains owner-only and owner-paid (frozen semantics) | DONE | `nilchain/x/nilchain/keeper/msg_server.go` (`OpenRetrievalSession`) | `nilchain/x/nilchain/keeper/msg_server_retrieval_sessions_test.go` | — |
 | Implement requester-paid `MsgOpenRetrievalSessionSponsored` | DONE | `nilchain/x/nilchain/keeper/msg_server.go` (`OpenRetrievalSessionSponsored`) | `nilchain/x/nilchain/keeper/msg_server_sponsored_sessions_test.go` | — |
-| Implement allowlist verification (merkle root + proof) | PARTIAL | Implemented in `OpenRetrievalSessionSponsored`, but no tests | N/A | Missing deterministic test vectors (see Phase 0) |
+| Implement allowlist verification (merkle root + proof) | DONE | `OpenRetrievalSessionSponsored` verification + unit tests in `nilchain/x/nilchain/keeper/msg_server_sponsored_sessions_test.go` | `cd nilchain && go test ./...` | — |
 | Implement voucher (EIP-712 signature) + one-time nonce anti-replay | DONE | `OpenRetrievalSessionSponsored` + voucher nonce tracking in keeper | `nilchain/x/nilchain/keeper/msg_server_sponsored_sessions_test.go` | — |
 
 ## Phase 4 — Protocol retrieval hooks (audit/repair) + audit budget


### PR DESCRIPTION
Updates the repo-anchored gap report to reflect current CI reality (Mode2 stripe retrieval byte-equality assertion + allowlist proof test vectors are now covered), and advances the trusted devnet soft-launch tracker (marks PR12 merged; adds PR14/PR15 skeletons).

Test gate:
- bash -n install.sh