### PR TITLE
Faucet: configurable listen addr (default localhost)

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -319,3 +319,17 @@ Checklist:
 - [x] Update `ops/systemd/env/nilchaind.env` to default CometBFT RPC to localhost.
 - [x] Update `ops/systemd/env/nil-gateway-router.env` to default router listen addr to localhost.
 - [x] Add a brief note in `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` that these are safe defaults for the HTTPS subdomain profile.
+
+---
+
+### PR20 — Faucet safe bind default (listen addr) (CURRENT)
+
+- Branch: `codex/faucet-listen-addr`
+- Goal: Make the hub faucet bind to localhost by default (Caddy remains the public entrypoint).
+- Test gate:
+  - `cd nil_faucet && go test ./...`
+
+Checklist:
+- [x] Add `NIL_LISTEN_ADDR` support to `nil_faucet` (default `127.0.0.1:8081`).
+- [x] Update `ops/systemd/env/nil-faucet.env` to set `NIL_LISTEN_ADDR=127.0.0.1:8081`.
+- [x] Update `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` to remove the “firewall-only” faucet bind note.

--- a/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
+++ b/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
@@ -131,7 +131,7 @@ Minimum required edits:
 - recommended (hub behind Caddy): bind services to localhost and expose only via HTTPS (systemd env templates default to this):
   - `nilchaind.env`: `NIL_RPC_LADDR=tcp://127.0.0.1:26657`
   - `nil-gateway-router.env`: `NIL_LISTEN_ADDR=127.0.0.1:8080`
-  - `nil_faucet` currently binds to `:8081` (use a firewall to block direct `8081/tcp` and expose only via Caddy)
+  - `nil-faucet.env`: `NIL_LISTEN_ADDR=127.0.0.1:8081`
 
 3) Enable + start (recommended order):
 

--- a/nil_faucet/main.go
+++ b/nil_faucet/main.go
@@ -23,6 +23,7 @@ import (
 var (
 	chainID     = envDefault("NIL_CHAIN_ID", "test-1")
 	homeDir     = envDefault("NIL_HOME", "../.nilchain")
+	listenAddr  = envDefault("NIL_LISTEN_ADDR", "127.0.0.1:8081")
 	amount      = envDefault("NIL_AMOUNT", "1000000000000000000aatom,1000000stake")
 	denom       = envDefault("NIL_DENOM", "stake")
 	gasPrices   = envDefault("NIL_GAS_PRICES", "0.001aatom")
@@ -51,8 +52,8 @@ func main() {
 	// Enable CORS
 	r.Use(mux.CORSMethodMiddleware(r))
 
-	log.Printf("Starting NilChain Faucet on :8081 (chain-id=%s, home=%s)\n", chainID, homeDir)
-	log.Fatal(http.ListenAndServe(":8081", r))
+	log.Printf("Starting NilChain Faucet on %s (chain-id=%s, home=%s)\n", listenAddr, chainID, homeDir)
+	log.Fatal(http.ListenAndServe(listenAddr, r))
 }
 
 // deriveNilchaindDir attempts to find a working directory where nilchaind

--- a/ops/systemd/env/nil-faucet.env
+++ b/ops/systemd/env/nil-faucet.env
@@ -5,6 +5,10 @@ NIL_ROOT_DIR=/opt/nilstore
 NIL_HOME=/var/lib/nilstore/nilchaind
 NIL_CHAIN_ID=<set-me>
 
+# Networking
+# For the trusted devnet hub profile (behind HTTPS reverse proxy), bind locally.
+NIL_LISTEN_ADDR=127.0.0.1:8081
+
 # Token + fees
 NIL_DENOM=stake
 NIL_AMOUNT=1000000000000000000aatom,100000000stake


### PR DESCRIPTION
- Adds `NIL_LISTEN_ADDR` to `nil_faucet` (default `127.0.0.1:8081`).
- Updates hub systemd env template + soft-launch runbook to match.
- Updates `AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md` with PR20 section.

Test gate:
- `cd nil_faucet && go test ./...`