### PR TITLE
PR19: hub local bind defaults

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -290,10 +290,11 @@ Checklist:
 
 ---
 
-### PR18 — Provider onboarding polish (quickstart + systemd + HTTPS + healthcheck) (CURRENT)
+### PR18 — Provider onboarding polish (quickstart + systemd + HTTPS + healthcheck) (MERGED)
 
 - Branch: `codex/provider-onboarding-polish`
 - Goal: Make a remote SP join (and stay running) feel copy/paste: quickstart docs reference systemd templates, HTTPS proxy options, and the healthcheck script.
+- PR: https://github.com/Nil-Store/nil-store/pull/74
 - Test gate:
   - `bash -n scripts/run_devnet_provider.sh`
 
@@ -303,3 +304,17 @@ Checklist:
   - `ops/caddy/Caddyfile.provider.example` for HTTPS
   - `scripts/devnet_healthcheck.sh provider ...` for verification
 - [x] Add a short “provider systemd” snippet to `ops/systemd/README.md`.
+
+---
+
+### PR19 — Hub ops safety defaults (bind to localhost by default) (CURRENT)
+
+- Branch: `codex/hub-local-bind-defaults`
+- Goal: Reduce accidental public exposure of hub-local ports by making the systemd env templates default to localhost bindings (Caddy stays the public entrypoint).
+- Test gate:
+  - `bash -n scripts/run_devnet_alpha_multi_sp.sh`
+
+Checklist:
+- [x] Update `ops/systemd/env/nilchaind.env` to default CometBFT RPC to localhost.
+- [x] Update `ops/systemd/env/nil-gateway-router.env` to default router listen addr to localhost.
+- [x] Add a brief note in `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` that these are safe defaults for the HTTPS subdomain profile.

--- a/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
+++ b/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
@@ -128,7 +128,7 @@ Minimum required edits:
 - set `NIL_CHAIN_ID` (use the value printed by the bootstrap script, or your chosen chain id)
 - set `NIL_GATEWAY_SP_AUTH` on the router and providers (shared secret)
 - set `NIL_FAUCET_AUTH_TOKEN` (recommended for invite-only; share with collaborators out-of-band)
-- recommended (hub behind Caddy): bind services to localhost and expose only via HTTPS:
+- recommended (hub behind Caddy): bind services to localhost and expose only via HTTPS (systemd env templates default to this):
   - `nilchaind.env`: `NIL_RPC_LADDR=tcp://127.0.0.1:26657`
   - `nil-gateway-router.env`: `NIL_LISTEN_ADDR=127.0.0.1:8080`
   - `nil_faucet` currently binds to `:8081` (use a firewall to block direct `8081/tcp` and expose only via Caddy)

--- a/ops/systemd/env/nil-gateway-router.env
+++ b/ops/systemd/env/nil-gateway-router.env
@@ -6,7 +6,8 @@ NIL_ROOT_DIR=/opt/nilstore
 NIL_GATEWAY_ROUTER=1
 
 # Networking
-NIL_LISTEN_ADDR=:8080
+# For the trusted devnet hub profile (behind HTTPS reverse proxy), bind locally.
+NIL_LISTEN_ADDR=127.0.0.1:8080
 
 # Chain connectivity
 NIL_CHAIN_ID=<set-me>
@@ -35,4 +36,3 @@ NIL_ENABLE_TX_RELAY=0
 
 # Optional: disable libp2p server for the soft launch (simpler networking).
 NIL_P2P_ENABLED=0
-

--- a/ops/systemd/env/nilchaind.env
+++ b/ops/systemd/env/nilchaind.env
@@ -14,8 +14,9 @@ NIL_CHAIN_ID=<set-me>
 NIL_GAS_PRICES=0.001aatom
 
 # Networking
-NIL_RPC_LADDR=tcp://0.0.0.0:26657
+# For the trusted devnet hub profile (behind HTTPS reverse proxy), bind CometBFT RPC locally.
+# If you intentionally want RPC reachable without a reverse proxy, override this.
+NIL_RPC_LADDR=tcp://127.0.0.1:26657
 
 # App toggles
 NIL_DISABLE_EVM_MEMPOOL=0
-


### PR DESCRIPTION
Goal: reduce accidental public exposure of hub-local ports by defaulting systemd env templates to localhost bindings.

Changes:
- ops/systemd/env/nilchaind.env: default RPC laddr to 127.0.0.1.
- ops/systemd/env/nil-gateway-router.env: default listen addr to 127.0.0.1.
- docs/TRUSTED_DEVNET_SOFT_LAUNCH.md: clarify templates default to safe binds.
- AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md: add PR19 tracker entry and check off items.

Test gate:
- bash -n scripts/run_devnet_alpha_multi_sp.sh