### PR TITLE
Docs: clarify agent trackers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 *   **Commit Regularly:** Always commit your work frequently, in small, logical chunks.
 *   **Prohibited Commands:** Agents are strictly forbidden from running aggressive Git commands like `git clean` or `git reset --hard` as these can lead to irreversible data loss of uncommitted work. If such commands are necessary, confirm with the user first.
 *   **Tests Before Push:** For every non-trivial change, run the most relevant unit/e2e tests before committing. Do not push code that you haven't at least smoke-tested locally.
-*   **Commit & Push Cadence:** Treat this file as the canonical TODO list. As you complete tasks, update the checklist, commit your work with a descriptive message, and push to both remotes (`origin` and `nil-store`) in small, verified increments.
+*   **Commit & Push Cadence:** Treat `AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md` as the canonical PR-by-PR TODO list for the Feb 2026 trusted devnet soft launch. Keep this file high-level and link out to repo-tracked TODOs/checklists instead of using this as a sprint tracker.
 *   **Default Autonomy:** Unless the user explicitly says “don’t commit/push yet,” agents should **automatically** commit completed work (after relevant tests pass) and push to both remotes. Keep commits small and descriptive, and avoid batching unrelated changes.
 
 This document outlines a strategic "Go-to-Market" Engineering Roadmap for the NilStore Network, designed to iteratively validate, market, and refine the project from "Paperware" to "Software." It recognizes the need to align Technology, Community, and Economy.

--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -452,14 +452,28 @@ Checklist:
 
 ---
 
-### PR29 — Readiness report: trusted devnet links + CI limits (CURRENT)
+### PR29 — Readiness report: trusted devnet links + CI limits (MERGED)
 
 - Branch: `codex/readiness-report-devnet-links`
 - Goal: Make `docs/TESTNET_READINESS_REPORT.md` the crisp “are we ready?” entrypoint for the soft launch (with clear links + what CI doesn’t prove).
-- PR: (pending)
+- PR: https://github.com/Nil-Store/nil-store/pull/91
 - Test gate:
   - `bash -n scripts/run_local_stack.sh`
 
 Checklist:
 - [x] Add a “Trusted devnet soft launch” section linking to the go/no-go checklist + collaborator packet + monitoring docs.
 - [x] Add a short “CI does not prove” section (WAN/long-run/security), linking to `docs/GAP_REPORT_REPO_ANCHORED.md` for the full matrix.
+
+---
+
+### PR30 — Agent file hygiene: point to current trackers (CURRENT)
+
+- Branch: `codex/agent-files-hygiene`
+- Goal: Reduce confusion by making the root agent docs clearly point to the Feb 2026 trusted devnet tracker and repo-anchored runbooks.
+- PR: (pending)
+- Test gate:
+  - `bash -n install.sh`
+
+Checklist:
+- [x] Update `AGENTS.md` to treat `AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md` as the canonical trusted-devnet TODO list (and clarify this file is a roadmap).
+- [x] Update `docs/AGENTS_AUTONOMOUS_RUNBOOK.md` header to point to `docs/AGENTS_RUNBOOK_REPO_ANCHORED.md` + `docs/GAP_REPORT_REPO_ANCHORED.md` for current reality.

--- a/docs/AGENTS_AUTONOMOUS_RUNBOOK.md
+++ b/docs/AGENTS_AUTONOMOUS_RUNBOOK.md
@@ -7,6 +7,10 @@
 
 This runbook is intentionally verbose and operational. It is designed so an autonomous agent can execute it end-to-end without asking for clarifications.
 
+Note (Feb 2026): this repo now has a **repo-anchored** version of the key outputs:
+- `docs/AGENTS_RUNBOOK_REPO_ANCHORED.md` (where things live + what CI runs)
+- `docs/GAP_REPORT_REPO_ANCHORED.md` (spec ↔ code ↔ CI matrix)
+
 ---
 
 ## 0) Non‑negotiables (hard constraints)
@@ -480,4 +484,3 @@ The agent is done when:
 - CI is green,
 - documentation matches behavior,
 - and the testnet launch checklist can be executed by a human without tribal knowledge.
-


### PR DESCRIPTION
Clarifies that AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md is the canonical tracker for the Feb 2026 trusted devnet soft launch, and adds pointers to the repo-anchored runbook + gap report from the autonomous runbook.

Test gate:
- bash -n install.sh