### PR TITLE
Docs: tighten CI truth in gap report

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -397,14 +397,28 @@ Checklist:
 
 ---
 
-### PR25 — Repo-anchored agent runbook refresh (CI truth + devnet tracker links) (CURRENT)
+### PR25 — Repo-anchored agent runbook refresh (CI truth + devnet tracker links) (MERGED)
 
 - Branch: `codex/agents-runbook-refresh`
 - Goal: Make the repo-anchored agent runbook match current CI reality and link to the trusted devnet tracker/docs.
-- PR: (pending)
+- PR: https://github.com/Nil-Store/nil-store/pull/87
 - Test gate:
   - `bash -n scripts/run_local_stack.sh`
 
 Checklist:
 - [x] Mark PR24 as MERGED (this PR is the follow-up).
 - [x] Refresh `docs/AGENTS_RUNBOOK_REPO_ANCHORED.md` (Feb 2026 reality: CI jobs, test gates, and doc index pointers).
+
+---
+
+### PR26 — Gap report CI truth + docs index pointer (CURRENT)
+
+- Branch: `codex/gap-report-ci-truth`
+- Goal: Make it explicit what CI jobs prove (and don’t) and make the doc index point to the repo-anchored agent runbook.
+- PR: (pending)
+- Test gate:
+  - `bash -n install.sh`
+
+Checklist:
+- [x] Update `docs/GAP_REPORT_REPO_ANCHORED.md` CI section to match `.github/workflows/ci.yml` (Foundry, parity, Tauri, and E2E suites).
+- [x] Update `DOCS.md` to include `docs/AGENTS_RUNBOOK_REPO_ANCHORED.md` in the Agent Runbooks section.

--- a/DOCS.md
+++ b/DOCS.md
@@ -51,6 +51,7 @@ This repo contains a mix of **normative protocol spec**, **RFC drafts**, **imple
 ## Agent Runbooks
 
 - `docs/AGENTS_AUTONOMOUS_RUNBOOK.md`: Autonomous phase plan for repo anchoring, deal lifecycle, retrieval policies, protocol hooks, and compression.
+- `docs/AGENTS_RUNBOOK_REPO_ANCHORED.md`: Repo-specific index of where things live + what CI actually runs.
 - `docs/GAP_REPORT_REPO_ANCHORED.md`: Requirement → implementation gap matrix (repo-anchored).
 - `docs/TESTNET_READINESS_REPORT.md`: Phase 8 testnet readiness gates + one-command local stack and e2e.
 

--- a/docs/GAP_REPORT_REPO_ANCHORED.md
+++ b/docs/GAP_REPORT_REPO_ANCHORED.md
@@ -16,17 +16,26 @@ Legend:
 
 ## CI: what is actually exercised (today)
 
+The authoritative CI definition is `.github/workflows/ci.yml` (plus `e2e_playwright.yml` for a standalone Playwright run).
+
 - Unit tests
-  - Chain: `cd nilchain && go test ./...`
-  - Gateway: `go test ./nil_gateway/...`
+  - Go:
+    - Chain: `cd nilchain && go test ./...`
+    - Gateway: `cd nil_gateway && go test ./...`
+    - Faucet: `cd nil_faucet && go test ./...`
+    - Relayer: `cd nil_relayer && go test ./...`
   - Rust: `cargo test` in `nil_core`, `nil_cli`, `nil_p2p`, `nil_mock_l1`
-  - Web: `nil-website` build + unit tests + lint
-- E2E scripts (run in CI)
-  - Lifecycle: `scripts/e2e_lifecycle.sh` (+ `scripts/e2e_lifecycle_no_gateway.sh`) — uses **gateway tx relay** for deterministic runs.
+  - Web: `npm -C nil-website run build` + `npm -C nil-website run test:unit` + `npm -C nil-website run lint`
+  - Tauri GUI: `npm -C nil_gateway_gui test` + `cd nil_gateway_gui/src-tauri && cargo test` (plus fmt/clippy checks)
+  - Solidity contracts: `cd nil_bridge && forge test -vv`
+- Cross-target parity
+  - Native/WASM parity: CI builds `nil_core` with `wasm-pack` and runs `tools/parity/compare_parity.ts`.
+- E2E scripts (run in CI; single-machine)
+  - Lifecycle: `scripts/e2e_lifecycle.sh` (+ `scripts/e2e_lifecycle_no_gateway.sh`) — dev-convenient; uses faucet + **gateway tx relay** for deterministic runs.
   - Retrieval fees: `e2e_retrieval_fees.sh`
   - Retrieval sessions (CLI): `e2e_open_retrieval_session_cli.sh`, `e2e_open_retrieval_session_mode2_cli.sh`
   - Multi-SP regression: `scripts/ci_e2e_gateway_retrieval_multi_sp.sh`
-- Browser E2E (Playwright; wallet-first via in-page E2E wallet)
+- Browser E2E (Playwright; wallet-first via in-page E2E wallet; single-machine)
   - `scripts/e2e_browser_smoke_no_gateway.sh`
   - `scripts/e2e_browser_libp2p_relay.sh`
   - `scripts/e2e_mode2_stripe_multi_sp.sh`


### PR DESCRIPTION
Update repo docs so it is explicit what CI actually runs.

- `docs/GAP_REPORT_REPO_ANCHORED.md`: expand CI coverage list to match `.github/workflows/ci.yml` (Foundry, parity, Tauri, E2E)
- `DOCS.md`: link `docs/AGENTS_RUNBOOK_REPO_ANCHORED.md`
- `AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md`: mark PR25 merged; add PR26 section

Test gate:
- `bash -n install.sh`