### PR TITLE
Docs: add trusted devnet collaborator packet

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -425,13 +425,27 @@ Checklist:
 
 ---
 
-### PR27 — Trusted devnet go/no-go checklist (CURRENT)
+### PR27 — Trusted devnet go/no-go checklist (MERGED)
 
 - Branch: `codex/devnet-go-no-go-checklist`
 - Goal: Add a crisp, operator-focused checklist for when we’re ready to invite collaborators (and what to verify first).
-- PR: (pending)
+- PR: https://github.com/Nil-Store/nil-store/pull/89
 - Test gate:
   - `bash -n scripts/run_devnet_alpha_multi_sp.sh`
 
 Checklist:
 - [x] Add a “Go/No-Go checklist” section to `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` (hub + provider + website + smoke).
+
+---
+
+### PR28 — Trusted devnet collaborator packet (invite + quickstart) (CURRENT)
+
+- Branch: `codex/devnet-collaborator-packet`
+- Goal: Give hub operators a single “send this to collaborators” doc covering website testing + (optional) SP joining.
+- PR: (pending)
+- Test gate:
+  - `bash -n scripts/run_devnet_alpha_multi_sp.sh`
+
+Checklist:
+- [x] Add `docs/TRUSTED_DEVNET_COLLABORATOR_PACKET.md` (website tester path + SP operator path).
+- [x] Link it from `DOCS.md` (Implementation Onboarding section).

--- a/DOCS.md
+++ b/DOCS.md
@@ -45,6 +45,7 @@ This repo contains a mix of **normative protocol spec**, **RFC drafts**, **imple
 - `HAPPY_PATH.md`: Local devnet “happy path” runbook.
 - `DEVNET_MULTI_PROVIDER.md`: How to run a multi-provider devnet and join as a remote provider.
 - `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md`: Trusted collaborator devnet soft launch pack (hub + remote providers).
+- `docs/TRUSTED_DEVNET_COLLABORATOR_PACKET.md`: “Send this to collaborators” quickstart (website testing + optional SP join).
 - `docs/REMOTE_SP_JOIN_QUICKSTART.md`: Remote provider join quickstart (fast path).
 - `docs/TRUSTED_DEVNET_MONITORING_CHECKLIST.md`: Minimal monitoring checklist for the soft launch.
 

--- a/docs/TRUSTED_DEVNET_COLLABORATOR_PACKET.md
+++ b/docs/TRUSTED_DEVNET_COLLABORATOR_PACKET.md
@@ -1,0 +1,159 @@
+# Trusted Devnet Collaborator Packet (Feb 2026)
+
+This is the “send this to collaborators” doc for the **trusted devnet soft launch**.
+
+Audience:
+- **Website testers** (no server required)
+- **Storage Provider (SP) operators** (optional; run `nil_gateway` in provider mode)
+
+If you are the hub operator, also read: `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md`.
+
+---
+
+## What you need from the hub operator
+
+You should receive:
+- Website URL: `https://web.<domain>`
+- EVM RPC: `https://evm.<domain>`
+- Chain ID: `<chain-id>` (e.g. `31337`)
+- Faucet URL (optional): `https://faucet.<domain>/faucet`
+- Faucet auth token (optional): a secret string you paste into the website UI (do **not** share publicly)
+- Gateway URL (optional; for diagnostics): `https://gateway.<domain>`
+
+If you are running an SP, you also need:
+- Hub RPC: `https://rpc.<domain>`
+- Hub LCD: `https://lcd.<domain>`
+- Router↔provider shared secret: `NIL_GATEWAY_SP_AUTH=...` (treat like a password)
+
+---
+
+## Path A — Website tester (no server)
+
+Goal: run the end-to-end flow **create deal → upload → commit → retrieve** from the website using MetaMask.
+
+### 1) Open the website + connect wallet
+
+1. Open `https://web.<domain>`.
+2. Click **Connect wallet** (MetaMask).
+3. If prompted, add/switch to the NilStore devnet network using the RPC the hub operator gave you.
+
+If you need to add the network manually:
+- Network name: `NilStore Devnet`
+- RPC URL: `https://evm.<domain>`
+- Chain ID: `<chain-id>`
+- Currency symbol: `ATOM` (gas denom is `aatom` in the current devnet profile)
+
+### 2) Get test funds
+
+If the faucet UI is enabled on the website:
+1. Paste the faucet auth token (if provided).
+2. Click **Fund** (or equivalent).
+
+If the faucet UI is not enabled, ask the hub operator to fund your address.
+
+### 3) Store your first file
+
+1. Create a deal (capacity container).
+2. Upload a small file (start with ~10–100 KiB).
+3. Commit the content (this updates the on-chain `manifest_root`).
+4. Retrieve the file back and confirm it matches what you uploaded.
+
+Tip: if you test with a text file, change a line and re-upload to confirm the commit changes the retrieval.
+
+---
+
+## Path B — Storage Provider (SP) operator (optional)
+
+Goal: register a provider on-chain and run a provider gateway so the hub router can place data on you.
+
+This packet is intentionally short; the canonical SP join docs are:
+- Fast path: `docs/REMOTE_SP_JOIN_QUICKSTART.md`
+- Full guide: `DEVNET_MULTI_PROVIDER.md`
+- Endpoint formats: `docs/networking/PROVIDER_ENDPOINTS.md`
+
+### 0) Prereqs
+
+- A Linux host with a **publicly reachable** TCP port (recommended: `8091/tcp`)
+- Go + Rust toolchains installed
+- This repo checked out
+
+### 1) Initialize your provider key
+
+```bash
+PROVIDER_KEY=provider1 ./scripts/run_devnet_provider.sh init
+```
+
+Save the printed provider address (`nil1...`).
+
+### 2) Get gas funds
+
+Ask the hub operator to fund your provider address with a small amount of `aatom` for gas.
+
+### 3) Choose your provider endpoint multiaddr
+
+Example (HTTP, public IP + port):
+
+```bash
+export PROVIDER_ENDPOINT="/ip4/<your-public-ip>/tcp/8091/http"
+```
+
+### 4) Register on-chain (uses the hub RPC/LCD)
+
+```bash
+export HUB_NODE="https://rpc.<domain>"
+export HUB_LCD="https://lcd.<domain>"
+export CHAIN_ID="<chain-id>"
+export PROVIDER_KEY="provider1"
+
+./scripts/run_devnet_provider.sh register
+```
+
+### 5) Start your provider gateway
+
+```bash
+export NIL_GATEWAY_SP_AUTH="<shared-from-hub>"
+export NIL_LCD_BASE="$HUB_LCD"
+export NIL_NODE="$HUB_NODE"
+export NIL_CHAIN_ID="$CHAIN_ID"
+export PROVIDER_KEY="provider1"
+export PROVIDER_LISTEN=":8091"
+
+./scripts/run_devnet_provider.sh start
+```
+
+Verify locally:
+
+```bash
+curl -sf http://127.0.0.1:8091/health
+```
+
+Recommended verification:
+
+```bash
+scripts/devnet_healthcheck.sh provider \
+  --provider http://127.0.0.1:8091 \
+  --hub-lcd "$HUB_LCD" \
+  --provider-addr <nil1...>
+```
+
+### 6) Tell the hub operator
+
+Send:
+- your provider address (`nil1...`)
+- your registered endpoint (`/ip4/.../tcp/.../http`)
+
+---
+
+## What to report when something breaks
+
+Please capture:
+- What path you were following (A: website tester, B: provider operator)
+- Deal ID (if visible) and the action that failed (create / upload / commit / retrieve)
+- For retrieval failures:
+  - request headers you used (notably `X-Nil-Session-Id`, if you were using curl)
+  - hub response header `X-Nil-Provider` (who served the bytes)
+  - the hub `gateway.*` URL and timestamp
+- A screenshot + browser console log (website), or command output (CLI)
+
+If you can reproduce reliably, that’s gold: include “steps to reproduce” from a fresh page load or fresh process start.
+


### PR DESCRIPTION
Adds a collaborator-facing packet for the Feb 2026 trusted devnet soft launch (website tester path + optional SP operator path).

Also updates the trusted devnet tracker and links the new doc from DOCS.md.

Test gate:
- bash -n scripts/run_devnet_alpha_multi_sp.sh