### PR TITLE
CI: deflake gateway-absent upload test

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -509,11 +509,11 @@ Checklist:
 
 ---
 
-### PR33 — Dynamic pricing: E2E smoke for storage price update (CURRENT)
+### PR33 — Dynamic pricing: E2E smoke for storage price update (MERGED)
 
 - Branch: `codex/dynamic-pricing-storage-e2e`
 - Goal: Add a deterministic E2E smoke path to validate the storage dynamic pricing controller updates `storage_price` at the next epoch boundary (opt-in; does not change CI defaults).
-- PR: (create)
+- PR: https://github.com/Nil-Store/nil-store/pull/95
 - Test gate:
   - `bash -n e2e_retrieval_fees.sh`
   - `NIL_DYNAMIC_PRICING_E2E=1 ./e2e_retrieval_fees.sh`
@@ -522,3 +522,17 @@ Checklist:
 - [x] Extend `e2e_retrieval_fees.sh` dynamic mode to patch storage dynamic pricing params in genesis.
 - [x] Assert `storage_price` updates to `storage_price_max` at the next epoch boundary (alongside the existing retrieval assertion).
 - [x] Update `docs/GAP_REPORT_REPO_ANCHORED.md` dynamic pricing row to reflect the new smoke coverage.
+
+---
+
+### PR34 — CI: deflake Playwright “Gateway Absent” upload flow (CURRENT)
+
+- Branch: `codex/deflake-gateway-absent-ui`
+- Goal: Reduce flakes in `nil-website/tests/gateway-absent-ui.spec.ts` by ensuring the test reliably navigates back to the Mode 2 upload panel (and enables Advanced only if needed) before waiting on `mdu-file-input`.
+- PR: (create)
+- Test gate:
+  - `npm -C nil-website run test:unit`
+  - `scripts/e2e_browser_smoke_no_gateway.sh`
+
+Checklist:
+- [x] Update `nil-website/tests/gateway-absent-ui.spec.ts` to robustly reach the upload UI before selecting a file.

--- a/nil-website/tests/gateway-absent-ui.spec.ts
+++ b/nil-website/tests/gateway-absent-ui.spec.ts
@@ -7,87 +7,99 @@ test.describe('gateway absent', () => {
   test.skip(!hasLocalStack, 'requires local stack (gateway disabled)')
 
   test('gateway absent: dashboard upload falls back to direct SP', async ({ page }) => {
-  test.setTimeout(300_000)
+    test.setTimeout(300_000)
 
-  page.on('pageerror', (err) => {
-    console.log(`[pageerror] ${err.message}`)
-  })
-  page.on('console', (msg) => {
-    if (msg.type() === 'error') {
-      console.log(`[console:${msg.type()}] ${msg.text()}`)
-    }
-  })
-
-  await page.setViewportSize({ width: 1280, height: 720 })
-  await page.goto(dashboardPath, { waitUntil: 'networkidle' })
-
-  await page.waitForSelector('#root', { timeout: 60_000 })
-  await page.waitForSelector('[data-testid="connect-wallet"], [data-testid="wallet-address"], [data-testid="wallet-address-full"]', {
-    timeout: 60_000,
-    state: 'attached',
-  })
-  const walletAddress = page.locator('[data-testid="wallet-address"], [data-testid="wallet-address-full"]').first()
-  if (!(await walletAddress.isVisible().catch(() => false))) {
-    const connectButton = page.getByTestId('connect-wallet').first()
-    await connectButton.click({ force: true })
-    await page.evaluate(async () => {
-      const eth = (window as { ethereum?: { request?: (args: { method: string }) => Promise<unknown> } }).ethereum
-      if (!eth?.request) {
-        throw new Error('No injected wallet available for E2E')
-      }
-      await eth.request({ method: 'eth_requestAccounts' })
+    page.on('pageerror', (err) => {
+      console.log(`[pageerror] ${err.message}`)
     })
-    await expect(walletAddress).toBeVisible({ timeout: 60_000 })
-  }
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        console.log(`[console:${msg.type()}] ${msg.text()}`)
+      }
+    })
 
-  await page.getByTestId('faucet-request').click()
-  const stakeBalance = page.getByTestId('cosmos-stake-balance')
-  await expect(stakeBalance).not.toHaveText(/^(?:—|0 stake)$/, { timeout: 120_000 })
+    await page.setViewportSize({ width: 1280, height: 720 })
+    await page.goto(dashboardPath, { waitUntil: 'networkidle' })
 
-  const placementSelect = page.getByTestId('alloc-placement-profile')
-  if (!(await placementSelect.isVisible().catch(() => false))) {
-    await page.getByTestId('workspace-advanced-toggle').click()
-    await expect(placementSelect).toBeVisible({ timeout: 10_000 })
-  }
-  await placementSelect.selectOption('auto')
-  await page.getByTestId('alloc-submit').click()
-
-  await expect(page.getByTestId('workspace-deal-title')).toHaveText(/Deal #\d+/, { timeout: 120_000 })
-  const dealTitle = (await page.getByTestId('workspace-deal-title').textContent()) || ''
-  const dealId = dealTitle.match(/#(\d+)/)?.[1] || ''
-  expect(dealId).not.toBe('')
-
-  // Mode 2 upload uses the FileSharder (WASM sharding + direct SP fallback).
-  // The input is hidden; interact with it directly via test id.
-  const mode2FileInput = page.getByTestId('mdu-file-input')
-  if ((await mode2FileInput.count().catch(() => 0)) === 0) {
-    const toggle = page.getByTestId('tab-content')
-    if (await toggle.isVisible().catch(() => false)) {
-      await toggle.click()
+    await page.waitForSelector('#root', { timeout: 60_000 })
+    await page.waitForSelector(
+      '[data-testid="connect-wallet"], [data-testid="wallet-address"], [data-testid="wallet-address-full"]',
+      {
+        timeout: 60_000,
+        state: 'attached',
+      },
+    )
+    const walletAddress = page.locator('[data-testid="wallet-address"], [data-testid="wallet-address-full"]').first()
+    if (!(await walletAddress.isVisible().catch(() => false))) {
+      const connectButton = page.getByTestId('connect-wallet').first()
+      await connectButton.click({ force: true })
+      await page.evaluate(async () => {
+        const eth = (window as { ethereum?: { request?: (args: { method: string }) => Promise<unknown> } }).ethereum
+        if (!eth?.request) {
+          throw new Error('No injected wallet available for E2E')
+        }
+        await eth.request({ method: 'eth_requestAccounts' })
+      })
+      await expect(walletAddress).toBeVisible({ timeout: 60_000 })
     }
-  }
-  await expect(mode2FileInput).toHaveCount(1, { timeout: 120_000 })
-  await mode2FileInput.setInputFiles({
-    name: 'gateway-absent.txt',
-    mimeType: 'text/plain',
-    buffer: Buffer.from('gateway-absent-upload'),
-  })
 
-  const uploadBtn = page.getByTestId('mdu-upload')
-  await expect(uploadBtn).toBeVisible({ timeout: 180_000 })
-  await expect(uploadBtn).toBeEnabled({ timeout: 180_000 })
-  await uploadBtn.click()
+    await page.getByTestId('faucet-request').click()
+    const stakeBalance = page.getByTestId('cosmos-stake-balance')
+    await expect(stakeBalance).not.toHaveText(/^(?:—|0 stake)$/, { timeout: 120_000 })
 
-  const commitBtn = page.getByTestId('mdu-commit')
-  await expect(commitBtn).toBeVisible({ timeout: 180_000 })
-  await expect(commitBtn).toBeEnabled({ timeout: 180_000 })
-  await commitBtn.click()
+    const placementSelect = page.getByTestId('alloc-placement-profile')
+    if (!(await placementSelect.isVisible().catch(() => false))) {
+      await page.getByTestId('workspace-advanced-toggle').click()
+      await expect(placementSelect).toBeVisible({ timeout: 10_000 })
+    }
+    await placementSelect.selectOption('auto')
+    await page.getByTestId('alloc-submit').click()
 
-  await expect(page.locator('text=/^Tx: 0x/i').first()).toBeVisible({ timeout: 180_000 })
-  await expect(page.getByTestId(`deal-manifest-${dealId}`)).toContainText('0x', { timeout: 180_000 })
+    await expect(page.getByTestId('workspace-deal-title')).toHaveText(/Deal #\d+/, { timeout: 120_000 })
+    const dealTitle = (await page.getByTestId('workspace-deal-title').textContent()) || ''
+    const dealId = dealTitle.match(/#(\d+)/)?.[1] || ''
+    expect(dealId).not.toBe('')
 
-  const routeLabel = page.getByTestId('transport-route')
-  await expect(routeLabel).toBeVisible({ timeout: 120_000 })
-  await expect(routeLabel).toHaveText(/Route: direct sp/i, { timeout: 120_000 })
+    // Mode 2 upload uses the FileSharder (WASM sharding + direct SP fallback).
+    // The input is hidden; interact with it directly via test id.
+    const mode2FileInput = page.getByTestId('mdu-file-input')
+    if ((await mode2FileInput.count().catch(() => 0)) === 0) {
+      // If we're on the Legacy (Mode 1) panel, switch back to Upload.
+      // `tab-content` is gated behind Advanced, so enable it if needed.
+      const tabToggle = page.getByTestId('tab-content')
+      if ((await tabToggle.count().catch(() => 0)) === 0) {
+        const advancedToggle = page.getByTestId('workspace-advanced-toggle')
+        if ((await advancedToggle.count().catch(() => 0)) > 0) {
+          await advancedToggle.click({ force: true })
+          await expect(tabToggle).toBeAttached({ timeout: 10_000 })
+        }
+      }
+      if ((await tabToggle.count().catch(() => 0)) > 0) {
+        await tabToggle.click({ force: true })
+      }
+    }
+    await expect(mode2FileInput).toHaveCount(1, { timeout: 180_000 })
+    await mode2FileInput.setInputFiles({
+      name: 'gateway-absent.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('gateway-absent-upload'),
+    })
+
+    const uploadBtn = page.getByTestId('mdu-upload')
+    await expect(uploadBtn).toBeVisible({ timeout: 180_000 })
+    await expect(uploadBtn).toBeEnabled({ timeout: 180_000 })
+    await uploadBtn.click()
+
+    const commitBtn = page.getByTestId('mdu-commit')
+    await expect(commitBtn).toBeVisible({ timeout: 180_000 })
+    await expect(commitBtn).toBeEnabled({ timeout: 180_000 })
+    await commitBtn.click()
+
+    await expect(page.locator('text=/^Tx: 0x/i').first()).toBeVisible({ timeout: 180_000 })
+    await expect(page.getByTestId(`deal-manifest-${dealId}`)).toContainText('0x', { timeout: 180_000 })
+
+    const routeLabel = page.getByTestId('transport-route')
+    await expect(routeLabel).toBeVisible({ timeout: 120_000 })
+    await expect(routeLabel).toHaveText(/Route: direct sp/i, { timeout: 120_000 })
   })
 })


### PR DESCRIPTION
Deflakes the Playwright “Gateway Absent” flow by making the test explicitly navigate back to the Mode 2 upload panel before waiting for `mdu-file-input`.

Changes:
- `nil-website/tests/gateway-absent-ui.spec.ts`: enable Advanced only if needed, then click the tab toggle to return to Upload when the file input isn’t present.
- `AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md`: mark PR33 as merged (link PR #95) and add PR34.

Test:
- `npm -C nil-website run test:unit`
- `scripts/e2e_browser_smoke_no_gateway.sh`
