### PR TITLE
Docs: add NAT/Cloudflare Tunnel setup for trusted devnet

### DIFF
--- a/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
+++ b/AGENTS_TRUSTED_DEVNET_SOFT_LAUNCH_TODO.md
@@ -597,3 +597,19 @@ Checklist:
 - [x] Update `docs/manual-devnet-runbook.md` to clearly separate “script parity (tx relay)” vs “wallet-first (no relay)” flows.
 - [x] Fix any stale endpoint/script references (use `scripts/devnet_healthcheck.sh` and `/health` where appropriate).
 - [x] Ensure `docs/TESTNET_READINESS_REPORT.md` references remain accurate (update wording only if needed).
+
+---
+
+### PR39 — Docs: NAT-friendly hub/SP setup via Cloudflare Tunnel (CURRENT)
+
+- Branch: `codex/cloudflare-nat-devnet-docs`
+- Goal: Make trusted-devnet setup clear for home servers behind NAT by adding a first-class Cloudflare Tunnel profile for hub ingress and provider endpoints.
+- PR: (create)
+- Test gate:
+  - `bash -n scripts/run_devnet_alpha_multi_sp.sh`
+  - `bash -n scripts/run_devnet_provider.sh`
+
+Checklist:
+- [x] Add a Cloudflare Tunnel profile to `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md` for hub endpoints (`rpc/lcd/evm/gateway/faucet/web`) when inbound `80/443` is unavailable.
+- [x] Update provider onboarding docs (`docs/TRUSTED_DEVNET_COLLABORATOR_PACKET.md`, `docs/REMOTE_SP_JOIN_QUICKSTART.md`) with direct vs tunnel endpoint examples.
+- [x] Improve docs discoverability (`README.md`, `DOCS.md`) by linking `docs/networking/PROVIDER_ENDPOINTS.md`.

--- a/DOCS.md
+++ b/DOCS.md
@@ -47,6 +47,7 @@ This repo contains a mix of **normative protocol spec**, **RFC drafts**, **imple
 - `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md`: Trusted collaborator devnet soft launch pack (hub + remote providers).
 - `docs/TRUSTED_DEVNET_COLLABORATOR_PACKET.md`: “Send this to collaborators” quickstart (website testing + optional SP join).
 - `docs/REMOTE_SP_JOIN_QUICKSTART.md`: Remote provider join quickstart (fast path).
+- `docs/networking/PROVIDER_ENDPOINTS.md`: Provider endpoint profiles (`direct` and `cloudflare-tunnel`).
 - `docs/TRUSTED_DEVNET_MONITORING_CHECKLIST.md`: Minimal monitoring checklist for the soft launch.
 
 ## Agent Runbooks

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repo is currently geared toward a **trusted devnet soft launch (Feb 2026)**
 - Testnet readiness gates + one-command suites: `docs/TESTNET_READINESS_REPORT.md`
 - Trusted devnet pack (hub + remote providers): `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md`
 - Collaborator packet (“send this to testers”): `docs/TRUSTED_DEVNET_COLLABORATOR_PACKET.md`
+- Provider endpoint profiles (`direct` vs `cloudflare-tunnel`): `docs/networking/PROVIDER_ENDPOINTS.md`
 
 ## Quick start (local, what CI exercises)
 

--- a/docs/REMOTE_SP_JOIN_QUICKSTART.md
+++ b/docs/REMOTE_SP_JOIN_QUICKSTART.md
@@ -15,7 +15,7 @@ If you want the full guide, see `DEVNET_MULTI_PROVIDER.md`.
 
 - This repo checked out
 - Go + Rust toolchains installed
-- A public reachable provider endpoint (recommended: inbound TCP port + HTTP; HTTPS is optional for this soft launch)
+- A reachable provider endpoint (either direct public IP/port-forward, or Cloudflare Tunnel HTTPS)
 - (Optional, recommended) systemd + a reverse proxy:
   - systemd templates: `ops/systemd/nil-gateway-provider.service` + `ops/systemd/env/nil-gateway-provider.env`
   - HTTPS reverse proxy example: `ops/caddy/Caddyfile.provider.example`
@@ -36,7 +36,7 @@ Ask the hub operator to send you some `aatom` (gas) via the faucet or a direct b
 
 ### 3) Pick an endpoint multiaddr
 
-For the simplest join, register an IP+port endpoint:
+Option A (direct/public endpoint): register an IP+port endpoint:
 
 - `/ip4/<your-public-ip>/tcp/8091/http`
 
@@ -46,7 +46,18 @@ Set it:
 export PROVIDER_ENDPOINT="/ip4/<your-public-ip>/tcp/8091/http"
 ```
 
-If you need HTTPS/DNS-based endpoints, see `docs/networking/PROVIDER_ENDPOINTS.md`.
+Option B (behind NAT with Cloudflare Tunnel): register DNS+HTTPS endpoint:
+
+- `/dns4/sp.<domain>/tcp/443/https`
+
+```bash
+export PROVIDER_ENDPOINT="/dns4/sp.<domain>/tcp/443/https"
+```
+
+In your tunnel ingress, route that hostname to the local provider listener (for example `service: http://localhost:8091`).
+
+Cloudflare Tunnel setup and endpoint helper details:
+- `docs/networking/PROVIDER_ENDPOINTS.md`
 
 ### 4) Register your provider on-chain
 

--- a/docs/TRUSTED_DEVNET_COLLABORATOR_PACKET.md
+++ b/docs/TRUSTED_DEVNET_COLLABORATOR_PACKET.md
@@ -73,7 +73,7 @@ This packet is intentionally short; the canonical SP join docs are:
 
 ### 0) Prereqs
 
-- A Linux host with a **publicly reachable** TCP port (recommended: `8091/tcp`)
+- A Linux host (publicly reachable **or** behind NAT via Cloudflare Tunnel)
 - Go + Rust toolchains installed
 - This repo checked out
 
@@ -91,11 +91,22 @@ Ask the hub operator to fund your provider address with a small amount of `aatom
 
 ### 3) Choose your provider endpoint multiaddr
 
-Example (HTTP, public IP + port):
+Option A (direct HTTP, public IP + port):
 
 ```bash
 export PROVIDER_ENDPOINT="/ip4/<your-public-ip>/tcp/8091/http"
 ```
+
+Option B (Cloudflare Tunnel HTTPS, behind NAT):
+
+```bash
+# After creating a Cloudflare Tunnel hostname (example: sp1.<domain>)
+export PROVIDER_ENDPOINT="/dns4/sp1.<domain>/tcp/443/https"
+```
+
+In your tunnel config, point that hostname to the local provider listener (for example `service: http://localhost:8091`).
+
+Cloudflare Tunnel setup reference (recommended for NAT): `docs/networking/PROVIDER_ENDPOINTS.md`.
 
 ### 4) Register on-chain (uses the hub RPC/LCD)
 
@@ -156,4 +167,3 @@ Please capture:
 - A screenshot + browser console log (website), or command output (CLI)
 
 If you can reproduce reliably, that’s gold: include “steps to reproduce” from a fresh page load or fresh process start.
-

--- a/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
+++ b/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
@@ -11,12 +11,12 @@ Related:
 
 ## Architecture (locked for soft launch)
 
-- **Hub (VPS)** runs:
+- **Hub** runs (either public VPS or home server behind NAT):
   - `nilchaind` (CometBFT RPC + LCD + EVM JSON-RPC)
   - `nil_gateway` in **router** mode
   - `nil_faucet` (enabled, rate-limited; collaborator-only)
   - `nil-website` (static build behind HTTPS)
-- **Providers (remote SPs)** run:
+- **Providers (remote SPs)** run (direct endpoint or Cloudflare Tunnel endpoint):
   - `nil_gateway` in **provider** mode (one per SP)
 - **Users** interact via:
   - Website + MetaMask (wallet-first), or curl for debugging
@@ -39,11 +39,31 @@ Use HTTPS subdomains (reverse-proxied to localhost ports):
 Reverse proxy templates:
 - Caddy examples live in `ops/caddy/` (`ops/caddy/Caddyfile.hub.example` + `ops/caddy/Caddyfile.provider.example`).
 
-## Hub VPS runbook (blank box → running devnet)
+## Connectivity profiles (choose one)
 
-This section is the **hub operator** checklist for standing up the public endpoints on a fresh VPS.
+### Profile A — Public ingress + Caddy (default)
 
-### 0) DNS + firewall (required)
+- Hub has reachable inbound `80/443`.
+- DNS (`rpc/lcd/evm/gateway/faucet/web`) resolves directly to the hub public IP.
+- Caddy terminates TLS and proxies to localhost ports.
+
+### Profile B — Home server behind NAT/CGNAT + Cloudflare Tunnel
+
+- Hub is not directly reachable from the internet.
+- `cloudflared` publishes the same public hostnames and forwards to localhost ports.
+- Inbound `80/443` on the hub is not required.
+- Provider machines can also use Cloudflare Tunnel endpoints (`/dns4/<host>/tcp/443/https`) when they cannot open inbound ports.
+- Endpoint details for providers: `docs/networking/PROVIDER_ENDPOINTS.md`.
+
+## Hub runbook (blank box → running devnet)
+
+This section is the **hub operator** checklist for standing up public endpoints on either:
+- a public VPS (Profile A), or
+- a home server behind NAT/CGNAT (Profile B).
+
+### 0) Choose ingress profile (required)
+
+#### Profile A (public ingress + Caddy)
 
 1) Create DNS records (A/AAAA) for:
 - `rpc.<domain>`
@@ -64,13 +84,28 @@ Keep the underlying service ports **local-only** (recommended) or **firewalled**
 - `8080` (router gateway)
 - `8081` (faucet)
 
+#### Profile B (home server behind NAT/CGNAT + Cloudflare Tunnel)
+
+1) In Cloudflare DNS, use proxied hostnames for:
+- `rpc.<domain>`
+- `lcd.<domain>`
+- `evm.<domain>`
+- `gateway.<domain>`
+- `faucet.<domain>`
+- `web.<domain>`
+
+2) Keep only SSH inbound to the server (typically `22/tcp` on LAN/VPN as you prefer).
+
+3) Keep all NilStore services bound to localhost (`127.0.0.1`), then publish them through `cloudflared` (section 4B).
+
 ### 1) Install prerequisites (one-time)
 
 You need toolchains to build binaries + the static website:
 - Go (see `go.mod`; currently Go `1.25.x`)
 - Rust (stable) + `wasm-pack` + `wasm32-unknown-unknown`
 - Node.js + npm
-- Caddy (for HTTPS)
+- Caddy (Profile A reverse proxy, or Profile B local static web server on `127.0.0.1:8088`)
+- cloudflared (Profile B)
 
 ### 2) Clone + bootstrap chain home (one-time)
 
@@ -137,7 +172,7 @@ Minimum required edits:
 - set `NIL_CHAIN_ID` (use the value printed by the bootstrap script, or your chosen chain id)
 - set `NIL_GATEWAY_SP_AUTH` on the router and providers (shared secret)
 - set `NIL_FAUCET_AUTH_TOKEN` (recommended for invite-only; share with collaborators out-of-band)
-- recommended (hub behind Caddy): bind services to localhost and expose only via HTTPS (systemd env templates default to this):
+- recommended (hub behind Caddy or Cloudflare Tunnel): bind services to localhost and expose only via the public edge:
   - `nilchaind.env`: `NIL_RPC_LADDR=tcp://127.0.0.1:26657`
   - `nil-gateway-router.env`: `NIL_LISTEN_ADDR=127.0.0.1:8080`
   - `nil-faucet.env`: `NIL_LISTEN_ADDR=127.0.0.1:8081`
@@ -150,7 +185,9 @@ sudo systemctl enable --now nil-gateway-router
 sudo systemctl enable --now nil-faucet
 ```
 
-### 4) Caddy (HTTPS reverse proxy)
+### 4) Caddy (HTTPS reverse proxy, Profile A)
+
+If you are using Profile B (Cloudflare Tunnel), skip this section and use section 4B.
 
 1) Copy the hub example and replace `example.com`:
 
@@ -163,6 +200,78 @@ sudoedit /etc/caddy/Caddyfile
 
 ```bash
 sudo systemctl reload caddy || sudo systemctl restart caddy
+```
+
+### 4B) Cloudflare Tunnel (NAT/CGNAT profile, replaces public ingress)
+
+Use this when the hub is behind NAT and you cannot expose inbound `80/443`.
+
+1) Authenticate and create the hub tunnel:
+
+```bash
+cloudflared tunnel login
+cloudflared tunnel create nilstore-hub
+cloudflared tunnel route dns nilstore-hub rpc.<domain>
+cloudflared tunnel route dns nilstore-hub lcd.<domain>
+cloudflared tunnel route dns nilstore-hub evm.<domain>
+cloudflared tunnel route dns nilstore-hub gateway.<domain>
+cloudflared tunnel route dns nilstore-hub faucet.<domain>
+cloudflared tunnel route dns nilstore-hub web.<domain>
+```
+
+2) Create `/etc/cloudflared/config.yml`:
+
+```yaml
+tunnel: <HUB_TUNNEL_ID>
+credentials-file: /etc/cloudflared/<HUB_TUNNEL_ID>.json
+ingress:
+  - hostname: rpc.<domain>
+    service: http://127.0.0.1:26657
+  - hostname: lcd.<domain>
+    service: http://127.0.0.1:1317
+  - hostname: evm.<domain>
+    service: http://127.0.0.1:8545
+  - hostname: gateway.<domain>
+    service: http://127.0.0.1:8080
+  - hostname: faucet.<domain>
+    service: http://127.0.0.1:8081
+  - hostname: web.<domain>
+    service: http://127.0.0.1:8088
+  - service: http_status:404
+```
+
+3) Run a local web static server at `127.0.0.1:8088` (one simple option):
+
+```bash
+sudo tee /etc/caddy/Caddyfile >/dev/null <<'EOF'
+{
+  auto_https off
+}
+
+:8088 {
+  bind 127.0.0.1
+  root * /opt/nilstore/nil-website/dist
+  encode zstd gzip
+  file_server
+}
+EOF
+sudo systemctl restart caddy
+```
+
+4) Install the tunnel credentials/config under `/etc/cloudflared/`, then run the tunnel as a service.
+The exact install command depends on your distro package; common pattern:
+
+```bash
+sudo cloudflared service install
+sudo systemctl enable --now cloudflared
+```
+
+5) Validate public endpoints:
+
+```bash
+curl -fsS https://rpc.<domain>/status >/dev/null
+curl -fsS https://gateway.<domain>/health >/dev/null
+curl -fsS https://web.<domain>/ >/dev/null
 ```
 
 ### 5) Website build (static, served at `web.<domain>`)
@@ -300,6 +409,7 @@ Send each collaborator:
 Then have them follow:
 
 - `docs/REMOTE_SP_JOIN_QUICKSTART.md`
+- `docs/networking/PROVIDER_ENDPOINTS.md` (choose `direct` or `cloudflare-tunnel` endpoint type)
 
 ## Faucet / funding (collaborators)
 
@@ -341,6 +451,7 @@ For a collaborator validating their SP is actually participating:
   - the registration tx likely failed (fund provider key for gas)
 - Router can’t reach provider:
   - endpoint multiaddr not reachable from hub (firewall/NAT)
+  - provider tunnel misconfigured (`cloudflared` down, wrong hostname, or wrong local service port)
   - `NIL_GATEWAY_SP_AUTH` mismatch between router and provider
 - Fetch fails with “missing X-Nil-Session-Id”:
   - sessions are **required by default** (`NIL_REQUIRE_ONCHAIN_SESSION=1`)
@@ -349,14 +460,14 @@ For a collaborator validating their SP is actually participating:
 
 This is the “are we ready to invite people?” checklist. If any item is failing, treat it as a **No-Go** until resolved.
 
-### Hub (VPS)
+### Hub
 
 - DNS + HTTPS are live for `rpc.*`, `lcd.*`, `evm.*`, `gateway.*`, `faucet.*`, `web.*` (200s; correct CORS where needed).
 - Hub healthcheck passes (preferred):
   - `scripts/devnet_healthcheck.sh hub --rpc https://rpc.<domain> --lcd https://lcd.<domain> --evm https://evm.<domain> --gateway https://gateway.<domain> --faucet https://faucet.<domain>`
 - Chain is producing blocks and not catching up:
   - `curl -s https://rpc.<domain>/status | jq '.result.sync_info.latest_block_height,.result.sync_info.catching_up'`
-- Hub services are bound to localhost (recommended; Caddy is the only public listener):
+- Hub services are bound to localhost (recommended; only edge processes listen publicly: Caddy for Profile A, cloudflared for Profile B):
   - `ss -lntp | rg '(:26657|:1317|:8545|:8080|:8081)'`
 - Faucet is configured for invite-only (recommended):
   - `NIL_FAUCET_AUTH_TOKEN` set and tested via curl.


### PR DESCRIPTION
## Summary
- add a first-class NAT/CGNAT deployment profile to trusted devnet hub docs using Cloudflare Tunnel
- document hub tunnel ingress mapping for rpc/lcd/evm/gateway/faucet/web hostnames
- update collaborator + remote SP quickstarts with direct vs cloudflare-tunnel endpoint options
- update docs index/README discoverability for provider endpoint profiles
- roll tracker forward with PR39 as current

## Test gate
- bash -n scripts/run_devnet_alpha_multi_sp.sh
- bash -n scripts/run_devnet_provider.sh
