### PR TITLE
PR17: mode2 stripe e2e flake reduction

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -259,13 +259,30 @@ Checklist:
 
 ---
 
-### PR16 — Devnet healthcheck script (hub + provider) (CURRENT)
+### PR16 — Devnet healthcheck script (hub + provider) (MERGED)
 
 - Branch: `codex/devnet-healthcheck-script`
 - Goal: Replace “tribal knowledge” monitoring with a single script that fails loudly when the devnet is unhealthy.
+- PR: https://github.com/Nil-Store/nil-store/pull/72
 - Test gate:
   - `bash -n scripts/devnet_healthcheck.sh`
 
 Checklist:
 - [x] Add `scripts/devnet_healthcheck.sh` (hub mode + provider mode) to validate RPC/LCD/EVM/gateway/faucet/health endpoints.
 - [x] Wire the script into `docs/TRUSTED_DEVNET_MONITORING_CHECKLIST.md` as an optional daily check.
+
+---
+
+### PR17 — Mode2 Stripe E2E flake reduction (gateway readiness + retries) (CURRENT)
+
+- Branch: `codex/mode2-stripe-e2e-retry`
+- Goal: Reduce CI flakes in `scripts/e2e_mode2_stripe_multi_sp.sh` by waiting for the local gateway “Connected” state and adding a single retry for the Mode2 Stripe suite in CI.
+- Test gate:
+  - `npm -C nil-website run test:unit`
+  - `npm -C nil-website run lint`
+  - `bash -n scripts/e2e_mode2_stripe_multi_sp.sh`
+
+Checklist:
+- [x] Add a stable selector/attribute for gateway connection status (so Playwright can wait for it).
+- [x] Update `nil-website/tests/mode2-stripe.spec.ts` to wait for gateway “Connected” before selecting files.
+- [x] Add a single CI retry for the Mode2 Stripe suite (targeted; not global).

--- a/nil-website/src/components/GatewayStatusWidget.tsx
+++ b/nil-website/src/components/GatewayStatusWidget.tsx
@@ -64,6 +64,8 @@ export const GatewayStatusWidget: React.FC<GatewayStatusWidgetProps> = ({ pollIn
 
   return (
     <div 
+      data-testid="gateway-status-widget"
+      data-status={status}
       className={`flex items-center gap-1 text-sm ${colorClass} ${className}`}
       title={tooltip}
     >

--- a/nil-website/tests/mode2-stripe.spec.ts
+++ b/nil-website/tests/mode2-stripe.spec.ts
@@ -1,9 +1,14 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import crypto from 'node:crypto'
 import fs from 'node:fs/promises'
 
 const dashboardPath = process.env.E2E_PATH || '/#/dashboard'
 const hasLocalStack = process.env.E2E_LOCAL_STACK === '1'
+
+async function waitForGatewayConnected(page: Page): Promise<void> {
+  const widget = page.getByTestId('gateway-status-widget')
+  await expect(widget).toHaveAttribute('data-status', 'connected', { timeout: 60_000 })
+}
 
 function cachedFileNameForPath(filePath: string): string {
   const normalized = String(filePath ?? '')
@@ -14,6 +19,7 @@ function cachedFileNameForPath(filePath: string): string {
 test.describe('mode2 stripe', () => {
   test.skip(!hasLocalStack, 'requires local stack')
   test.use({ acceptDownloads: true })
+  test.describe.configure({ retries: process.env.CI ? 1 : 0 })
 
   test('mode2 deal → shard → upload → commit → retrieve', async ({ page }) => {
     test.setTimeout(600_000)
@@ -50,6 +56,7 @@ test.describe('mode2 stripe', () => {
     expect(dealId).not.toBe('')
 
     await expect(page.getByTestId('mdu-file-input')).toHaveCount(1, { timeout: 180_000 })
+    await waitForGatewayConnected(page)
 
     await page.getByTestId('mdu-file-input').setInputFiles({
       name: filePath,
@@ -260,6 +267,7 @@ test.describe('mode2 stripe', () => {
     expect(dealId).not.toBe('')
 
     await expect(page.getByTestId('mdu-file-input')).toHaveCount(1, { timeout: 180_000 })
+    await waitForGatewayConnected(page)
 
     await page.getByTestId('mdu-file-input').setInputFiles({
       name: fileA.name,


### PR DESCRIPTION
Goal: reduce CI flakes in Mode2 Stripe Playwright E2E.

Changes:
- nil-website/src/components/GatewayStatusWidget.tsx: add data-testid + data-status for stable assertions.
- nil-website/tests/mode2-stripe.spec.ts: wait for gateway Connected before file selection; add 1 retry in CI for this suite only.
- AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md: mark PR16 merged; add PR17 tracker entry.

Test gate:
- npm -C nil-website run test:unit
- npm -C nil-website run lint
- bash -n scripts/e2e_mode2_stripe_multi_sp.sh