### PR TITLE
scripts: default LCD/EVM binds to localhost

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -334,3 +334,20 @@ Checklist:
 - [x] Add `NIL_LISTEN_ADDR` support to `nil_faucet` (default `127.0.0.1:8081`).
 - [x] Update `ops/systemd/env/nil-faucet.env` to set `NIL_LISTEN_ADDR=127.0.0.1:8081`.
 - [x] Update `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` to remove the “firewall-only” faucet bind note.
+
+---
+
+### PR21 — Bootstrap scripts: local-only LCD/EVM binds by default (CURRENT)
+
+- Branch: `codex/hub-bootstrap-local-binds`
+- Goal: Align the bootstrap scripts with the hub safety posture: bind LCD + EVM JSON-RPC to localhost by default, with an opt-in for `0.0.0.0` when needed.
+- PR: (pending)
+- Test gate:
+  - `bash -n scripts/run_devnet_alpha_multi_sp.sh`
+  - `bash -n scripts/run_local_stack.sh`
+
+Checklist:
+- [ ] Add `NIL_BIND_ALL=1` knob (default `0`) to opt into `0.0.0.0` binds for LCD/EVM JSON-RPC.
+- [ ] Update `scripts/run_devnet_alpha_multi_sp.sh` init-time config patching to respect `NIL_BIND_ALL`.
+- [ ] Update `scripts/run_local_stack.sh` init-time config patching (perl + python fallback) to respect `NIL_BIND_ALL`.
+- [ ] Document the knob in `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` (LAN / non-proxy debugging use only).

--- a/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
+++ b/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
@@ -89,6 +89,9 @@ sudo chown -R "$USER":"$USER" /var/lib/nilstore
 NIL_HOME=/var/lib/nilstore/nilchaind PROVIDER_COUNT=0 START_WEB=0 ./scripts/run_devnet_alpha_multi_sp.sh start
 ```
 
+Note: the bootstrap script binds LCD + EVM JSON-RPC to localhost by default (safe for the hub-behind-Caddy profile).
+If you intentionally want to bind them to `0.0.0.0` for LAN / non-proxy debugging, set `NIL_BIND_ALL=1` and firewall accordingly.
+
 Copy out (and store safely):
 - the printed `SP Auth` token (also at `_artifacts/devnet_alpha_multi_sp/sp_auth.txt`)
 - the printed `Home:` directory (should match the `NIL_HOME` you chose; keep it for systemd)

--- a/scripts/run_devnet_alpha_multi_sp.sh
+++ b/scripts/run_devnet_alpha_multi_sp.sh
@@ -13,6 +13,9 @@
 #
 # Hub-only mode (no local providers):
 #   PROVIDER_COUNT=0 ./scripts/run_devnet_alpha_multi_sp.sh start
+#
+# Networking:
+#   By default, LCD + EVM JSON-RPC bind to localhost. Set NIL_BIND_ALL=1 to bind to 0.0.0.0 (LAN debugging).
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -26,6 +29,7 @@ RPC_ADDR="${RPC_ADDR:-tcp://127.0.0.1:26657}"
 EVM_RPC_PORT="${EVM_RPC_PORT:-8545}"
 GAS_PRICE="${NIL_GAS_PRICES:-0.001aatom}"
 DENOM="${NIL_DENOM:-stake}"
+NIL_BIND_ALL="${NIL_BIND_ALL:-0}" # set to 1 to bind LCD/EVM JSON-RPC to 0.0.0.0
 
 NILCHAIND_BIN="$ROOT_DIR/nilchain/nilchaind"
 NIL_CLI_BIN="$ROOT_DIR/nil_cli/target/release/nil_cli"
@@ -423,9 +427,17 @@ init_chain() {
   APP_TOML="$CHAIN_HOME/config/app.toml"
   perl -pi -e 's/^max-txs *= *-1/max-txs = 0/' "$APP_TOML"
   perl -pi -e 's/^enable *= *false/enable = true/' "$APP_TOML"            # JSON-RPC enable
-  perl -pi -e 's|^address *= *"127\\.0\\.0\\.1:8545"|address = "0.0.0.0:8545"|' "$APP_TOML"
-  perl -pi -e 's|^ws-address *= *"127\\.0\\.0\\.1:8546"|ws-address = "0.0.0.0:8546"|' "$APP_TOML"
-  perl -pi -e 's|^address *= *"tcp://localhost:1317"|address = "tcp://0.0.0.0:1317"|' "$APP_TOML"
+  if [ "$NIL_BIND_ALL" = "1" ]; then
+    perl -pi -e 's|^address *= *"127\\.0\\.0\\.1:8545"|address = "0.0.0.0:8545"|' "$APP_TOML"
+    perl -pi -e 's|^ws-address *= *"127\\.0\\.0\\.1:8546"|ws-address = "0.0.0.0:8546"|' "$APP_TOML"
+    perl -pi -e 's|^address *= *"tcp://localhost:1317"|address = "tcp://0.0.0.0:1317"|' "$APP_TOML"
+  else
+    # Safe-by-default (hub profile): keep LCD + JSON-RPC local-only and expose only via reverse proxy.
+    perl -pi -e 's|^address *= *"0\\.0\\.0\\.0:8545"|address = "127.0.0.1:8545"|' "$APP_TOML"
+    perl -pi -e 's|^ws-address *= *"0\\.0\\.0\\.0:8546"|ws-address = "127.0.0.1:8546"|' "$APP_TOML"
+    perl -pi -e 's|^address *= *"tcp://0\\.0\\.0\\.0:1317"|address = "tcp://127.0.0.1:1317"|' "$APP_TOML"
+    perl -pi -e 's|^address *= *"tcp://localhost:1317"|address = "tcp://127.0.0.1:1317"|' "$APP_TOML"
+  fi
   perl -pi -e 's/^enabled-unsafe-cors *= *false/enabled-unsafe-cors = true/' "$APP_TOML"
   perl -pi -e "s/^evm-chain-id *= *[0-9]+/evm-chain-id = $EVM_CHAIN_ID/" "$APP_TOML"
 }

--- a/scripts/run_local_stack.sh
+++ b/scripts/run_local_stack.sh
@@ -3,6 +3,9 @@
 # Usage:
 #   ./scripts/run_local_stack.sh start   # default
 #   ./scripts/run_local_stack.sh stop    # kill background processes started by this script
+#
+# Networking:
+#   By default, LCD + EVM JSON-RPC bind to localhost. Set NIL_BIND_ALL=1 to bind to 0.0.0.0 (LAN debugging).
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -15,6 +18,7 @@ EVM_RPC_PORT="${EVM_RPC_PORT:-8545}"
 RPC_ADDR="${RPC_ADDR:-tcp://127.0.0.1:26657}"
 GAS_PRICE="${NIL_GAS_PRICES:-0.001aatom}"
 DENOM="${NIL_DENOM:-stake}"
+NIL_BIND_ALL="${NIL_BIND_ALL:-0}" # set to 1 to bind LCD/EVM JSON-RPC to 0.0.0.0
 export NIL_AMOUNT="1000000000000000000aatom,100000000stake" # 1 aatom, 100 stake
 FAUCET_MNEMONIC="${FAUCET_MNEMONIC:-course what neglect valley visual ride common cricket bachelor rigid vessel mask actor pumpkin edit follow sorry used divorce odor ask exclude crew hole}"
 NILCHAIND_BIN="$ROOT_DIR/nilchain/nilchaind"
@@ -524,23 +528,44 @@ PY
   APP_TOML="$CHAIN_HOME/config/app.toml"
   perl -pi -e 's/^max-txs *= *-1/max-txs = 0/' "$APP_TOML"
   perl -pi -e 's/^enable *= *false/enable = true/' "$APP_TOML"            # JSON-RPC enable
-  perl -pi -e 's|^address *= *"127\\.0\\.0\\.1:8545"|address = "0.0.0.0:8545"|' "$APP_TOML"
-  perl -pi -e 's|^ws-address *= *"127\\.0\\.0\\.1:8546"|ws-address = "0.0.0.0:8546"|' "$APP_TOML"
-  perl -pi -e 's|^address *= *"tcp://localhost:1317"|address = "tcp://0.0.0.0:1317"|' "$APP_TOML"
+  if [ "$NIL_BIND_ALL" = "1" ]; then
+    perl -pi -e 's|^address *= *"127\\.0\\.0\\.1:8545"|address = "0.0.0.0:8545"|' "$APP_TOML"
+    perl -pi -e 's|^ws-address *= *"127\\.0\\.0\\.1:8546"|ws-address = "0.0.0.0:8546"|' "$APP_TOML"
+    perl -pi -e 's|^address *= *"tcp://localhost:1317"|address = "tcp://0.0.0.0:1317"|' "$APP_TOML"
+  else
+    # Safer local dev defaults: keep LCD + JSON-RPC local-only. Set NIL_BIND_ALL=1 to override.
+    perl -pi -e 's|^address *= *"0\\.0\\.0\\.0:8545"|address = "127.0.0.1:8545"|' "$APP_TOML"
+    perl -pi -e 's|^ws-address *= *"0\\.0\\.0\\.0:8546"|ws-address = "127.0.0.1:8546"|' "$APP_TOML"
+    perl -pi -e 's|^address *= *"tcp://0\\.0\\.0\\.0:1317"|address = "tcp://127.0.0.1:1317"|' "$APP_TOML"
+    perl -pi -e 's|^address *= *"tcp://localhost:1317"|address = "tcp://127.0.0.1:1317"|' "$APP_TOML"
+  fi
   perl -pi -e 's/^enabled-unsafe-cors *= *false/enabled-unsafe-cors = true/' "$APP_TOML"
   perl -pi -e "s/^evm-chain-id *= *[0-9]+/evm-chain-id = $EVM_CHAIN_ID/" "$APP_TOML"
   # Fallback patcher in case formats change (pure string replace to avoid extra deps)
   python3 - "$APP_TOML" <<'PY' || true
-import sys, pathlib
+import os, sys, pathlib
 path = pathlib.Path(sys.argv[1])
 txt = path.read_text()
-for src, dst in [
-    ('address = "127.0.0.1:8545"', 'address = "0.0.0.0:8545"'),
-    ('ws-address = "127.0.0.1:8546"', 'ws-address = "0.0.0.0:8546"'),
-    ('address = "tcp://localhost:1317"', 'address = "tcp://0.0.0.0:1317"'),
+bind_all = os.environ.get("NIL_BIND_ALL", "0") == "1"
+replacements = [
     ('enabled-unsafe-cors = false', 'enabled-unsafe-cors = true'),
     ('evm-chain-id = 262144', 'evm-chain-id = 31337'),
-]:
+]
+if bind_all:
+    replacements = [
+        ('address = "127.0.0.1:8545"', 'address = "0.0.0.0:8545"'),
+        ('ws-address = "127.0.0.1:8546"', 'ws-address = "0.0.0.0:8546"'),
+        ('address = "tcp://localhost:1317"', 'address = "tcp://0.0.0.0:1317"'),
+        ('address = "tcp://127.0.0.1:1317"', 'address = "tcp://0.0.0.0:1317"'),
+    ] + replacements
+else:
+    replacements = [
+        ('address = "0.0.0.0:8545"', 'address = "127.0.0.1:8545"'),
+        ('ws-address = "0.0.0.0:8546"', 'ws-address = "127.0.0.1:8546"'),
+        ('address = "tcp://0.0.0.0:1317"', 'address = "tcp://127.0.0.1:1317"'),
+        ('address = "tcp://localhost:1317"', 'address = "tcp://127.0.0.1:1317"'),
+    ] + replacements
+for src, dst in replacements:
     txt = txt.replace(src, dst)
 path.write_text(txt)
 PY


### PR DESCRIPTION
PR21: Align bootstrap/local scripts with the hub safety posture by defaulting LCD + EVM JSON-RPC binds to localhost.

- Adds `NIL_BIND_ALL=1` opt-in to bind LCD/EVM JSON-RPC to `0.0.0.0` for LAN/non-proxy debugging.
- Updates `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` + the PR tracker.

Test gate:
- `bash -n scripts/run_devnet_alpha_multi_sp.sh`
- `bash -n scripts/run_local_stack.sh`
