### PR TITLE
CI: align Go toolchain to go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22' # Using modern Go
+          go-version: '1.25.x' # Match `go.mod` (nilchain/nil_gateway/etc.)
           cache-dependency-path: ${{ matrix.service }}/go.sum
 
       - name: Set up Rust
@@ -228,7 +228,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.25.x'
           cache: true
           cache-dependency-path: |
             **/go.sum
@@ -312,7 +312,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.25.x'
           cache: true
           cache-dependency-path: |
             **/go.sum
@@ -390,7 +390,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.25.x'
           cache: true
           cache-dependency-path: |
             **/go.sum
@@ -468,7 +468,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.25.x'
           cache: true
           cache-dependency-path: |
             **/go.sum
@@ -543,7 +543,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.25.x'
           cache: true
           cache-dependency-path: |
             **/go.sum

--- a/.github/workflows/tauri_release.yml
+++ b/.github/workflows/tauri_release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.25.x'
 
       - name: Install Linux system deps
         if: runner.os == 'Linux'

--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -525,14 +525,28 @@ Checklist:
 
 ---
 
-### PR34 — CI: deflake Playwright “Gateway Absent” upload flow (CURRENT)
+### PR34 — CI: deflake Playwright “Gateway Absent” upload flow (MERGED)
 
 - Branch: `codex/deflake-gateway-absent-ui`
 - Goal: Reduce flakes in `nil-website/tests/gateway-absent-ui.spec.ts` by ensuring the test reliably navigates back to the Mode 2 upload panel (and enables Advanced only if needed) before waiting on `mdu-file-input`.
-- PR: (create)
+- PR: https://github.com/Nil-Store/nil-store/pull/96
 - Test gate:
   - `npm -C nil-website run test:unit`
   - `scripts/e2e_browser_smoke_no_gateway.sh`
 
 Checklist:
 - [x] Update `nil-website/tests/gateway-absent-ui.spec.ts` to robustly reach the upload UI before selecting a file.
+
+---
+
+### PR35 — CI: align Go toolchain with `go.mod` (1.25.x) (CURRENT)
+
+- Branch: `codex/ci-go-1-25x`
+- Goal: Reduce CI/toolchain drift by using Go `1.25.x` (matches `nilchain/go.mod`, `nil_gateway/go.mod`, etc.) instead of relying on toolchain auto-download from an older Go.
+- PR: (create)
+- Test gate:
+  - `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/ci.yml\"); YAML.load_file(\".github/workflows/tauri_release.yml\")'`
+
+Checklist:
+- [ ] Update `.github/workflows/ci.yml` `actions/setup-go` versions to `1.25.x`.
+- [ ] Update `.github/workflows/tauri_release.yml` `actions/setup-go` version to `1.25.x`.


### PR DESCRIPTION
Align GitHub Actions Go version with module go versions (nilchain/nil_gateway/nil_faucet/nil_relayer require Go 1.25.x).

- Updates actions/setup-go in CI + Tauri release workflow to use 1.25.x (avoids relying on toolchain auto-download).
- Updates AGENTS tracker: marks PR34 merged, adds PR35.