### PR TITLE
Bootstrap: guard rm -rf of persistent home

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -363,5 +363,5 @@ Checklist:
   - `bash -n scripts/run_devnet_alpha_multi_sp.sh`
 
 Checklist:
-- [ ] Add `NIL_REINIT_HOME=1` (or similar) opt-in before deleting an existing `NIL_HOME` outside the repo `_artifacts/` tree.
-- [ ] Update `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` bootstrap command to include the new opt-in when using a persistent hub home.
+- [x] Add `NIL_REINIT_HOME=1` (or similar) opt-in before deleting an existing `NIL_HOME` outside the repo `_artifacts/` tree.
+- [x] Update `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` bootstrap command to include the new opt-in when using a persistent hub home.

--- a/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
+++ b/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
@@ -89,6 +89,12 @@ sudo chown -R "$USER":"$USER" /var/lib/nilstore
 NIL_HOME=/var/lib/nilstore/nilchaind PROVIDER_COUNT=0 START_WEB=0 ./scripts/run_devnet_alpha_multi_sp.sh start
 ```
 
+If you need to re-run bootstrap later, the script will refuse to delete an existing non-`_artifacts/` home unless you explicitly opt in:
+
+```bash
+NIL_HOME=/var/lib/nilstore/nilchaind NIL_REINIT_HOME=1 PROVIDER_COUNT=0 START_WEB=0 ./scripts/run_devnet_alpha_multi_sp.sh start
+```
+
 Note: the bootstrap script binds LCD + EVM JSON-RPC to localhost by default (safe for the hub-behind-Caddy profile).
 If you intentionally want to bind them to `0.0.0.0` for LAN / non-proxy debugging, set `NIL_BIND_ALL=1` and firewall accordingly.
 
@@ -102,7 +108,7 @@ Stop the script-managed processes:
 PROVIDER_COUNT=0 START_WEB=0 ./scripts/run_devnet_alpha_multi_sp.sh stop
 ```
 
-Important: `run_devnet_alpha_multi_sp.sh start` **re-initializes** its chain home on every start. Use it only for bootstrap and local smoke tests.
+Important: `run_devnet_alpha_multi_sp.sh start` **wipes/re-initializes** its chain home when the home is under `_artifacts/` (default) or when `NIL_REINIT_HOME=1` is set. Use it only for bootstrap and local smoke tests.
 
 ### 3) systemd (hub services)
 
@@ -269,7 +275,7 @@ PROVIDER_COUNT=0 START_WEB=0 ./scripts/run_devnet_alpha_multi_sp.sh start
 PROVIDER_COUNT=0 START_WEB=0 ./scripts/run_devnet_alpha_multi_sp.sh stop
 ```
 
-Important: `run_devnet_alpha_multi_sp.sh start` **re-initializes** its chain home on every start. Do not use it as a long-running “service manager” for the soft launch.
+Important: `run_devnet_alpha_multi_sp.sh start` **wipes/re-initializes** its chain home when the home is under `_artifacts/` (default) or when `NIL_REINIT_HOME=1` is set. Do not use it as a long-running “service manager” for the soft launch.
 
 ## Hub: long-running (systemd templates)
 

--- a/scripts/run_devnet_alpha_multi_sp.sh
+++ b/scripts/run_devnet_alpha_multi_sp.sh
@@ -30,6 +30,7 @@ EVM_RPC_PORT="${EVM_RPC_PORT:-8545}"
 GAS_PRICE="${NIL_GAS_PRICES:-0.001aatom}"
 DENOM="${NIL_DENOM:-stake}"
 NIL_BIND_ALL="${NIL_BIND_ALL:-0}" # set to 1 to bind LCD/EVM JSON-RPC to 0.0.0.0
+NIL_REINIT_HOME="${NIL_REINIT_HOME:-0}" # set to 1 to allow wiping an existing CHAIN_HOME outside _artifacts/
 
 NILCHAIND_BIN="$ROOT_DIR/nilchain/nilchaind"
 NIL_CLI_BIN="$ROOT_DIR/nil_cli/target/release/nil_cli"
@@ -53,6 +54,94 @@ FAUCET_MNEMONIC="${FAUCET_MNEMONIC:-course what neglect valley visual ride commo
 mkdir -p "$LOG_DIR" "$PID_DIR"
 
 banner() { printf '\n=== %s ===\n' "$*"; }
+
+chain_home_is_under_artifacts() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required for this script (missing python3 in PATH)" >&2
+    exit 1
+  fi
+
+  python3 - "$CHAIN_HOME" "$ROOT_DIR/_artifacts" <<'PY'
+import os
+import sys
+
+home = os.path.realpath(sys.argv[1])
+artifacts = os.path.realpath(sys.argv[2])
+try:
+    common = os.path.commonpath([home, artifacts])
+except ValueError:
+    common = ""
+sys.exit(0 if common == artifacts else 1)
+PY
+}
+
+wipe_chain_home_if_safe() {
+  if [ -z "$CHAIN_HOME" ]; then
+    echo "Refusing to wipe: CHAIN_HOME is empty" >&2
+    exit 1
+  fi
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required for this script (missing python3 in PATH)" >&2
+    exit 1
+  fi
+
+  if [ ! -e "$CHAIN_HOME" ]; then
+    return 0
+  fi
+
+  if [ ! -d "$CHAIN_HOME" ]; then
+    echo "Refusing to wipe: CHAIN_HOME exists but is not a directory: $CHAIN_HOME" >&2
+    exit 1
+  fi
+
+  local chain_home_real artifacts_real root_real
+  chain_home_real="$(python3 - "$CHAIN_HOME" <<'PY'
+import os, sys
+print(os.path.realpath(sys.argv[1]))
+PY
+)"
+  artifacts_real="$(python3 - "$ROOT_DIR/_artifacts" <<'PY'
+import os, sys
+print(os.path.realpath(sys.argv[1]))
+PY
+)"
+  root_real="$(python3 - "$ROOT_DIR" <<'PY'
+import os, sys
+print(os.path.realpath(sys.argv[1]))
+PY
+)"
+
+  if [ "$chain_home_real" = "/" ] || [ -z "$chain_home_real" ]; then
+    echo "Refusing to wipe: CHAIN_HOME resolved to an unsafe path: '$chain_home_real'" >&2
+    exit 1
+  fi
+  if [ "$chain_home_real" = "$root_real" ] || [ "$chain_home_real" = "$artifacts_real" ]; then
+    echo "Refusing to wipe: CHAIN_HOME resolved to a protected path: $chain_home_real" >&2
+    exit 1
+  fi
+
+  if chain_home_is_under_artifacts; then
+    banner "Wiping chain home under _artifacts: $CHAIN_HOME"
+    rm -rf "$CHAIN_HOME"
+    return 0
+  fi
+
+  if [ "$NIL_REINIT_HOME" != "1" ]; then
+    cat >&2 <<EOF
+Refusing to delete existing CHAIN_HOME outside the repo _artifacts/ tree:
+  CHAIN_HOME=$CHAIN_HOME
+  (resolved: $chain_home_real)
+
+If you really intend to re-initialize this home, re-run with:
+  NIL_REINIT_HOME=1
+EOF
+    exit 1
+  fi
+
+  banner "Wiping non-_artifacts chain home (NIL_REINIT_HOME=1): $CHAIN_HOME"
+  rm -rf "$CHAIN_HOME"
+}
 
 ensure_nil_core() {
   local lib_dir="$ROOT_DIR/nil_core/target/release"
@@ -405,7 +494,7 @@ gen_provider_key() {
 }
 
 init_chain() {
-  rm -rf "$CHAIN_HOME"
+  wipe_chain_home_if_safe
   banner "Initializing chain at $CHAIN_HOME"
   "$NILCHAIND_BIN" init devnet-alpha --chain-id "$CHAIN_ID" --home "$CHAIN_HOME"
 


### PR DESCRIPTION
- Adds `NIL_REINIT_HOME=1` opt-in before wiping an existing `NIL_HOME`/`CHAIN_HOME` outside `_artifacts/`.
- Adds extra path safety checks to avoid accidental destructive deletes.
- Updates `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` with the rerun/opt-in command.

Test: `bash -n scripts/run_devnet_alpha_multi_sp.sh`