### PR TITLE
PR18: provider onboarding polish

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -273,10 +273,11 @@ Checklist:
 
 ---
 
-### PR17 — Mode2 Stripe E2E flake reduction (gateway readiness + retries) (CURRENT)
+### PR17 — Mode2 Stripe E2E flake reduction (gateway readiness + retries) (MERGED)
 
 - Branch: `codex/mode2-stripe-e2e-retry`
 - Goal: Reduce CI flakes in `scripts/e2e_mode2_stripe_multi_sp.sh` by waiting for the local gateway “Connected” state and adding a single retry for the Mode2 Stripe suite in CI.
+- PR: https://github.com/Nil-Store/nil-store/pull/73
 - Test gate:
   - `npm -C nil-website run test:unit`
   - `npm -C nil-website run lint`
@@ -286,3 +287,19 @@ Checklist:
 - [x] Add a stable selector/attribute for gateway connection status (so Playwright can wait for it).
 - [x] Update `nil-website/tests/mode2-stripe.spec.ts` to wait for gateway “Connected” before selecting files.
 - [x] Add a single CI retry for the Mode2 Stripe suite (targeted; not global).
+
+---
+
+### PR18 — Provider onboarding polish (quickstart + systemd + HTTPS + healthcheck) (CURRENT)
+
+- Branch: `codex/provider-onboarding-polish`
+- Goal: Make a remote SP join (and stay running) feel copy/paste: quickstart docs reference systemd templates, HTTPS proxy options, and the healthcheck script.
+- Test gate:
+  - `bash -n scripts/run_devnet_provider.sh`
+
+Checklist:
+- [x] Update `docs/REMOTE_SP_JOIN_QUICKSTART.md` to reference:
+  - `ops/systemd/nil-gateway-provider.service` + `ops/systemd/env/nil-gateway-provider.env`
+  - `ops/caddy/Caddyfile.provider.example` for HTTPS
+  - `scripts/devnet_healthcheck.sh provider ...` for verification
+- [x] Add a short “provider systemd” snippet to `ops/systemd/README.md`.

--- a/docs/REMOTE_SP_JOIN_QUICKSTART.md
+++ b/docs/REMOTE_SP_JOIN_QUICKSTART.md
@@ -16,6 +16,9 @@ If you want the full guide, see `DEVNET_MULTI_PROVIDER.md`.
 - This repo checked out
 - Go + Rust toolchains installed
 - A public reachable provider endpoint (recommended: inbound TCP port + HTTP; HTTPS is optional for this soft launch)
+- (Optional, recommended) systemd + a reverse proxy:
+  - systemd templates: `ops/systemd/nil-gateway-provider.service` + `ops/systemd/env/nil-gateway-provider.env`
+  - HTTPS reverse proxy example: `ops/caddy/Caddyfile.provider.example`
 
 ## Step-by-step
 
@@ -69,12 +72,20 @@ export PROVIDER_LISTEN=":8091"
 ./scripts/run_devnet_provider.sh start
 ```
 
+Long-running (recommended): use the systemd templates in `ops/systemd/` and copy/edit `ops/systemd/env/nil-gateway-provider.env`.
+
 ### 6) Verify
 
 On the provider:
 
 ```bash
 curl -sf http://127.0.0.1:8091/health
+```
+
+Or run the healthcheck script (recommended):
+
+```bash
+scripts/devnet_healthcheck.sh provider --provider http://127.0.0.1:8091 --hub-lcd "$HUB_LCD" --provider-addr <nil1...>
 ```
 
 From the hub (or anywhere with LCD access):

--- a/ops/systemd/README.md
+++ b/ops/systemd/README.md
@@ -39,6 +39,26 @@ sudo systemctl enable --now nil-faucet
 journalctl -u nilchaind -f
 ```
 
+## Provider quick usage
+
+Providers can run `nil_gateway` in **provider** mode as a long-running service too:
+
+```bash
+sudo cp ops/systemd/nil-gateway-provider.service /etc/systemd/system/
+sudo systemctl daemon-reload
+
+sudo mkdir -p /etc/nilstore
+sudo cp ops/systemd/env/nil-gateway-provider.env /etc/nilstore/
+sudoedit /etc/nilstore/nil-gateway-provider.env
+
+sudo systemctl enable --now nil-gateway-provider
+```
+
+Minimum required edits in `nil-gateway-provider.env`:
+- `NIL_GATEWAY_SP_AUTH` must match the hub router
+- `NIL_CHAIN_ID`, `NIL_NODE`, `NIL_LCD_BASE` must point at the hub
+- `NIL_HOME` + `NIL_PROVIDER_KEY` must reference a key that exists locally
+
 ## Notes
 
 - These templates assume you checked the repo out at `/opt/nilstore`. Adjust as needed.


### PR DESCRIPTION
Goal: make remote SP onboarding more copy/paste (docs + systemd templates + healthcheck references).

Changes:
- docs/REMOTE_SP_JOIN_QUICKSTART.md: reference systemd template, HTTPS proxy example, and scripts/devnet_healthcheck.sh.
- ops/systemd/README.md: add provider quick usage snippet.
- AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md: add PR18 tracker entry and check off items.

Test gate:
- bash -n scripts/run_devnet_provider.sh