### PR TITLE
Docs: clarify local stack reset safety

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -391,6 +391,6 @@ Checklist:
   - `bash -n scripts/run_local_stack.sh`
 
 Checklist:
-- [ ] Add a short “Reset state” note to `HAPPY_PATH.md` (default `_artifacts` is safe; persistent `NIL_HOME` requires `NIL_REINIT_HOME=1`).
-- [ ] Update `docs/TESTNET_READINESS_REPORT.md` to mention `NIL_REINIT_HOME` and bump the report date.
-- [ ] Update `docs/manual-devnet-runbook.md` prerequisites to mention safe reset behavior (and how to opt into wiping a persistent home).
+- [x] Add a short “Reset state” note to `HAPPY_PATH.md` (default `_artifacts` is safe; persistent `NIL_HOME` requires `NIL_REINIT_HOME=1`).
+- [x] Update `docs/TESTNET_READINESS_REPORT.md` to mention `NIL_REINIT_HOME` and bump the report date.
+- [x] Update `docs/manual-devnet-runbook.md` prerequisites to mention safe reset behavior (and how to opt into wiping a persistent home).

--- a/HAPPY_PATH.md
+++ b/HAPPY_PATH.md
@@ -59,6 +59,14 @@ Stop the stack:
 scripts/run_local_stack.sh stop
 ```
 
+## Resetting local state (safe re-init)
+
+`scripts/run_local_stack.sh start` **always re-initializes** the chain home.
+
+- Default behavior (safe): if you do **not** set `NIL_HOME`, the script uses `_artifacts/nilchain_data` and will wipe/re-init that directory on each `start`.
+- Persistent home safety: if you set `NIL_HOME` to a path **outside** `_artifacts/`, the script will **refuse** to wipe it unless you explicitly opt in with `NIL_REINIT_HOME=1`.
+  - Example: `NIL_HOME=/var/lib/nilstore/local NIL_REINIT_HOME=1 scripts/run_local_stack.sh start`
+
 ## Common “why did fetch fail?”
 
 - `missing X-Nil-Session-Id`: sessions are **required by default** on byte-serving

--- a/docs/TESTNET_READINESS_REPORT.md
+++ b/docs/TESTNET_READINESS_REPORT.md
@@ -1,6 +1,6 @@
 # NilStore Testnet Readiness Report
 
-Date: 2026-02-04
+Date: 2026-02-05
 
 This report is the Phase 8 deliverable from `docs/AGENTS_AUTONOMOUS_RUNBOOK.md`.
 
@@ -11,6 +11,10 @@ Start the full local stack (chain + faucet + gateways + optional web UI):
 ```bash
 ./scripts/run_local_stack.sh start
 ```
+
+Notes:
+- `run_local_stack.sh start` **always re-initializes** the chain home.
+- Default home is `_artifacts/nilchain_data`. If you set `NIL_HOME` outside `_artifacts/`, the script will refuse to wipe it unless you set `NIL_REINIT_HOME=1`.
 
 Stop everything started by the script:
 

--- a/docs/manual-devnet-runbook.md
+++ b/docs/manual-devnet-runbook.md
@@ -9,6 +9,10 @@ This document translates the guarded end-to-end scripts into a human‑operable 
    ```bash
    ./scripts/run_local_stack.sh start
    ```
+   Notes:
+   - `run_local_stack.sh start` **always re-initializes** the chain home.
+   - Default home is `_artifacts/nilchain_data`. If you set `NIL_HOME` outside `_artifacts/`, the script will refuse to wipe it unless you set `NIL_REINIT_HOME=1`.
+     - Example: `NIL_HOME=/var/lib/nilstore/local NIL_REINIT_HOME=1 ./scripts/run_local_stack.sh start`
    This launches CometBFT + EVM chain, faucet, router, and SP gateways configured for multi‑SP scenarios.
 3. Confirm health endpoints are returning 200 (LCD `/cosmos/base/tendermint/v1beta1/node_info`, gateway `/gateway/create-deal-evm`), as done by `scripts/e2e_lifecycle.sh`.
 


### PR DESCRIPTION
 - Document that `scripts/run_local_stack.sh start` re-initializes the chain home
- Explain default `_artifacts/nilchain_data` behavior and `NIL_REINIT_HOME=1` opt-in for persistent `NIL_HOME`
- Update `HAPPY_PATH.md`, `docs/TESTNET_READINESS_REPORT.md`, and `docs/manual-devnet-runbook.md`