### PR TITLE
tauri: fix vitest walletconnect modal init

### DIFF
--- a/nil_gateway_gui/src/hooks/useWallet.ts
+++ b/nil_gateway_gui/src/hooks/useWallet.ts
@@ -15,10 +15,6 @@ const metadata = {
   icons: [],
 };
 
-const modal = new WalletConnectModal({
-  projectId: PROJECT_ID,
-});
-
 type WalletStatus = "disconnected" | "connecting" | "connected";
 
 function parseAccount(account: string) {
@@ -64,6 +60,7 @@ export function useWallet() {
       setError("WalletConnect not initialized");
       return;
     }
+    const modal = new WalletConnectModal({ projectId: PROJECT_ID });
     setStatus("connecting");
     setError(null);
     try {


### PR DESCRIPTION
Fixes intermittent/CI-only vitest failure where WalletConnectModal schedules browser-only UI work and throws `document is not defined` after test teardown.

Change:
- nil_gateway_gui/src/hooks/useWallet.ts: instantiate WalletConnectModal lazily inside connect() instead of at module scope.

Test gate:
- npm -C nil_gateway_gui test