### PR TITLE
Tracker: mark PR38 as merged (#100)

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -583,11 +583,11 @@ Checklist:
 
 ---
 
-### PR38 — Docs: sync manual devnet runbook with current scripts (CURRENT)
+### PR38 — Docs: sync manual devnet runbook with current scripts (MERGED)
 
 - Branch: `codex/manual-runbook-sync`
 - Goal: Keep `docs/manual-devnet-runbook.md` aligned with the guarded E2E scripts and current “relay-off by default” posture (make the profiles explicit).
-- PR: (create)
+- PR: https://github.com/Nil-Store/nil-store/pull/100
 - Test gate:
   - `bash -n scripts/run_local_stack.sh`
   - `bash -n scripts/e2e_lifecycle.sh`


### PR DESCRIPTION
## Summary
- mark PR38 in AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md as MERGED
- add the merged PR link (#100) for that section

## Why
- keeps the canonical trusted-devnet tracker in sync with repo/GitHub state
