### PR TITLE
CI: refresh Rust toolchain + cache actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,7 @@ jobs:
 
       - name: Set up Rust
         if: matrix.service == 'nil_gateway' || matrix.service == 'nilchain'
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build nil_core
         if: matrix.service == 'nil_gateway' || matrix.service == 'nilchain'
@@ -64,14 +60,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -158,11 +150,8 @@ jobs:
             librsvg2-dev
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
           components: rustfmt, clippy
 
       - name: Cargo Format
@@ -185,12 +174,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -234,15 +220,12 @@ jobs:
             **/go.sum
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: wasm32-unknown-unknown # Required for wasm-pack build
+          targets: wasm32-unknown-unknown # Required for wasm-pack build
 
       - name: Cache Cargo (nil_core/nil_cli)
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -318,15 +301,12 @@ jobs:
             **/go.sum
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Cache Cargo (nil_core/nil_cli)
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -357,7 +337,7 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - name: Cache Playwright Browsers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('nil-website/package-lock.json') }}
@@ -396,15 +376,12 @@ jobs:
             **/go.sum
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Cache Cargo (nil_core/nil_cli)
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -435,7 +412,7 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - name: Cache Playwright Browsers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('nil-website/package-lock.json') }}
@@ -474,15 +451,12 @@ jobs:
             **/go.sum
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Cache Cargo (nil_core/nil_cli)
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -513,7 +487,7 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
       - name: Cache Playwright Browsers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('nil-website/package-lock.json') }}
@@ -549,15 +523,12 @@ jobs:
             **/go.sum
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Cache Cargo (nil_core/nil_cli)
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/e2e_playwright.yml
+++ b/.github/workflows/e2e_playwright.yml
@@ -13,12 +13,9 @@ jobs:
           submodules: recursive
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -539,14 +539,28 @@ Checklist:
 
 ---
 
-### PR35 — CI: align Go toolchain with `go.mod` (1.25.x) (CURRENT)
+### PR35 — CI: align Go toolchain with `go.mod` (1.25.x) (MERGED)
 
 - Branch: `codex/ci-go-1-25x`
 - Goal: Reduce CI/toolchain drift by using Go `1.25.x` (matches `nilchain/go.mod`, `nil_gateway/go.mod`, etc.) instead of relying on toolchain auto-download from an older Go.
-- PR: (create)
+- PR: https://github.com/Nil-Store/nil-store/pull/97
 - Test gate:
   - `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/ci.yml\"); YAML.load_file(\".github/workflows/tauri_release.yml\")'`
 
 Checklist:
-- [ ] Update `.github/workflows/ci.yml` `actions/setup-go` versions to `1.25.x`.
-- [ ] Update `.github/workflows/tauri_release.yml` `actions/setup-go` version to `1.25.x`.
+- [x] Update `.github/workflows/ci.yml` `actions/setup-go` versions to `1.25.x`.
+- [x] Update `.github/workflows/tauri_release.yml` `actions/setup-go` version to `1.25.x`.
+
+---
+
+### PR36 — CI hygiene: remove `set-output` deprecation warnings (Rust + cache actions) (CURRENT)
+
+- Branch: `codex/ci-rust-action-update`
+- Goal: Reduce CI noise and future breakage risk by removing GitHub Actions `set-output` deprecation warnings (update Rust toolchain + cache actions).
+- PR: (create)
+- Test gate:
+  - `ruby -e 'require \"yaml\"; %w[.github/workflows/ci.yml .github/workflows/e2e_playwright.yml .github/workflows/tauri_release.yml].each { |p| YAML.load_file(p) }'`
+
+Checklist:
+- [ ] Replace `actions-rs/toolchain@v1` with a maintained Rust toolchain action in CI workflows.
+- [ ] Bump `actions/cache@v3` → `actions/cache@v4` in CI workflows.


### PR DESCRIPTION
Modernize CI workflows to reduce set-output deprecation warnings and future breakage risk.

- Replace actions-rs/toolchain with dtolnay/rust-toolchain.
- Bump actions/cache to v4.
- Update AGENTS tracker: mark PR35 merged, add PR36.