### PR TITLE
Gateway GUI PR2: deterministic launch window + baked-in local defaults

### DIFF
--- a/nil-website/src/components/Dashboard.tsx
+++ b/nil-website/src/components/Dashboard.tsx
@@ -26,6 +26,7 @@ import { toHexFromBase64OrHex } from '../domain/hex'
 import { useTransportRouter } from '../hooks/useTransportRouter'
 import { multiaddrToHttpUrl, multiaddrToP2pTarget } from '../lib/multiaddr'
 import { useLocalGateway } from '../hooks/useLocalGateway'
+import { useWalletNetworkGuard } from '../hooks/useWalletNetworkGuard'
 
 interface Provider {
   address: string
@@ -81,6 +82,13 @@ export function Dashboard() {
   const { submitUpdate, loading: updateLoading, lastTx: updateTx } = useUpdateDealContent()
   const { upload, loading: uploadLoading } = useUpload()
   const { switchNetwork } = useNetwork()
+  const {
+    walletChainId,
+    isWrongNetwork: walletIsWrongNetwork,
+    genesisMismatch,
+    accountPermissionMismatch,
+    refresh: refreshWalletNetwork,
+  } = useWalletNetworkGuard({ enabled: isConnected, pollMs: 15_000 })
   const [deals, setDeals] = useState<Deal[]>([])
   const [allDeals, setAllDeals] = useState<Deal[]>([])
   const [providers, setProviders] = useState<Provider[]>([])
@@ -98,8 +106,8 @@ export function Dashboard() {
   const providerCount = providers.length
   const defaultRsLabel = `${appConfig.defaultRsK}+${appConfig.defaultRsM}`
   const gatewayDesktopReleaseUrl = 'https://github.com/Nil-Store/nil-store/releases/latest'
-  const activeChainId = chainId
-  const isWrongNetwork = isConnected && activeChainId !== appConfig.chainId
+  const activeChainId = walletChainId ?? chainId
+  const isWrongNetwork = isConnected && walletIsWrongNetwork
 
   // Check if the RPC node itself is on the right chain
   const [rpcChainId, setRpcChainId] = useState<number | null>(null)
@@ -176,14 +184,15 @@ export function Dashboard() {
   const rpcMismatch = rpcChainId !== null && rpcChainId !== appConfig.chainId
   const faucetBusy = faucetLoading || faucetTxStatus === 'pending'
 
-  const handleSwitchNetwork = async () => {
+  const handleSwitchNetwork = useCallback(async (options?: { forceAdd?: boolean }) => {
     try {
-      await switchNetwork()
+      await switchNetwork({ forceAdd: options?.forceAdd })
+      await refreshWalletNetwork()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       alert(`Could not switch network. Please switch to Chain ID ${appConfig.chainId} manually.`)
     }
-  }
+  }, [refreshWalletNetwork, switchNetwork])
 
   const handleRefreshSummary = async () => {
     if (!nilAddress) return
@@ -217,6 +226,7 @@ export function Dashboard() {
   const [downloadToast, setDownloadToast] = useState<string | null>(null)
   const toastTimerRef = useRef<number | null>(null)
   const workspaceRef = useRef<HTMLDivElement | null>(null)
+  const autoSwitchMismatchKeyRef = useRef<string | null>(null)
   const allocRef = useRef<HTMLDivElement | null>(null)
   const mduRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
@@ -265,10 +275,38 @@ export function Dashboard() {
   }, [handleWalletError, openConnectModal])
 
   useEffect(() => {
+    if (accountPermissionMismatch) {
+      setWalletReconnectHint(true)
+      return
+    }
     if (isConnected && address) {
       setWalletReconnectHint(false)
     }
-  }, [isConnected, address])
+  }, [accountPermissionMismatch, address, isConnected])
+
+  useEffect(() => {
+    if (!accountPermissionMismatch) return
+    setStatusTone('error')
+    setStatusMsg('MetaMask account changed. Reconnect and approve access for the active account.')
+  }, [accountPermissionMismatch])
+
+  useEffect(() => {
+    if (!isConnected || !isWrongNetwork) {
+      autoSwitchMismatchKeyRef.current = null
+      return
+    }
+    const mismatchKind = genesisMismatch ? 'genesis' : 'chain'
+    const key = `${String(activeChainId ?? 'unknown')}:${mismatchKind}`
+    if (autoSwitchMismatchKeyRef.current === key) return
+    autoSwitchMismatchKeyRef.current = key
+    void handleSwitchNetwork({ forceAdd: genesisMismatch })
+  }, [
+    activeChainId,
+    genesisMismatch,
+    handleSwitchNetwork,
+    isConnected,
+    isWrongNetwork,
+  ])
 
   const [retrievalSessions, setRetrievalSessions] = useState<Record<string, unknown>[]>([])
   const [retrievalSessionsLoading, setRetrievalSessionsLoading] = useState(false)
@@ -1727,15 +1765,24 @@ export function Dashboard() {
             <div>
               <h3 className="font-bold text-yellow-700 dark:text-yellow-200">Wrong Network</h3>
               <p className="text-sm text-yellow-600 dark:text-yellow-300">
-                Connected to Chain ID <strong>{activeChainId}</strong>. App requires <strong>{appConfig.chainId}</strong> (NilChain Local).
+                {genesisMismatch ? (
+                  <>
+                    Connected to Chain ID <strong>{activeChainId}</strong>, but this is a different network than the NilStore RPC.
+                    We will reconfigure MetaMask to use the NilStore Devnet endpoint.
+                  </>
+                ) : (
+                  <>
+                    Connected to Chain ID <strong>{activeChainId}</strong>. App requires <strong>{appConfig.chainId}</strong> (NilStore Devnet).
+                  </>
+                )}
               </p>
             </div>
           </div>
           <button
-            onClick={handleSwitchNetwork}
+            onClick={() => void handleSwitchNetwork({ forceAdd: genesisMismatch })}
             className="px-4 py-2 bg-yellow-600 hover:bg-yellow-500 text-white text-sm font-bold rounded-lg transition-colors"
           >
-            Switch Network
+            {genesisMismatch ? 'Repair MetaMask Network' : 'Switch Network'}
           </button>
         </div>
       )}
@@ -1826,7 +1873,7 @@ export function Dashboard() {
               ) : isWrongNetwork ? (
                 <button
                   type="button"
-                  onClick={handleSwitchNetwork}
+                  onClick={() => void handleSwitchNetwork({ forceAdd: genesisMismatch })}
                   className="inline-flex items-center gap-2 rounded-md border border-border bg-background/80 px-3 py-2 text-xs font-semibold text-foreground hover:bg-secondary/40"
                 >
                   <Wallet className="h-3.5 w-3.5" />
@@ -2555,7 +2602,7 @@ export function Dashboard() {
                   )}
                 </div>
                 <button
-                  onClick={isWrongNetwork ? handleSwitchNetwork : handleCreateDealClick}
+                  onClick={isWrongNetwork ? () => void handleSwitchNetwork({ forceAdd: genesisMismatch }) : handleCreateDealClick}
                   disabled={dealLoading || (placementProfile === 'custom' && Boolean(mode2Config.error))}
                   data-testid="alloc-submit"
                   className="px-4 py-2 bg-primary hover:bg-primary/90 text-primary-foreground text-sm font-medium rounded-md disabled:opacity-50 transition-colors"

--- a/nil-website/src/components/DealDetail.tsx
+++ b/nil-website/src/components/DealDetail.tsx
@@ -1390,7 +1390,52 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
                                             const res = await fetch(url)
                                             if (!res.ok) {
                                               const txt = await res.text().catch(() => '')
-                                              throw new Error(txt || `gateway raw fetch failed (${res.status})`)
+                                              const normalized = txt.toLowerCase()
+                                              const missingSessionHeader = normalized.includes('x-nil-session-id')
+                                              if (!missingSessionHeader) {
+                                                throw new Error(txt || `gateway raw fetch failed (${res.status})`)
+                                              }
+
+                                              // Newer gateway paths may require session headers even for debug fetches.
+                                              // Fall back to the session-aware retrieval flow while forcing gateway base.
+                                              const manifestHex = toHexFromBase64OrHex(deal.cid) || deal.cid
+                                              const dealId = String(deal.id)
+                                              onFileActivity?.({
+                                                dealId,
+                                                filePath: f.path,
+                                                sizeBytes: f.size_bytes,
+                                                manifestRoot: manifestHex,
+                                                action: 'download',
+                                                status: 'pending',
+                                              })
+                                              const result = await fetchFile({
+                                                dealId,
+                                                manifestRoot: manifestHex,
+                                                owner: nilAddress,
+                                                filePath: f.path,
+                                                serviceBase: appConfig.gatewayBase,
+                                                rangeStart: safeStart,
+                                                rangeLen: safeLen,
+                                                fileStartOffset: f.start_offset,
+                                                fileSizeBytes: f.size_bytes,
+                                                mduSizeBytes: slab?.mdu_size_bytes ?? 8 * 1024 * 1024,
+                                                blobSizeBytes: slab?.blob_size_bytes ?? 128 * 1024,
+                                                sponsoredAuth,
+                                              })
+                                              if (!result) throw new Error('download failed')
+                                              const fallbackBytes = new Uint8Array(await result.blob.arrayBuffer())
+                                              await writeCachedFile(dealId, f.path, fallbackBytes)
+                                              setBrowserCachedByPath((prev) => ({ ...prev, [f.path]: true }))
+                                              downloadBlobAsFile(result.blob, f.path)
+                                              onFileActivity?.({
+                                                dealId,
+                                                filePath: f.path,
+                                                sizeBytes: f.size_bytes,
+                                                manifestRoot: manifestHex,
+                                                action: 'download',
+                                                status: 'success',
+                                              })
+                                              return
                                             }
                                             const bytes = new Uint8Array(await res.arrayBuffer())
                                             await writeCachedFile(String(deal.id), f.path, bytes)
@@ -1407,7 +1452,7 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
                                         data-testid="deal-detail-download-gateway"
                                         data-file-path={f.path}
                                         className="order-4 inline-flex items-center justify-center rounded-md border border-border bg-secondary px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:bg-secondary/70 disabled:opacity-50 disabled:pointer-events-none"
-                                        title="Debug: raw fetch via gateway (requires slab present)"
+                                        title="Download through local gateway path"
                                       >
                                         Gateway
                                       </button>

--- a/nil-website/src/hooks/useFetch.ts
+++ b/nil-website/src/hooks/useFetch.ts
@@ -736,41 +736,49 @@ export function useFetch() {
       if (sessionIds.length === 0) {
         throw new Error('no retrieval sessions were used during fetch')
       }
-      const confirmTxData = encodeConfirmRetrievalSessionsData(sessionIds)
-      const confirmTxHash = await walletClient.sendTransaction({
-        account: signerAddress,
-        to: appConfig.nilstorePrecompile as Hex,
-        data: confirmTxData,
-        gas: 3_000_000n,
-      })
-      await waitForTransactionReceipt(confirmTxHash)
-      receiptsSubmitted = 2
+      let confirmError: string | null = null
+      try {
+        const confirmTxData = encodeConfirmRetrievalSessionsData(sessionIds)
+        const confirmTxHash = await walletClient.sendTransaction({
+          account: signerAddress,
+          to: appConfig.nilstorePrecompile as Hex,
+          data: confirmTxData,
+          gas: 3_000_000n,
+        })
+        await waitForTransactionReceipt(confirmTxHash)
+        receiptsSubmitted = 2
+      } catch (err) {
+        confirmError = classifyWalletError(err, 'Confirm retrieval failed').message
+      }
 
       setProgress((p) => ({
         ...p,
         phase: 'submitting_proof_request',
         receiptsSubmitted,
+        message: confirmError ? `Receipt confirmation failed: ${confirmError}` : p.message,
       }))
 
       let proofSubmissionError: string | null = null
-      for (const [provider, sessionId] of usedSessionsByProvider.entries()) {
-        // `session-proof` forwarding currently relies on the local Gateway app.
-        // Keep file download successful even when the local gateway is not running.
-        try {
-          const proofBase = appConfig.gatewayBase
-          const proofRes = await fetch(`${proofBase}/gateway/session-proof?deal_id=${encodeURIComponent(dealId)}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ session_id: sessionId, provider }),
-          })
-          if (!proofRes.ok) {
-            const text = await proofRes.text().catch(() => '')
-            throw new Error(decodeHttpError(text) || `submit session proof failed (${proofRes.status})`)
+      if (!confirmError) {
+        for (const [provider, sessionId] of usedSessionsByProvider.entries()) {
+          // `session-proof` forwarding currently relies on the local Gateway app.
+          // Keep file download successful even when the local gateway is not running.
+          try {
+            const proofBase = appConfig.gatewayBase
+            const proofRes = await fetch(`${proofBase}/gateway/session-proof?deal_id=${encodeURIComponent(dealId)}`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ session_id: sessionId, provider }),
+            })
+            if (!proofRes.ok) {
+              const text = await proofRes.text().catch(() => '')
+              throw new Error(decodeHttpError(text) || `submit session proof failed (${proofRes.status})`)
+            }
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err)
+            if (!proofSubmissionError) proofSubmissionError = msg
+            console.warn('session-proof forwarding failed; download still succeeds', { provider, error: msg })
           }
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err)
-          if (!proofSubmissionError) proofSubmissionError = msg
-          console.warn('session-proof forwarding failed; download still succeeds', { provider, error: msg })
         }
       }
 
@@ -789,9 +797,10 @@ export function useFetch() {
       const url = URL.createObjectURL(blob)
       setDownloadUrl(url)
 
-      if (proofSubmissionError) {
+      const receiptPipelineError = [confirmError, proofSubmissionError].filter(Boolean).join('; ')
+      if (receiptPipelineError) {
         setReceiptStatus('failed')
-        setReceiptError(`Proof forwarding failed (download succeeded): ${proofSubmissionError}`)
+        setReceiptError(`Receipt pipeline failed (download succeeded): ${receiptPipelineError}`)
       } else {
         setReceiptStatus('submitted')
       }
@@ -799,7 +808,7 @@ export function useFetch() {
         ...p,
         phase: 'done',
         receiptsSubmitted: receiptsSubmitted,
-        message: proofSubmissionError ? `Download complete; proof forwarding failed: ${proofSubmissionError}` : p.message,
+        message: receiptPipelineError ? `Download complete; receipt pipeline failed: ${receiptPipelineError}` : p.message,
       }))
 
       return { url, blob }

--- a/nil-website/src/hooks/useNetwork.ts
+++ b/nil-website/src/hooks/useNetwork.ts
@@ -1,11 +1,49 @@
 import { useSwitchChain } from 'wagmi'
 import { appConfig } from '../config'
 
+type EthereumProvider = {
+  request?: (args: { method: string; params?: unknown[] | Record<string, unknown> }) => Promise<unknown>
+}
+
+type SwitchNetworkOptions = {
+  forceAdd?: boolean
+}
+
+function getEthereumProvider(): EthereumProvider | null {
+  if (typeof window === 'undefined') return null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ethereum = (window as any).ethereum as EthereumProvider | undefined
+  return ethereum ?? null
+}
+
 export function useNetwork() {
   const { switchChainAsync } = useSwitchChain()
 
-  const switchNetwork = async () => {
+  const addChain = async () => {
+    const ethereum = getEthereumProvider()
+    if (!ethereum?.request) throw new Error('No crypto wallet found')
+    await ethereum.request({
+      method: 'wallet_addEthereumChain',
+      params: [{
+        chainId: `0x${appConfig.chainId.toString(16)}`,
+        chainName: 'NilStore Devnet',
+        nativeCurrency: {
+          name: 'NIL',
+          symbol: 'NIL',
+          decimals: 18,
+        },
+        rpcUrls: [appConfig.evmRpc],
+        blockExplorerUrls: [appConfig.explorerBase],
+      }],
+    })
+  }
+
+  const switchNetwork = async (options?: SwitchNetworkOptions) => {
+    const forceAdd = Boolean(options?.forceAdd)
     try {
+      if (forceAdd) {
+        await addChain()
+      }
       await switchChainAsync({ chainId: appConfig.chainId })
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
@@ -15,24 +53,7 @@ export function useNetwork() {
       // -32603 is an Internal Error that sometimes wraps 4902 in some wallet versions.
       if (e.code === 4902 || e.message?.includes('Unrecognized chain ID') || e.code === -32603) {
          try {
-             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-             const ethereum = (window as any).ethereum
-             if (!ethereum) throw new Error('No crypto wallet found')
-
-             await ethereum.request({
-                 method: 'wallet_addEthereumChain',
-                 params: [{
-                     chainId: `0x${appConfig.chainId.toString(16)}`,
-                     chainName: 'NilStore Devnet',
-                     nativeCurrency: {
-                         name: 'NIL',
-                         symbol: 'NIL',
-                         decimals: 18,
-                     },
-                     rpcUrls: [appConfig.evmRpc],
-                     blockExplorerUrls: [appConfig.explorerBase],
-                 }],
-             })
+             await addChain()
              // Try switching again after adding
              await switchChainAsync({ chainId: appConfig.chainId })
          } catch (addError) {

--- a/nil-website/src/hooks/useWalletNetworkGuard.ts
+++ b/nil-website/src/hooks/useWalletNetworkGuard.ts
@@ -1,0 +1,247 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useAccount } from 'wagmi'
+import { appConfig } from '../config'
+
+type EthereumRequestArgs = {
+  method: string
+  params?: unknown[] | Record<string, unknown>
+}
+
+type EthereumProvider = {
+  request?: (args: EthereumRequestArgs) => Promise<unknown>
+  on?: (event: string, listener: (...args: unknown[]) => void) => void
+  removeListener?: (event: string, listener: (...args: unknown[]) => void) => void
+}
+
+type RpcBlock = {
+  hash?: unknown
+}
+
+type RpcEnvelope = {
+  result?: unknown
+}
+
+export type WalletNetworkGuardState = {
+  walletChainId: number | null
+  chainIdMismatch: boolean
+  genesisMismatch: boolean
+  isWrongNetwork: boolean
+  accountPermissionMismatch: boolean
+  expectedGenesisHash: string | null
+  walletGenesisHash: string | null
+  refresh: () => Promise<void>
+}
+
+function getEthereum(): EthereumProvider | null {
+  if (typeof window === 'undefined') return null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const eth = (window as any).ethereum as EthereumProvider | undefined
+  return eth ?? null
+}
+
+function normalizeAddress(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : ''
+}
+
+function normalizeHex(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  const trimmed = value.trim().toLowerCase()
+  if (!trimmed.startsWith('0x')) return ''
+  return trimmed
+}
+
+function parseHexChainId(raw: unknown): number | null {
+  if (typeof raw !== 'string') return null
+  const value = raw.trim()
+  if (!value) return null
+  const parsed = parseInt(value, 16)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+async function fetchExpectedGenesisHash(rpcUrl: string): Promise<string | null> {
+  try {
+    const res = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'eth_getBlockByNumber',
+        params: ['0x0', false],
+        id: 1,
+      }),
+    })
+    if (!res.ok) return null
+    const json = (await res.json().catch(() => null)) as RpcEnvelope | null
+    const block = (json?.result ?? null) as RpcBlock | null
+    const hash = normalizeHex(block?.hash)
+    return hash || null
+  } catch {
+    return null
+  }
+}
+
+async function fetchWalletGenesisHash(ethereum: EthereumProvider): Promise<string | null> {
+  if (typeof ethereum.request !== 'function') return null
+  try {
+    const raw = await ethereum.request({
+      method: 'eth_getBlockByNumber',
+      params: ['0x0', false],
+    })
+    const block = (raw ?? null) as RpcBlock | null
+    const hash = normalizeHex(block?.hash)
+    return hash || null
+  } catch {
+    return null
+  }
+}
+
+async function fetchWalletChainId(ethereum: EthereumProvider): Promise<number | null> {
+  if (typeof ethereum.request !== 'function') return null
+  try {
+    const raw = await ethereum.request({ method: 'eth_chainId' })
+    return parseHexChainId(raw)
+  } catch {
+    return null
+  }
+}
+
+async function fetchWalletAccounts(ethereum: EthereumProvider): Promise<string[]> {
+  if (typeof ethereum.request !== 'function') return []
+  try {
+    const raw = await ethereum.request({ method: 'eth_accounts' })
+    if (!Array.isArray(raw)) return []
+    return raw.map((item) => normalizeAddress(item)).filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+export function useWalletNetworkGuard(options?: { enabled?: boolean; pollMs?: number }) {
+  const { address, isConnected } = useAccount()
+  const enabled = options?.enabled ?? true
+  const pollMs = options?.pollMs ?? 20_000
+  const hiddenPollMs = Math.max(pollMs * 3, 60_000)
+
+  const [walletChainId, setWalletChainId] = useState<number | null>(null)
+  const [expectedGenesisHash, setExpectedGenesisHash] = useState<string | null>(null)
+  const [walletGenesisHash, setWalletGenesisHash] = useState<string | null>(null)
+  const [accountPermissionMismatch, setAccountPermissionMismatch] = useState(false)
+
+  const refresh = useCallback(async () => {
+    if (!enabled) return
+    const ethereum = getEthereum()
+    if (!ethereum) {
+      setWalletChainId(null)
+      setWalletGenesisHash(null)
+      setAccountPermissionMismatch(false)
+      return
+    }
+
+    const [walletChain, expectedGenesis, walletAccounts] = await Promise.all([
+      fetchWalletChainId(ethereum),
+      fetchExpectedGenesisHash(appConfig.evmRpc),
+      fetchWalletAccounts(ethereum),
+    ])
+
+    setWalletChainId(walletChain)
+    setExpectedGenesisHash(expectedGenesis)
+
+    const currentAddress = normalizeAddress(address)
+    const permissionMismatch =
+      Boolean(isConnected && currentAddress) &&
+      (walletAccounts.length === 0 || !walletAccounts.includes(currentAddress))
+    setAccountPermissionMismatch(permissionMismatch)
+
+    if (!isConnected || walletChain === null || walletChain !== appConfig.chainId) {
+      setWalletGenesisHash(null)
+      return
+    }
+
+    const walletGenesis = await fetchWalletGenesisHash(ethereum)
+    setWalletGenesisHash(walletGenesis)
+  }, [address, enabled, isConnected])
+
+  useEffect(() => {
+    if (!enabled) return
+    let cancelled = false
+    let timer: number | null = null
+    const ethereum = getEthereum()
+
+    const schedule = (delayMs: number) => {
+      if (cancelled) return
+      if (timer !== null) window.clearTimeout(timer)
+      timer = window.setTimeout(() => {
+        void runLoop()
+      }, delayMs)
+    }
+
+    const runLoop = async () => {
+      if (cancelled) return
+      await refresh()
+      if (cancelled) return
+      const hidden = typeof document !== 'undefined' && document.visibilityState === 'hidden'
+      schedule(hidden ? hiddenPollMs : pollMs)
+    }
+
+    const handleRefreshEvent = () => {
+      void refresh()
+    }
+
+    void runLoop()
+
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', handleRefreshEvent)
+    }
+    if (typeof window !== 'undefined') {
+      window.addEventListener('focus', handleRefreshEvent)
+    }
+    if (ethereum?.on) {
+      ethereum.on('accountsChanged', handleRefreshEvent)
+      ethereum.on('chainChanged', handleRefreshEvent)
+      ethereum.on('connect', handleRefreshEvent)
+      ethereum.on('disconnect', handleRefreshEvent)
+    }
+
+    return () => {
+      cancelled = true
+      if (timer !== null) window.clearTimeout(timer)
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', handleRefreshEvent)
+      }
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('focus', handleRefreshEvent)
+      }
+      if (ethereum?.removeListener) {
+        ethereum.removeListener('accountsChanged', handleRefreshEvent)
+        ethereum.removeListener('chainChanged', handleRefreshEvent)
+        ethereum.removeListener('connect', handleRefreshEvent)
+        ethereum.removeListener('disconnect', handleRefreshEvent)
+      }
+    }
+  }, [enabled, hiddenPollMs, pollMs, refresh])
+
+  const chainIdMismatch = useMemo(() => {
+    if (!isConnected) return false
+    if (walletChainId === null) return false
+    return walletChainId !== appConfig.chainId
+  }, [isConnected, walletChainId])
+
+  const genesisMismatch = useMemo(() => {
+    if (!isConnected) return false
+    if (chainIdMismatch) return false
+    if (!expectedGenesisHash || !walletGenesisHash) return false
+    return expectedGenesisHash !== walletGenesisHash
+  }, [chainIdMismatch, expectedGenesisHash, isConnected, walletGenesisHash])
+
+  return {
+    walletChainId,
+    chainIdMismatch,
+    genesisMismatch,
+    isWrongNetwork: chainIdMismatch || genesisMismatch,
+    accountPermissionMismatch,
+    expectedGenesisHash,
+    walletGenesisHash,
+    refresh,
+  } satisfies WalletNetworkGuardState
+}
+

--- a/nil-website/src/pages/FirstFile.tsx
+++ b/nil-website/src/pages/FirstFile.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAccount, useBalance, useChainId } from 'wagmi'
 import { formatUnits, numberToHex } from 'viem'
@@ -18,6 +18,7 @@ import { ethToNil } from '../lib/address'
 import { buildServiceHint } from '../lib/serviceHint'
 import { toHexFromBase64OrHex } from '../domain/hex'
 import { classifyWalletError } from '../lib/walletErrors'
+import { useWalletNetworkGuard } from '../hooks/useWalletNetworkGuard'
 
 function bytesToHex(bytes: Uint8Array): string {
   let out = ''
@@ -40,6 +41,13 @@ export function FirstFile() {
   const { upload, loading: uploadLoading } = useUpload()
   const { submitUpdate, loading: commitLoading, lastTx: commitTx } = useUpdateDealContent()
   const { fetchFile, loading: fetchLoading, progress, receiptStatus, receiptError } = useFetch()
+  const {
+    walletChainId,
+    isWrongNetwork: walletIsWrongNetwork,
+    genesisMismatch,
+    accountPermissionMismatch,
+    refresh: refreshWalletNetwork,
+  } = useWalletNetworkGuard({ enabled: isConnected, pollMs: 15_000 })
 
   const [duration, setDuration] = useState('100')
   const [initialEscrow, setInitialEscrow] = useState('1000000')
@@ -54,8 +62,10 @@ export function FirstFile() {
   const [downloadHash, setDownloadHash] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
+  const autoSwitchKeyRef = useRef<string | null>(null)
 
-  const isWrongNetwork = isConnected && chainId !== appConfig.chainId
+  const activeChainId = walletChainId ?? chainId
+  const isWrongNetwork = isConnected && walletIsWrongNetwork
   const nilAddress = useMemo(() => {
     if (!address) return ''
     return address.startsWith('0x') ? ethToNil(address) : address
@@ -82,6 +92,32 @@ export function FirstFile() {
     const trimmed = frac ? `${whole}.${frac.slice(0, 4)}` : whole
     return `${trimmed} ${balance.symbol || 'NIL'}`
   }, [balance])
+
+  useEffect(() => {
+    if (!accountPermissionMismatch) return
+    setError('MetaMask account changed. Reconnect wallet and approve access for the active account.')
+  }, [accountPermissionMismatch])
+
+  useEffect(() => {
+    if (!isConnected || !isWrongNetwork) {
+      autoSwitchKeyRef.current = null
+      return
+    }
+    const mismatchKind = genesisMismatch ? 'genesis' : 'chain'
+    const key = `${String(activeChainId ?? 'unknown')}:${mismatchKind}`
+    if (autoSwitchKeyRef.current === key) return
+    autoSwitchKeyRef.current = key
+    void switchNetwork({ forceAdd: genesisMismatch })
+      .then(() => refreshWalletNetwork())
+      .catch(() => undefined)
+  }, [
+    activeChainId,
+    genesisMismatch,
+    isConnected,
+    isWrongNetwork,
+    refreshWalletNetwork,
+    switchNetwork,
+  ])
 
   const handleUseSampleFile = async () => {
     setError(null)
@@ -141,8 +177,16 @@ export function FirstFile() {
       setError('EVM 0x address required')
       return
     }
+    if (accountPermissionMismatch) {
+      setError('MetaMask account changed. Reconnect wallet before creating a deal.')
+      return
+    }
     if (isWrongNetwork) {
-      setError(`Wrong network (wallet chainId=${chainId}). Switch to ${appConfig.chainId}.`)
+      setError(
+        genesisMismatch
+          ? `Wrong network identity for chainId ${activeChainId}. Repair MetaMask network settings and retry.`
+          : `Wrong network (wallet chainId=${activeChainId}). Switch to ${appConfig.chainId}.`,
+      )
       return
     }
     try {
@@ -367,10 +411,10 @@ export function FirstFile() {
           {isWrongNetwork && (
             <button
               type="button"
-              onClick={() => void switchNetwork()}
+              onClick={() => void switchNetwork({ forceAdd: genesisMismatch })}
               className="inline-flex items-center justify-center rounded-lg bg-yellow-600 hover:bg-yellow-500 px-4 py-2 text-sm font-bold text-white transition-colors"
             >
-              Switch to {numberToHex(appConfig.chainId)}
+              {genesisMismatch ? 'Repair MetaMask network' : `Switch to ${numberToHex(appConfig.chainId)}`}
             </button>
           )}
         </div>

--- a/nil-website/website-spec.md
+++ b/nil-website/website-spec.md
@@ -73,7 +73,7 @@ The application uses Vite for building and handling environment variables. Confi
 | `VITE_SP_BASE` | `http://localhost:8082` | Default Storage Provider base for direct uploads/fetches when provider discovery is unavailable. |
 | `VITE_COSMOS_CHAIN_ID` | `31337` | Chain ID for the Cosmos layer. |
 | `VITE_EVM_RPC` | `http://localhost:8545` | EVM JSON-RPC endpoint (auto-falls back to `https://evm.<domain>` when hosted on matching public domain). |
-| `VITE_CHAIN_ID` | `31337` | Chain ID for the EVM layer (default: Localhost). |
+| `VITE_CHAIN_ID` | `31337` | Chain ID for the EVM layer. **For shared/public devnets, set a NilStore-specific value (do not reuse `31337`) to avoid collisions with other local chains in MetaMask.** |
 | `VITE_ENABLE_FAUCET` | auto (`1` on `*.nilstore.org`, else `0`) | Faucet UI/actions override (`1` force on, `0` force off). |
 | `VITE_FAUCET_AUTH_TOKEN` | *(empty)* | Optional build-time faucet auth token. When set, the website sends this token automatically on faucet requests. |
 | `VITE_DEFAULT_RS_K` | `2` | Default RS K used by web deal creation when not explicitly overridden. |

--- a/nil_gateway/router_proxy.go
+++ b/nil_gateway/router_proxy.go
@@ -33,6 +33,20 @@ var routerHTTPClient = &http.Client{
 	},
 }
 
+func copyUpstreamResponseHeaders(dst http.Header, src http.Header) {
+	for k, vals := range src {
+		// Router handlers apply canonical CORS headers at the edge.
+		// Avoid duplicating provider Access-Control-* headers, which can produce
+		// invalid values such as "origin, origin" and break browser fetches.
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(k)), "access-control-") {
+			continue
+		}
+		for _, v := range vals {
+			dst.Add(k, v)
+		}
+	}
+}
+
 func proxyToProviderBaseURL(w http.ResponseWriter, r *http.Request, providerBaseURL string) {
 	setCORS(w)
 	if r.Method == http.MethodOptions {
@@ -66,11 +80,7 @@ func proxyToProviderBaseURL(w http.ResponseWriter, r *http.Request, providerBase
 	}
 	defer resp.Body.Close()
 
-	for k, vals := range resp.Header {
-		for _, v := range vals {
-			w.Header().Add(k, v)
-		}
-	}
+	copyUpstreamResponseHeaders(w.Header(), resp.Header)
 	// Ensure CORS headers are always present on responses returned via the router.
 	setCORS(w)
 	w.WriteHeader(resp.StatusCode)
@@ -121,11 +131,7 @@ func tryProxyToProviderBaseURL(w http.ResponseWriter, r *http.Request, providerB
 		}
 
 		// Not a routing miss: forward the 400 response to the client.
-		for k, vals := range resp.Header {
-			for _, v := range vals {
-				w.Header().Add(k, v)
-			}
-		}
+		copyUpstreamResponseHeaders(w.Header(), resp.Header)
 		setCORS(w)
 		w.WriteHeader(resp.StatusCode)
 		_, copyErr := w.Write(bodyBytes)
@@ -145,11 +151,7 @@ func tryProxyToProviderBaseURL(w http.ResponseWriter, r *http.Request, providerB
 			return false, fmt.Errorf("session provider mismatch: %s", body)
 		}
 
-		for k, vals := range resp.Header {
-			for _, v := range vals {
-				w.Header().Add(k, v)
-			}
-		}
+		copyUpstreamResponseHeaders(w.Header(), resp.Header)
 		setCORS(w)
 		w.WriteHeader(resp.StatusCode)
 		_, copyErr := w.Write(bodyBytes)
@@ -169,11 +171,7 @@ func tryProxyToProviderBaseURL(w http.ResponseWriter, r *http.Request, providerB
 		return false, fmt.Errorf("provider returned %d: %s", resp.StatusCode, body)
 	}
 
-	for k, vals := range resp.Header {
-		for _, v := range vals {
-			w.Header().Add(k, v)
-		}
-	}
+	copyUpstreamResponseHeaders(w.Header(), resp.Header)
 	setCORS(w)
 	w.WriteHeader(resp.StatusCode)
 
@@ -254,11 +252,7 @@ func tryProxyUploadToProviderBaseURL(w http.ResponseWriter, r *http.Request, pro
 		return false, fmt.Errorf("provider returned %d: %s", resp.StatusCode, body)
 	}
 
-	for k, vals := range resp.Header {
-		for _, v := range vals {
-			w.Header().Add(k, v)
-		}
-	}
+	copyUpstreamResponseHeaders(w.Header(), resp.Header)
 	setCORS(w)
 	w.WriteHeader(resp.StatusCode)
 

--- a/nil_gateway/router_proxy_test.go
+++ b/nil_gateway/router_proxy_test.go
@@ -98,6 +98,73 @@ func TestRouterGatewayFetch_ProxiesByDealProvider(t *testing.T) {
 	}
 }
 
+func TestRouterGatewayUploadStatus_DeduplicatesCORSHeaders(t *testing.T) {
+	requireOnchainSessionForTest(t, false)
+	dealProviderCache = sync.Map{}
+	dealProvidersCache = sync.Map{}
+	providerBaseCache = sync.Map{}
+
+	providerAddr := "nil1provider"
+	providerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := strings.TrimSpace(r.Header.Get("Origin"))
+		if origin == "" {
+			origin = "*"
+		}
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"state":"done"}`))
+	}))
+	defer providerSrv.Close()
+
+	maddr := mustHTTPMultiaddr(t, providerSrv.URL)
+	lcdSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/nilchain/nilchain/v1/deals/"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"deal": map[string]any{
+					"providers": []string{providerAddr},
+				},
+			})
+		case strings.HasPrefix(r.URL.Path, "/nilchain/nilchain/v1/providers/"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"provider": map[string]any{
+					"endpoints": []string{maddr},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer lcdSrv.Close()
+
+	oldLCD := lcdBase
+	lcdBase = lcdSrv.URL
+	t.Cleanup(func() { lcdBase = oldLCD })
+
+	r := mux.NewRouter()
+	r.HandleFunc("/gateway/upload-status", RouterGatewayUploadStatus).Methods("GET", "OPTIONS")
+	handler := withGlobalCORS(r)
+
+	const origin = "http://localhost:5173"
+	req := httptest.NewRequest(http.MethodGet, "/gateway/upload-status?deal_id=1&upload_id=u1", nil)
+	req.Header.Set("Origin", origin)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", w.Code, w.Body.String())
+	}
+
+	values := w.Header().Values("Access-Control-Allow-Origin")
+	if len(values) != 1 {
+		t.Fatalf("expected single Access-Control-Allow-Origin header, got %v", values)
+	}
+	if got := strings.TrimSpace(values[0]); got != origin {
+		t.Fatalf("expected Access-Control-Allow-Origin=%q, got %q", origin, got)
+	}
+}
+
 func TestRouterGatewayFetch_FailsOverWhenPrimaryUnavailable(t *testing.T) {
 	requireOnchainSessionForTest(t, false)
 	dealProviderCache = sync.Map{}

--- a/nil_gateway_gui/README.md
+++ b/nil_gateway_gui/README.md
@@ -22,6 +22,7 @@
 
 - Default base URL is `http://127.0.0.1:8080` (website-compatible localhost flow).
 - The GUI shows live logs from the embedded local Gateway process.
+- The GUI shows a local storage snapshot (cached deals/files/bytes) from the sidecar uploads directory.
 - Main actions manage the local Gateway lifecycle (`Connect`, `Start gateway`, `Stop`), with API smoke actions behind **Advanced (experimental)**.
 
 ## Build From Source

--- a/nil_gateway_gui/src-tauri/src/lib.rs
+++ b/nil_gateway_gui/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ use api::{
     SignedIntentRequest,
 };
 use bridge::{BridgeManager, BridgeStartResponse};
-use sidecar::{GatewayConfig, SidecarManager};
+use sidecar::{GatewayConfig, GatewayStorageSummary, SidecarManager};
 use std::sync::Arc;
 use tauri::{AppHandle, State};
 
@@ -158,6 +158,14 @@ async fn deal_fetch_file(
         .await
 }
 
+#[tauri::command]
+async fn gateway_local_storage(
+    app: AppHandle,
+    _state: State<'_, AppState>,
+) -> Result<GatewayStorageSummary, String> {
+    sidecar::local_storage_summary(&app)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // On some Linux GPU stacks (notably mixed/transitioning NVIDIA setups),
@@ -179,6 +187,7 @@ pub fn run() {
             gateway_stop,
             gateway_status,
             gateway_attach,
+            gateway_local_storage,
             wallet_bridge_start,
             wallet_bridge_wait,
             deal_upload_file,

--- a/nil_gateway_gui/src-tauri/src/sidecar.rs
+++ b/nil_gateway_gui/src-tauri/src/sidecar.rs
@@ -1,12 +1,12 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager};
 
 const DEFAULT_LISTEN_ADDR: &str = "127.0.0.1:8080";
@@ -23,6 +23,43 @@ pub struct GatewayConfig {
 pub struct GatewayStartResponse {
     pub base_url: String,
     pub pid: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayStorageFileEntry {
+    pub relative_path: String,
+    pub size_bytes: u64,
+    pub modified_unix: i64,
+    pub deal_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayStorageDealEntry {
+    pub deal_id: String,
+    pub file_count: u64,
+    pub total_bytes: u64,
+    pub manifest_count: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayStorageSummary {
+    pub gateway_dir: String,
+    pub uploads_dir: String,
+    pub session_db_path: String,
+    pub session_db_exists: bool,
+    pub total_files: u64,
+    pub total_bytes: u64,
+    pub deal_count: u64,
+    pub manifest_count: u64,
+    pub deal_entries: Vec<GatewayStorageDealEntry>,
+    pub recent_files: Vec<GatewayStorageFileEntry>,
+}
+
+#[derive(Debug, Clone)]
+struct GatewayStoragePaths {
+    gateway_dir: PathBuf,
+    uploads_dir: PathBuf,
+    session_db_path: PathBuf,
 }
 
 pub struct SidecarManager {
@@ -340,25 +377,18 @@ fn configure_sidecar_runtime_env_for_bin_dir(cmd: &mut Command, bin_dir: &Path) 
 }
 
 fn configure_sidecar_storage_env(app: &AppHandle, cmd: &mut Command) {
-    let base_dir = app
-        .path()
-        .app_data_dir()
-        .ok()
-        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".nilstore")));
-    let Some(base_dir) = base_dir else {
+    let Some(paths) = resolve_gateway_storage_paths(app) else {
         return;
     };
 
-    let gateway_dir = base_dir.join("gateway");
-    let uploads_dir = gateway_dir.join("uploads");
-    if fs::create_dir_all(&uploads_dir).is_err() {
+    if fs::create_dir_all(&paths.uploads_dir).is_err() {
         return;
     }
 
     // Keep process cwd in a known writable location for any relative fallback paths.
-    cmd.current_dir(&gateway_dir);
-    cmd.env("NIL_UPLOAD_DIR", &uploads_dir);
-    cmd.env("NIL_SESSION_DB_PATH", uploads_dir.join("sessions.db"));
+    cmd.current_dir(&paths.gateway_dir);
+    cmd.env("NIL_UPLOAD_DIR", &paths.uploads_dir);
+    cmd.env("NIL_SESSION_DB_PATH", &paths.session_db_path);
 }
 
 fn configure_sidecar_from_binary_layout(cmd: &mut Command, binary: &str) {
@@ -384,4 +414,156 @@ fn configure_sidecar_from_binary_layout(cmd: &mut Command, binary: &str) {
     }
 
     configure_sidecar_runtime_env_for_bin_dir(cmd, bin_dir);
+}
+
+fn resolve_gateway_storage_paths(app: &AppHandle) -> Option<GatewayStoragePaths> {
+    let base_dir = app
+        .path()
+        .app_data_dir()
+        .ok()
+        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".nilstore")))?;
+
+    let gateway_dir = base_dir.join("gateway");
+    let uploads_dir = gateway_dir.join("uploads");
+    let session_db_path = uploads_dir.join("sessions.db");
+    Some(GatewayStoragePaths {
+        gateway_dir,
+        uploads_dir,
+        session_db_path,
+    })
+}
+
+fn parse_deal_id(parts: &[String]) -> String {
+    if parts.len() >= 2 && parts[0] == "deals" {
+        return parts[1].clone();
+    }
+    "unscoped".to_string()
+}
+
+fn parse_manifest_key(parts: &[String]) -> Option<(String, String)> {
+    if parts.len() >= 3 && parts[0] == "deals" {
+        return Some((parts[1].clone(), parts[2].clone()));
+    }
+    None
+}
+
+pub fn local_storage_summary(app: &AppHandle) -> Result<GatewayStorageSummary, String> {
+    let Some(paths) = resolve_gateway_storage_paths(app) else {
+        return Err("unable to resolve local gateway storage path".to_string());
+    };
+    fs::create_dir_all(&paths.uploads_dir)
+        .map_err(|err| format!("failed to ensure uploads directory exists: {err}"))?;
+
+    #[derive(Default)]
+    struct DealAgg {
+        file_count: u64,
+        total_bytes: u64,
+    }
+
+    let mut total_files: u64 = 0;
+    let mut total_bytes: u64 = 0;
+    let mut deal_aggs: HashMap<String, DealAgg> = HashMap::new();
+    let mut manifest_keys: HashSet<String> = HashSet::new();
+    let mut recent_files: Vec<GatewayStorageFileEntry> = Vec::new();
+
+    let mut stack = vec![paths.uploads_dir.clone()];
+    while let Some(dir) = stack.pop() {
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let meta = match entry.metadata() {
+                Ok(meta) => meta,
+                Err(_) => continue,
+            };
+
+            if meta.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if !meta.is_file() {
+                continue;
+            }
+
+            total_files += 1;
+            let size = meta.len();
+            total_bytes += size;
+
+            let rel = path
+                .strip_prefix(&paths.uploads_dir)
+                .unwrap_or(path.as_path())
+                .to_path_buf();
+            let rel_str = rel.to_string_lossy().to_string();
+            let rel_parts: Vec<String> = rel
+                .iter()
+                .map(|part| part.to_string_lossy().to_string())
+                .collect();
+            let deal_id = parse_deal_id(&rel_parts);
+
+            if let Some((deal, manifest)) = parse_manifest_key(&rel_parts) {
+                manifest_keys.insert(format!("{deal}::{manifest}"));
+            }
+
+            let agg = deal_aggs.entry(deal_id.clone()).or_default();
+            agg.file_count += 1;
+            agg.total_bytes += size;
+
+            let modified_unix = meta
+                .modified()
+                .ok()
+                .and_then(|m| m.duration_since(UNIX_EPOCH).ok())
+                .map(|d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX))
+                .unwrap_or(0);
+
+            recent_files.push(GatewayStorageFileEntry {
+                relative_path: rel_str,
+                size_bytes: size,
+                modified_unix,
+                deal_id,
+            });
+        }
+    }
+
+    let mut manifest_count_by_deal: HashMap<String, u64> = HashMap::new();
+    for key in &manifest_keys {
+        if let Some((deal_id, _)) = key.split_once("::") {
+            *manifest_count_by_deal
+                .entry(deal_id.to_string())
+                .or_insert(0) += 1;
+        }
+    }
+
+    let mut deal_entries: Vec<GatewayStorageDealEntry> = deal_aggs
+        .into_iter()
+        .map(|(deal_id, agg)| GatewayStorageDealEntry {
+            manifest_count: manifest_count_by_deal.get(&deal_id).copied().unwrap_or(0),
+            deal_id,
+            file_count: agg.file_count,
+            total_bytes: agg.total_bytes,
+        })
+        .collect();
+    deal_entries.sort_by(|a, b| {
+        b.total_bytes
+            .cmp(&a.total_bytes)
+            .then_with(|| b.file_count.cmp(&a.file_count))
+            .then_with(|| a.deal_id.cmp(&b.deal_id))
+    });
+
+    recent_files.sort_by(|a, b| b.modified_unix.cmp(&a.modified_unix));
+    recent_files.truncate(12);
+
+    Ok(GatewayStorageSummary {
+        gateway_dir: paths.gateway_dir.to_string_lossy().to_string(),
+        uploads_dir: paths.uploads_dir.to_string_lossy().to_string(),
+        session_db_path: paths.session_db_path.to_string_lossy().to_string(),
+        session_db_exists: paths.session_db_path.exists(),
+        total_files,
+        total_bytes,
+        deal_count: u64::try_from(deal_entries.len()).unwrap_or(u64::MAX),
+        manifest_count: u64::try_from(manifest_keys.len()).unwrap_or(u64::MAX),
+        deal_entries,
+        recent_files,
+    })
 }

--- a/nil_gateway_gui/src-tauri/tauri.conf.json
+++ b/nil_gateway_gui/src-tauri/tauri.conf.json
@@ -13,10 +13,10 @@
     "windows": [
       {
         "title": "nil_gateway_gui",
-        "width": 1240,
-        "height": 860,
-        "minWidth": 1080,
-        "minHeight": 720,
+        "width": 1320,
+        "height": 820,
+        "minWidth": 1120,
+        "minHeight": 700,
         "center": true
       }
     ],

--- a/nil_gateway_gui/src/App.css
+++ b/nil_gateway_gui/src/App.css
@@ -4,13 +4,209 @@
 
 :root {
   color-scheme: light;
+  --ng-ink-900: #0f172a;
+  --ng-ink-700: #334155;
+  --ng-ink-500: #64748b;
+  --ng-line: #dbe5f1;
+  --ng-surface: #ffffff;
+  --ng-accent: #0ea5e9;
+  --ng-accent-soft: #e0f2fe;
+  --ng-success: #16a34a;
+  --ng-success-soft: #dcfce7;
+  --ng-warn: #f59e0b;
+  --ng-warn-soft: #fef3c7;
+  --ng-danger: #dc2626;
+  --ng-danger-soft: #fee2e2;
 }
 
 body {
-  @apply bg-slate-50 text-slate-900;
-  font-family: "Space Grotesk", system-ui, -apple-system, sans-serif;
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f6f9fd 0%, #edf3fa 100%);
+  color: var(--ng-ink-900);
+  font-family:
+    "Avenir Next",
+    "Segoe UI",
+    "SF Pro Text",
+    "Inter",
+    system-ui,
+    -apple-system,
+    sans-serif;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+.gateway-app {
+  position: relative;
+}
+
+.gateway-app::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(560px 210px at 50% -48px, rgba(14, 165, 233, 0.08), transparent 70%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0));
+  z-index: 0;
 }
 
 .surface-card {
-  @apply rounded-2xl border border-slate-200 bg-white/80 shadow-[0_24px_80px_rgba(15,23,42,0.08)] backdrop-blur;
+  position: relative;
+  border-radius: 18px;
+  border: 1px solid #e3ecf6;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.97), rgba(255, 255, 255, 0.9)),
+    var(--ng-surface);
+  box-shadow:
+    0 8px 24px rgba(15, 23, 42, 0.05),
+    0 1px 2px rgba(15, 23, 42, 0.03);
+  backdrop-filter: blur(10px);
+  z-index: 1;
+}
+
+.surface-hero {
+  overflow: hidden;
+}
+
+.surface-hero::after {
+  content: "";
+  position: absolute;
+  right: -80px;
+  top: -120px;
+  width: 340px;
+  height: 340px;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(14, 165, 233, 0.14) 0%, rgba(14, 165, 233, 0) 72%);
+  pointer-events: none;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 9999px;
+  background: currentColor;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.8);
+}
+
+.control-btn {
+  border-radius: 10px;
+  border: 1px solid var(--ng-line);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--ng-ink-700);
+  font-weight: 650;
+  font-size: 13px;
+  line-height: 1;
+  padding: 10px 14px;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    color 140ms ease,
+    transform 140ms ease,
+    box-shadow 140ms ease;
+}
+
+.control-btn:hover {
+  background: #f8fbff;
+  border-color: #cfe0f2;
+}
+
+.control-btn:active {
+  transform: translateY(1px);
+}
+
+.control-btn:disabled {
+  opacity: 0.56;
+  cursor: not-allowed;
+}
+
+.control-btn-primary {
+  background: linear-gradient(180deg, #0f172a 0%, #111f38 100%);
+  border-color: #0f172a;
+  color: #f8fafc;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.14);
+}
+
+.control-btn-primary:hover {
+  background: linear-gradient(180deg, #111f38 0%, #122646 100%);
+  border-color: #122646;
+}
+
+.control-btn-inline {
+  font-size: 12px;
+  padding: 8px 11px;
+}
+
+.meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 9999px;
+  border: 1px solid #d7e8f7;
+  background: rgba(224, 242, 254, 0.72);
+  color: #0b4a6c;
+  font-size: 11px;
+  font-weight: 650;
+  padding: 5px 10px;
+}
+
+.meta-chip strong {
+  color: #0f172a;
+}
+
+.panel-tab {
+  border-radius: 9999px;
+  border: 1px solid var(--ng-line);
+  background: rgba(255, 255, 255, 0.95);
+  color: #475569;
+  font-size: 12px;
+  font-weight: 650;
+  letter-spacing: 0.01em;
+  padding: 8px 13px;
+  transition: all 140ms ease;
+}
+
+.panel-tab:hover {
+  background: #f8fbff;
+  border-color: #cae0f5;
+}
+
+.panel-tab-active {
+  background: linear-gradient(180deg, #0f172a 0%, #142846 100%);
+  border-color: #142846;
+  color: #f8fafc;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.14);
+}
+
+.metric-card {
+  border-radius: 13px;
+  border: 1px solid #e5edf6;
+  background: #ffffff;
+}
+
+.soft-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: #6b7d95;
+}
+
+.log-panel {
+  border-radius: 14px;
+  border: 1px solid #d5e2ef;
+  background: linear-gradient(180deg, #020918 0%, #031029 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.subtle-divider {
+  border-color: #ecf2f8;
 }

--- a/nil_gateway_gui/src/App.test.tsx
+++ b/nil_gateway_gui/src/App.test.tsx
@@ -4,6 +4,6 @@ import App from "./App";
 describe("App shell", () => {
   it("renders the main title", () => {
     render(<App />);
-    expect(screen.getByText("NilGateway GUI")).toBeInTheDocument();
+    expect(screen.getByText("Local Gateway")).toBeInTheDocument();
   });
 });

--- a/nil_gateway_gui/src/App.tsx
+++ b/nil_gateway_gui/src/App.tsx
@@ -1,5 +1,5 @@
 import { open, save } from "@tauri-apps/plugin-dialog";
-import { openUrl } from "@tauri-apps/plugin-opener";
+import { openPath, openUrl } from "@tauri-apps/plugin-opener";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import "./App.css";
@@ -7,12 +7,14 @@ import logoDark from "./assets/nilstore-dark.png";
 import {
   fetchFile,
   gatewayAttach,
+  gatewayLocalStorage,
   gatewayStart,
   gatewayStatus,
   gatewayStop,
   listFiles,
   uploadFile,
   type GatewayFileEntry,
+  type GatewayStorageSummary,
   type GatewayStatusResponse,
   type GatewayUploadResponse,
 } from "./lib/gateway";
@@ -26,12 +28,18 @@ type GatewayPhase =
   | "stopping"
   | "error";
 
+type ReadinessState = "ready" | "pending" | "blocked";
+
 const LOG_BUFFER_LIMIT = 400;
 const STATUS_POLL_MS = 8_000;
+const STORAGE_POLL_MS = 18_000;
 const STARTUP_PROBE_ATTEMPTS = 20;
 const STARTUP_PROBE_DELAY_MS = 250;
 const RECOVERY_FAILURE_THRESHOLD = 2;
 const RECOVERY_COOLDOWN_MS = 20_000;
+const RECENT_DEAL_LIMIT = 6;
+const RECENT_FILE_LIMIT = 8;
+const RECENT_ACTIVITY_LIMIT = 5;
 
 function errorMessage(err: unknown, fallback: string): string {
   if (err instanceof Error && err.message) return err.message;
@@ -41,6 +49,29 @@ function errorMessage(err: unknown, fallback: string): string {
 
 function normalizeListenAddr(baseUrl: string): string {
   return baseUrl.replace(/^https?:\/\//, "").replace(/\/$/, "");
+}
+
+function formatBytes(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0 B";
+  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+  let size = value;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+  const precision = size >= 100 || unitIndex === 0 ? 0 : size >= 10 ? 1 : 2;
+  return `${size.toFixed(precision)} ${units[unitIndex]}`;
+}
+
+function formatUnixTime(unixSeconds: number): string {
+  if (!Number.isFinite(unixSeconds) || unixSeconds <= 0) return "n/a";
+  return new Date(unixSeconds * 1000).toLocaleString();
+}
+
+function toFileUrl(path: string): string {
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  return `file://${encodeURI(normalized)}`;
 }
 
 function hostFromBaseUrl(value: string): string {
@@ -88,6 +119,40 @@ function statusLabel(phase: GatewayPhase): string {
   }
 }
 
+function readinessBadgeClass(state: ReadinessState): string {
+  if (state === "ready") return "bg-emerald-100 text-emerald-700";
+  if (state === "pending") return "bg-amber-100 text-amber-700";
+  return "bg-rose-100 text-rose-700";
+}
+
+function readinessLabel(state: ReadinessState): string {
+  if (state === "ready") return "Ready";
+  if (state === "pending") return "In progress";
+  return "Needs attention";
+}
+
+async function copyToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textArea = document.createElement("textarea");
+  textArea.value = text;
+  textArea.style.position = "fixed";
+  textArea.style.top = "-9999px";
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+  try {
+    if (!document.execCommand("copy")) {
+      throw new Error("copy command returned false");
+    }
+  } finally {
+    document.body.removeChild(textArea);
+  }
+}
+
 export default function App() {
   const [gatewayBaseUrl, setGatewayBaseUrl] = useState("http://127.0.0.1:8080");
   const [gateway, setGateway] = useState<GatewayStatusResponse | null>(null);
@@ -96,6 +161,8 @@ export default function App() {
   const [statusDetail, setStatusDetail] = useState<string | null>(null);
   const [actionBusy, setActionBusy] = useState(false);
   const [lastStatusAt, setLastStatusAt] = useState<number | null>(null);
+  const [diagCopyBusy, setDiagCopyBusy] = useState(false);
+  const [diagCopyMessage, setDiagCopyMessage] = useState<string | null>(null);
   const [logs, setLogs] = useState<string[]>([]);
   const [autoScrollLogs, setAutoScrollLogs] = useState(true);
   const [showAdvanced, setShowAdvanced] = useState(false);
@@ -118,6 +185,13 @@ export default function App() {
   const [listError, setListError] = useState<string | null>(null);
   const [downloadBusy, setDownloadBusy] = useState<string | null>(null);
   const [downloadError, setDownloadError] = useState<string | null>(null);
+  const [storageSummary, setStorageSummary] = useState<GatewayStorageSummary | null>(null);
+  const [storageError, setStorageError] = useState<string | null>(null);
+  const [storageLastAt, setStorageLastAt] = useState<number | null>(null);
+  const [storageBusy, setStorageBusy] = useState(false);
+  const [storageDealFilter, setStorageDealFilter] = useState<string>("all");
+  const [storageFileQuery, setStorageFileQuery] = useState("");
+  const [activePanel, setActivePanel] = useState<"overview" | "storage" | "diagnostics">("overview");
 
   const baseHost = useMemo(() => hostFromBaseUrl(gatewayBaseUrl), [gatewayBaseUrl]);
   const baseIsLoopback = useMemo(() => isLoopbackHost(baseHost), [baseHost]);
@@ -135,6 +209,28 @@ export default function App() {
       return next.slice(next.length - LOG_BUFFER_LIMIT);
     });
   }, []);
+
+  const refreshLocalStorage = useCallback(
+    async (opts?: { silent?: boolean }) => {
+      const silent = opts?.silent ?? false;
+      if (!silent) {
+        setStorageBusy(true);
+      }
+      try {
+        const summary = await gatewayLocalStorage();
+        setStorageSummary(summary);
+        setStorageError(null);
+        setStorageLastAt(Date.now());
+      } catch (err) {
+        setStorageError(errorMessage(err, "Could not read local storage state."));
+      } finally {
+        if (!silent) {
+          setStorageBusy(false);
+        }
+      }
+    },
+    [],
+  );
 
   const applyOnlineStatus = useCallback((status: GatewayStatusResponse) => {
     setGateway(status);
@@ -342,6 +438,22 @@ export default function App() {
     };
   }, [attachAndProbe, gatewayBaseUrl, recoverFromStatusFailure]);
 
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      if (cancelled) return;
+      await refreshLocalStorage({ silent: true });
+    };
+    void tick();
+    const timer = window.setInterval(() => {
+      void tick();
+    }, STORAGE_POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [refreshLocalStorage]);
+
   const handleAttach = async () => {
     setActionBusy(true);
     try {
@@ -394,6 +506,27 @@ export default function App() {
     await openUrl(`${base}${suffix}`);
   };
 
+  const handleOpenCacheDir = async () => {
+    if (!storageSummary?.uploads_dir) return;
+    try {
+      await openPath(storageSummary.uploads_dir);
+      addLog(`Opened cache folder: ${storageSummary.uploads_dir}`);
+      return;
+    } catch (err) {
+      const firstError = errorMessage(err, "openPath failed");
+      addLog(`Open cache folder failed (path): ${firstError}`);
+      try {
+        await openUrl(toFileUrl(storageSummary.uploads_dir));
+        addLog(`Opened cache folder via file URL: ${storageSummary.uploads_dir}`);
+        return;
+      } catch (fallbackErr) {
+        const secondError = errorMessage(fallbackErr, "openUrl fallback failed");
+        setStatusDetail(`Could not open cache folder: ${secondError}`);
+        addLog(`Open cache folder failed (url): ${secondError}`);
+      }
+    }
+  };
+
   const handlePickFile = async () => {
     const selected = await open({ multiple: false, directory: false });
     if (typeof selected === "string") {
@@ -430,6 +563,7 @@ export default function App() {
       if (!listDealId) setListDealId(uploadDealId);
       if (!listOwner) setListOwner(uploadOwner);
       addLog(`Uploaded ${response.filename} -> ${response.manifest_root.slice(0, 18)}...`);
+      void refreshLocalStorage({ silent: true });
     } catch (err) {
       const msg = errorMessage(err, "Upload failed");
       setUploadError(msg);
@@ -495,6 +629,7 @@ export default function App() {
         output_path: outputPath,
       });
       addLog(`Downloaded ${entry.path}`);
+      void refreshLocalStorage({ silent: true });
     } catch (err) {
       const msg = errorMessage(err, "Download failed");
       setDownloadError(msg);
@@ -521,367 +656,797 @@ export default function App() {
     return enabled.length > 0 ? enabled.join(", ") : "None enabled";
   }, [gateway]);
 
+  const storageDealEntries = useMemo(
+    () => (storageSummary?.deal_entries ?? []).slice(0, RECENT_DEAL_LIMIT),
+    [storageSummary],
+  );
+
+  const storageRecentFiles = useMemo(
+    () => (storageSummary?.recent_files ?? []).slice(0, RECENT_FILE_LIMIT),
+    [storageSummary],
+  );
+
+  const filteredStorageDealEntries = useMemo(
+    () =>
+      storageDealFilter === "all"
+        ? storageDealEntries
+        : storageDealEntries.filter((deal) => deal.deal_id === storageDealFilter),
+    [storageDealEntries, storageDealFilter],
+  );
+
+  const filteredStorageRecentFiles = useMemo(() => {
+    const query = storageFileQuery.trim().toLowerCase();
+    return storageRecentFiles.filter((file) => {
+      if (storageDealFilter !== "all" && file.deal_id !== storageDealFilter) {
+        return false;
+      }
+      if (!query) return true;
+      return file.relative_path.toLowerCase().includes(query);
+    });
+  }, [storageDealFilter, storageFileQuery, storageRecentFiles]);
+
+  const dependencyIssues = useMemo(() => {
+    const issues: string[] = [];
+    if (gateway?.deps?.lcd_reachable === false) {
+      issues.push("LCD unreachable: chain queries and deal checks may fail.");
+    }
+    if (gateway?.deps?.sp_reachable === false) {
+      issues.push("Storage provider unreachable: uploads/retrieval may route to browser fallback.");
+    }
+    return issues;
+  }, [gateway?.deps]);
+
+  const readinessItems = useMemo(
+    () =>
+      [
+        {
+          key: "gateway",
+          title: "Gateway process",
+          state:
+            phase === "online"
+              ? "ready"
+              : phase === "booting" || phase === "starting" || phase === "checking"
+                ? "pending"
+                : "blocked",
+          detail:
+            phase === "online"
+              ? gateway?.listening_addr || "Listening"
+              : "Start or reconnect the local Gateway process",
+        },
+        {
+          key: "chain",
+          title: "Chain connectivity",
+          state:
+            gateway?.deps?.lcd_reachable === true
+              ? "ready"
+              : gateway?.deps?.lcd_reachable === false
+                ? "blocked"
+                : phase === "online"
+                  ? "pending"
+                  : "blocked",
+          detail:
+            gateway?.deps?.lcd_reachable === true
+              ? "LCD reachable"
+              : "Gateway cannot reach LCD endpoint",
+        },
+        {
+          key: "providers",
+          title: "Storage providers",
+          state:
+            gateway?.deps?.sp_reachable === true
+              ? "ready"
+              : gateway?.deps?.sp_reachable === false
+                ? "blocked"
+                : phase === "online"
+                  ? "pending"
+                  : "blocked",
+          detail:
+            gateway?.deps?.sp_reachable === true
+              ? "Provider paths reachable"
+              : "Provider path check failed",
+        },
+      ] as Array<{ key: string; title: string; state: ReadinessState; detail: string }>,
+    [gateway?.deps?.lcd_reachable, gateway?.deps?.sp_reachable, gateway?.listening_addr, phase],
+  );
+
+  const readinessCounts = useMemo(
+    () => ({
+      ready: readinessItems.filter((item) => item.state === "ready").length,
+      pending: readinessItems.filter((item) => item.state === "pending").length,
+      blocked: readinessItems.filter((item) => item.state === "blocked").length,
+    }),
+    [readinessItems],
+  );
+
+  const recentActivity = useMemo(() => logs.slice(-RECENT_ACTIVITY_LIMIT).reverse(), [logs]);
+
   const formFieldClass =
-    "w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700";
+    "w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)]";
+
+  const handleCopyDiagnostics = useCallback(async () => {
+    setDiagCopyBusy(true);
+    try {
+      const payload = {
+        generated_at: new Date().toISOString(),
+        ui: {
+          phase,
+          phase_message: phaseMessage,
+          status_detail: statusDetail,
+          auto_start: autoStartEnabled,
+          gateway_base_url: gatewayBaseUrl,
+          last_status_at: lastStatusAt,
+          storage_last_at: storageLastAt,
+        },
+        readiness: readinessItems,
+        gateway_status: gateway,
+        storage_summary: storageSummary,
+        tail_logs: logs.slice(-40),
+      };
+      await copyToClipboard(JSON.stringify(payload, null, 2));
+      setDiagCopyMessage("Diagnostics copied.");
+      addLog("Copied diagnostics snapshot to clipboard.");
+    } catch (err) {
+      const msg = errorMessage(err, "Failed to copy diagnostics.");
+      setDiagCopyMessage(msg);
+      addLog(`Diagnostics copy failed: ${msg}`);
+    } finally {
+      setDiagCopyBusy(false);
+      window.setTimeout(() => setDiagCopyMessage(null), 3000);
+    }
+  }, [
+    addLog,
+    autoStartEnabled,
+    gateway,
+    gatewayBaseUrl,
+    lastStatusAt,
+    logs,
+    phase,
+    phaseMessage,
+    readinessItems,
+    statusDetail,
+    storageLastAt,
+    storageSummary,
+  ]);
+
+  const isConnecting =
+    phase === "booting" || phase === "checking" || phase === "starting" || phase === "stopping";
+
+  const tabButtonClass = (panel: "overview" | "storage" | "diagnostics") =>
+    [
+      "panel-tab",
+      activePanel === panel ? "panel-tab-active" : "",
+    ].join(" ");
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-sky-100">
-      <div className="mx-auto max-w-7xl space-y-6 p-6">
-        <header className="surface-card p-6">
+    <div className="gateway-app min-h-screen">
+      <div className="mx-auto max-w-6xl space-y-5 px-5 py-6">
+        <header className="surface-card surface-hero p-6">
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div className="min-w-0">
               <div className="flex items-center gap-3">
                 <img
                   src={logoDark}
                   alt="NilStore"
-                  className="h-10 w-10 rounded-full border border-slate-200 bg-white/80 p-1"
+                  className="h-10 w-10 rounded-full border border-slate-200 bg-white p-1 shadow-sm"
                 />
                 <div>
-                  <p className="text-xs uppercase tracking-[0.2em] text-slate-400">NilStore</p>
-                  <h1 className="text-2xl font-semibold text-slate-900">NilGateway GUI</h1>
+                  <p className="soft-label">NilStore</p>
+                  <h1 className="text-[34px] font-semibold leading-none text-slate-900">Local Gateway</h1>
                 </div>
               </div>
-              <p className="mt-2 text-sm text-slate-500">
-                Local Gateway manager for `https://nilstore.org/#/dashboard`.
+              <p className="mt-2 max-w-2xl text-sm text-slate-600">
+                Keep your local Gateway ready for uploads and retrievals in the NilStore dashboard.
               </p>
             </div>
 
             <div className="flex flex-wrap items-center gap-2">
-              <span
-                className={`rounded-full px-3 py-1 text-xs font-semibold ${statusBadgeClass(phase)}`}
-              >
+              <span className={`status-pill rounded-full px-3 py-1 text-xs font-semibold ${statusBadgeClass(phase)}`}>
+                <span className="status-dot" />
                 {statusLabel(phase)}
               </span>
               <button
                 type="button"
-                className="rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50"
-                onClick={handleOpenDashboard}
-              >
-                Open NilStore Dashboard
-              </button>
-              <button
-                type="button"
-                className="rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 disabled:opacity-60"
-                onClick={handleAttach}
-                disabled={actionBusy}
-              >
-                Connect
-              </button>
-              <button
-                type="button"
-                className="rounded-lg bg-slate-900 px-3 py-2 text-xs font-semibold text-white transition hover:bg-slate-800 disabled:opacity-60"
-                onClick={handleStart}
-                disabled={actionBusy || phase === "online" || phase === "starting"}
-              >
-                Start gateway
-              </button>
-              <button
-                type="button"
-                className="rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 disabled:opacity-60"
-                onClick={handleStop}
-                disabled={actionBusy || phase === "offline" || phase === "booting" || phase === "stopping"}
-              >
-                Stop
-              </button>
-            </div>
-          </div>
-
-          <div className="mt-4 grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
-            <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
-              Local Gateway URL
-              <input
-                className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm normal-case tracking-normal text-slate-700"
-                value={gatewayBaseUrl}
-                onChange={(event) => setGatewayBaseUrl(event.target.value)}
-              />
-            </label>
-
-            <div className="flex items-end">
-              <button
-                type="button"
-                className="rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 disabled:opacity-60"
+                className="control-btn control-btn-primary"
                 onClick={() => {
-                  void ensureGateway({ startIfOffline: false });
+                  if (phase === "online") {
+                    void handleOpenDashboard();
+                    return;
+                  }
+                  void handleStart();
                 }}
-                disabled={actionBusy}
+                disabled={actionBusy || isConnecting}
               >
-                Refresh status
+                {phase === "online"
+                  ? "Open NilStore Dashboard"
+                  : isConnecting
+                    ? "Connecting..."
+                    : "Start local Gateway"}
+              </button>
+              <button
+                type="button"
+                className="control-btn"
+                onClick={() => setActivePanel("diagnostics")}
+              >
+                Diagnostics
               </button>
             </div>
           </div>
 
-          <div className="mt-4 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700">
-            <p className="font-medium">{phaseMessage}</p>
-            {statusDetail ? <p className="mt-1 text-xs text-slate-500">Detail: {statusDetail}</p> : null}
-            {lastStatusAt ? (
-              <p className="mt-1 text-xs text-slate-500">
-                Last status check: {new Date(lastStatusAt).toLocaleTimeString()}
-              </p>
-            ) : null}
+          <div className="mt-4 rounded-xl border subtle-divider bg-white/90 px-4 py-3">
+            <p className="text-sm font-semibold text-slate-800">{phaseMessage}</p>
+            {statusDetail ? <p className="mt-1 text-xs text-slate-500">{statusDetail}</p> : null}
             <p className="mt-1 text-xs text-slate-500">
-              Auto-start: {autoStartEnabled ? "enabled" : "paused"}
+              {readinessCounts.ready}/3 checks ready
+              {readinessCounts.blocked > 0
+                ? ` · ${readinessCounts.blocked} needs attention`
+                : readinessCounts.pending > 0
+                  ? ` · ${readinessCounts.pending} in progress`
+                  : " · system healthy"}
+              {lastStatusAt ? ` · checked ${new Date(lastStatusAt).toLocaleTimeString()}` : ""}
             </p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              <span className="meta-chip">
+                <strong>Endpoint</strong> {gatewayBaseUrl}
+              </span>
+              <span className="meta-chip">
+                <strong>Mode</strong> {gateway?.mode || "standalone"}
+              </span>
+              <span className="meta-chip">
+                <strong>Auto-start</strong> {autoStartEnabled ? "enabled" : "paused"}
+              </span>
+            </div>
+            {diagCopyMessage ? (
+              <p className="mt-1 text-xs font-semibold text-emerald-700">{diagCopyMessage}</p>
+            ) : null}
           </div>
 
           {!baseIsLoopback ? (
             <div className="mt-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
-              Non-local endpoint configured. The website expects local Gateway routing on localhost; use `http://127.0.0.1:8080` unless you are intentionally debugging remote gateway access.
+              Non-local endpoint configured. Use `http://127.0.0.1:8080` for normal local Gateway flows.
             </div>
           ) : null}
         </header>
 
-        <section className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
-          <div className="surface-card p-6">
-            <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-500">
-              Local Gateway health
-            </h2>
+        <section className="surface-card p-5">
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              className={tabButtonClass("overview")}
+              onClick={() => setActivePanel("overview")}
+            >
+              Overview
+            </button>
+            <button
+              type="button"
+              className={tabButtonClass("storage")}
+              onClick={() => setActivePanel("storage")}
+            >
+              Storage
+            </button>
+            <button
+              type="button"
+              className={tabButtonClass("diagnostics")}
+              onClick={() => setActivePanel("diagnostics")}
+            >
+              Diagnostics
+            </button>
+          </div>
 
-            <div className="mt-4 grid gap-3 sm:grid-cols-2">
-              <div className="rounded-xl border border-slate-200 bg-white p-3">
-                <p className="text-xs uppercase tracking-wide text-slate-500">Listening</p>
-                <p className="mt-1 text-sm font-semibold text-slate-900">
-                  {gateway?.listening_addr || "—"}
+          {activePanel === "overview" ? (
+            <div className="mt-4 space-y-4">
+              <div className="grid gap-3 md:grid-cols-3">
+                {readinessItems.map((item) => (
+                  <div key={item.key} className="metric-card px-3 py-3">
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="soft-label">{item.title}</p>
+                      <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${readinessBadgeClass(item.state)}`}>
+                        {readinessLabel(item.state)}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-sm text-slate-700">{item.detail}</p>
+                  </div>
+                ))}
+              </div>
+
+              {dependencyIssues.length > 0 ? (
+                <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+                  {dependencyIssues.map((issue) => (
+                    <p key={issue}>{issue}</p>
+                  ))}
+                </div>
+              ) : null}
+
+              <div className="metric-card">
+                <div className="border-b subtle-divider px-3 py-2 soft-label">
+                  Recent activity
+                </div>
+                {recentActivity.length === 0 ? (
+                  <p className="px-3 py-3 text-sm text-slate-500">
+                    No recent activity yet.
+                  </p>
+                ) : (
+                  <ul className="space-y-1.5 px-3 py-3">
+                    {recentActivity.map((line, index) => (
+                      <li
+                        key={`activity-${index}-${line}`}
+                        className="list-disc pl-1 text-xs text-slate-600 marker:text-slate-300"
+                      >
+                        {line}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <details className="metric-card bg-slate-50/70 p-3">
+                <summary className="cursor-pointer text-sm font-semibold text-slate-700">
+                  Connection controls
+                </summary>
+                <div className="mt-3 grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
+                  <label className="text-xs font-semibold text-slate-500">
+                    Gateway URL
+                    <input
+                      className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700"
+                      value={gatewayBaseUrl}
+                      onChange={(event) => setGatewayBaseUrl(event.target.value)}
+                    />
+                  </label>
+                  <div className="flex items-end gap-2">
+                    <button
+                      type="button"
+                      className="control-btn control-btn-inline"
+                      onClick={() => void ensureGateway({ startIfOffline: false })}
+                      disabled={actionBusy}
+                    >
+                      Refresh status
+                    </button>
+                    <button
+                      type="button"
+                      className="control-btn control-btn-inline"
+                      onClick={handleAttach}
+                      disabled={actionBusy}
+                    >
+                      Reconnect
+                    </button>
+                    <button
+                      type="button"
+                      className="control-btn control-btn-inline"
+                      onClick={handleStop}
+                      disabled={actionBusy || phase === "offline" || phase === "booting" || phase === "stopping"}
+                    >
+                      Stop
+                    </button>
+                  </div>
+                </div>
+                <p className="mt-2 text-xs text-slate-500">
+                  Auto-start: {autoStartEnabled ? "enabled" : "paused"}
+                </p>
+              </details>
+            </div>
+          ) : null}
+
+          {activePanel === "storage" ? (
+            <div className="mt-4 space-y-4">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+                  <div className="metric-card px-3 py-2">
+                  <p className="soft-label">Deals</p>
+                    <p className="text-sm font-semibold text-slate-900">{storageSummary?.deal_count ?? 0}</p>
+                  </div>
+                  <div className="metric-card px-3 py-2">
+                  <p className="soft-label">Manifests</p>
+                    <p className="text-sm font-semibold text-slate-900">{storageSummary?.manifest_count ?? 0}</p>
+                  </div>
+                  <div className="metric-card px-3 py-2">
+                  <p className="soft-label">Files</p>
+                    <p className="text-sm font-semibold text-slate-900">{storageSummary?.total_files ?? 0}</p>
+                  </div>
+                  <div className="metric-card px-3 py-2">
+                  <p className="soft-label">Disk</p>
+                    <p className="text-sm font-semibold text-slate-900">{formatBytes(storageSummary?.total_bytes ?? 0)}</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    className="control-btn control-btn-inline"
+                    onClick={() => {
+                      void refreshLocalStorage();
+                    }}
+                    disabled={storageBusy}
+                  >
+                    {storageBusy ? "Refreshing..." : "Refresh cache"}
+                  </button>
+                  <button
+                    type="button"
+                    className="control-btn control-btn-inline"
+                    onClick={() => {
+                      void handleOpenCacheDir();
+                    }}
+                    disabled={!storageSummary?.uploads_dir}
+                  >
+                    Open cache folder
+                  </button>
+                </div>
+              </div>
+
+              <div className="grid gap-2 md:grid-cols-[180px_minmax(0,1fr)]">
+                <label className="text-xs font-semibold text-slate-500">
+                  Deal filter
+                  <select
+                    className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-2 py-2 text-sm text-slate-700"
+                    value={storageDealFilter}
+                    onChange={(event) => setStorageDealFilter(event.target.value)}
+                  >
+                    <option value="all">All deals</option>
+                    {storageDealEntries.map((deal) => (
+                      <option key={deal.deal_id} value={deal.deal_id}>
+                        Deal {deal.deal_id}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="text-xs font-semibold text-slate-500">
+                  File search
+                  <input
+                    className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700"
+                    placeholder="Filter cached files by path..."
+                    value={storageFileQuery}
+                    onChange={(event) => setStorageFileQuery(event.target.value)}
+                  />
+                </label>
+              </div>
+
+              {(storageDealFilter !== "all" || storageFileQuery.trim() !== "") ? (
+                <button
+                  type="button"
+                  className="control-btn control-btn-inline"
+                  onClick={() => {
+                    setStorageDealFilter("all");
+                    setStorageFileQuery("");
+                  }}
+                >
+                  Reset filters
+                </button>
+              ) : null}
+
+              {storageError ? (
+                <p className="text-xs text-rose-600">{storageError}</p>
+              ) : null}
+
+              <div className="metric-card px-3 py-2 text-xs text-slate-600">
+                <p className="break-all">
+                  <span className="font-semibold text-slate-700">Uploads dir:</span>{" "}
+                  {storageSummary?.uploads_dir || "n/a"}
+                </p>
+                <p className="break-all">
+                  <span className="font-semibold text-slate-700">Session DB:</span>{" "}
+                  {storageSummary?.session_db_path || "n/a"}{" "}
+                  {storageSummary?.session_db_exists ? "(present)" : "(not created yet)"}
+                </p>
+                <p>
+                  <span className="font-semibold text-slate-700">Last cache scan:</span>{" "}
+                  {storageLastAt ? new Date(storageLastAt).toLocaleTimeString() : "n/a"}
                 </p>
               </div>
-              <div className="rounded-xl border border-slate-200 bg-white p-3">
-                <p className="text-xs uppercase tracking-wide text-slate-500">Mode</p>
-                <p className="mt-1 text-sm font-semibold text-slate-900">{gateway?.mode || "—"}</p>
-              </div>
-              <div className="rounded-xl border border-slate-200 bg-white p-3">
-                <p className="text-xs uppercase tracking-wide text-slate-500">Dependencies</p>
-                <p className="mt-1 text-xs text-slate-700 break-all">{depsSummary}</p>
-              </div>
-              <div className="rounded-xl border border-slate-200 bg-white p-3">
-                <p className="text-xs uppercase tracking-wide text-slate-500">Capabilities</p>
-                <p className="mt-1 text-xs text-slate-700 break-all">{capabilitiesSummary}</p>
+
+              <div className="grid gap-3 lg:grid-cols-2">
+                <div className="metric-card">
+                  <div className="border-b subtle-divider px-3 py-2 soft-label">
+                    Cached deals
+                  </div>
+                  {filteredStorageDealEntries.length === 0 ? (
+                    <div className="px-3 py-3 text-xs text-slate-500">
+                      {storageDealEntries.length === 0
+                        ? "No deal cache folders yet."
+                        : "No deals match the current filter."}
+                    </div>
+                  ) : (
+                    filteredStorageDealEntries.map((deal) => (
+                      <div
+                        key={deal.deal_id}
+                        className="grid grid-cols-[0.7fr_0.7fr_0.7fr_0.7fr_auto] gap-2 border-b border-slate-100 px-3 py-2 text-xs text-slate-700 last:border-b-0"
+                      >
+                        <span className="font-semibold text-slate-900">{deal.deal_id}</span>
+                        <span>{formatBytes(deal.total_bytes)}</span>
+                        <span>{deal.file_count} files</span>
+                        <span>{deal.manifest_count} manifests</span>
+                        <button
+                          type="button"
+                          className="control-btn control-btn-inline px-2 py-1 text-[10px]"
+                          onClick={() => setStorageDealFilter(deal.deal_id)}
+                        >
+                          Focus
+                        </button>
+                      </div>
+                    ))
+                  )}
+                </div>
+
+                <div className="metric-card">
+                  <div className="border-b subtle-divider px-3 py-2 soft-label">
+                    Recent cached files
+                  </div>
+                  {filteredStorageRecentFiles.length === 0 ? (
+                    <div className="px-3 py-3 text-xs text-slate-500">
+                      {storageRecentFiles.length === 0 && storageDealFilter === "all" && !storageFileQuery
+                        ? "No cached files yet."
+                        : "No cached files match this filter/search."}
+                    </div>
+                  ) : (
+                    filteredStorageRecentFiles.map((file) => (
+                      <div
+                        key={`${file.relative_path}-${file.modified_unix}`}
+                        className="border-b border-slate-100 px-3 py-2 text-xs text-slate-700 last:border-b-0"
+                      >
+                        <p className="truncate font-medium text-slate-900">{file.relative_path}</p>
+                        <p className="mt-0.5 text-slate-500">
+                          {formatBytes(file.size_bytes)} · deal {file.deal_id} · {formatUnixTime(file.modified_unix)}
+                        </p>
+                      </div>
+                    ))
+                  )}
+                </div>
               </div>
             </div>
+          ) : null}
 
-            <div className="mt-4 flex flex-wrap gap-2">
-              <button
-                type="button"
-                className="rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50"
-                onClick={() => void handleOpenEndpoint("/health")}
-              >
-                Open /health
-              </button>
-              <button
-                type="button"
-                className="rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50"
-                onClick={() => void handleOpenEndpoint("/status")}
-              >
-                Open /status
-              </button>
-            </div>
-
-            <details className="mt-6 rounded-2xl border border-slate-200 bg-white" open={showAdvanced}>
-              <summary
-                className="cursor-pointer list-none px-4 py-3 text-sm font-semibold text-slate-800"
-                onClick={(e) => {
-                  e.preventDefault();
-                  setShowAdvanced((prev) => !prev);
-                }}
-              >
-                Advanced (experimental): gateway API smoke actions
-              </summary>
-              {showAdvanced ? (
-                <div className="space-y-6 border-t border-slate-100 p-4">
-                  <div>
-                    <p className="text-xs uppercase tracking-[0.16em] text-slate-500">
-                      Upload (gateway/upload)
+          {activePanel === "diagnostics" ? (
+            <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+              <div className="metric-card p-3">
+                <div className="flex items-center justify-between">
+                  <h2 className="soft-label text-slate-600">Live gateway logs</h2>
+                  <div className="flex items-center gap-3 text-xs text-slate-500">
+                    <label className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={autoScrollLogs}
+                        onChange={(event) => setAutoScrollLogs(event.target.checked)}
+                      />
+                      Auto-scroll
+                    </label>
+                    <button
+                      type="button"
+                      className="control-btn control-btn-inline px-2 py-1"
+                      onClick={() => setLogs([])}
+                    >
+                      Clear
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="log-panel mt-3 h-[340px] overflow-auto p-3 font-mono text-xs leading-relaxed text-emerald-200"
+                  ref={(node) => {
+                    if (node && autoScrollLogs) {
+                      node.scrollTop = node.scrollHeight;
+                    }
+                  }}
+                >
+                  {logs.length === 0 ? (
+                    <p className="text-slate-400">
+                      Waiting for gateway logs. Start or connect to the local Gateway to stream output.
                     </p>
-                    <div className="mt-3 grid gap-3 sm:grid-cols-2">
-                      <label className="text-sm text-slate-600">
-                        Deal ID
-                        <input
-                          className={formFieldClass}
-                          value={uploadDealId}
-                          onChange={(event) => setUploadDealId(event.target.value)}
-                        />
-                      </label>
-                      <label className="text-sm text-slate-600">
-                        Owner
-                        <input
-                          className={formFieldClass}
-                          value={uploadOwner}
-                          onChange={(event) => setUploadOwner(event.target.value)}
-                          placeholder="nil1..."
-                        />
-                      </label>
-                      <label className="text-sm text-slate-600">
-                        NilFS path
-                        <input
-                          className={formFieldClass}
-                          value={uploadFilePath}
-                          onChange={(event) => setUploadFilePath(event.target.value)}
-                        />
-                      </label>
-                      <div className="text-sm text-slate-600">
-                        Local file
-                        <div className="mt-2 flex flex-wrap items-center gap-2">
-                          <button
-                            type="button"
-                            className="rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700"
-                            onClick={handlePickFile}
-                          >
-                            Choose file
-                          </button>
-                          <span className="text-xs text-slate-500 break-all">
-                            {localFilePath || "No file selected"}
-                          </span>
+                  ) : (
+                    logs.map((line, index) => <p key={`${index}-${line}`}>{line}</p>)
+                  )}
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <div className="metric-card p-3">
+                  <p className="soft-label">Gateway internals</p>
+                  <div className="mt-2 space-y-1 text-xs text-slate-600">
+                    <p>
+                      <span className="font-semibold text-slate-700">Listening:</span>{" "}
+                      {gateway?.listening_addr || "—"}
+                    </p>
+                    <p>
+                      <span className="font-semibold text-slate-700">Mode:</span> {gateway?.mode || "—"}
+                    </p>
+                    <p className="break-all">
+                      <span className="font-semibold text-slate-700">Dependencies:</span> {depsSummary}
+                    </p>
+                    <p className="break-all">
+                      <span className="font-semibold text-slate-700">Capabilities:</span> {capabilitiesSummary}
+                    </p>
+                    <p className="break-all">
+                      <span className="font-semibold text-slate-700">Provider base:</span>{" "}
+                      {gateway?.provider_base || "Not reported"}
+                    </p>
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      className="control-btn control-btn-inline"
+                      onClick={() => void handleOpenEndpoint("/health")}
+                    >
+                      Open /health
+                    </button>
+                    <button
+                      type="button"
+                      className="control-btn control-btn-inline"
+                      onClick={() => void handleOpenEndpoint("/status")}
+                    >
+                      Open /status
+                    </button>
+                    <button
+                      type="button"
+                      className="control-btn control-btn-inline"
+                      onClick={() => {
+                        void handleCopyDiagnostics();
+                      }}
+                      disabled={diagCopyBusy}
+                    >
+                      {diagCopyBusy ? "Copying..." : "Copy diagnostics"}
+                    </button>
+                  </div>
+                </div>
+
+              </div>
+
+              <details className="metric-card bg-slate-50/70 p-3 lg:col-span-2" open={showAdvanced}>
+                <summary
+                  className="cursor-pointer text-sm font-semibold text-slate-700"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setShowAdvanced((prev) => !prev);
+                  }}
+                >
+                  Advanced API smoke actions
+                </summary>
+                {showAdvanced ? (
+                  <div className="mt-3 space-y-6 border-t subtle-divider pt-3">
+                    <div>
+                      <p className="text-xs font-semibold text-slate-500">Upload (`/gateway/upload`)</p>
+                      <div className="mt-2 grid gap-3 sm:grid-cols-2">
+                        <label className="text-sm text-slate-600">
+                          Deal ID
+                          <input
+                            className={formFieldClass}
+                            value={uploadDealId}
+                            onChange={(event) => setUploadDealId(event.target.value)}
+                          />
+                        </label>
+                        <label className="text-sm text-slate-600">
+                          Owner
+                          <input
+                            className={formFieldClass}
+                            value={uploadOwner}
+                            onChange={(event) => setUploadOwner(event.target.value)}
+                            placeholder="nil1..."
+                          />
+                        </label>
+                        <label className="text-sm text-slate-600">
+                          NilFS path
+                          <input
+                            className={formFieldClass}
+                            value={uploadFilePath}
+                            onChange={(event) => setUploadFilePath(event.target.value)}
+                          />
+                        </label>
+                        <div className="text-sm text-slate-600">
+                          Local file
+                          <div className="mt-2 flex flex-wrap items-center gap-2">
+                            <button
+                              type="button"
+                              className="control-btn control-btn-inline"
+                              onClick={handlePickFile}
+                            >
+                              Choose file
+                            </button>
+                            <span className="text-xs text-slate-500 break-all">
+                              {localFilePath || "No file selected"}
+                            </span>
+                          </div>
                         </div>
                       </div>
-                    </div>
-                    <div className="mt-3 flex flex-wrap items-center gap-2">
-                      <button
-                        type="button"
-                        className="rounded-lg bg-slate-900 px-3 py-2 text-xs font-semibold text-white transition hover:bg-slate-800 disabled:opacity-60"
-                        onClick={handleUpload}
-                        disabled={uploadBusy || phase !== "online"}
-                      >
-                        {uploadBusy ? "Uploading..." : "Upload file"}
-                      </button>
-                      {uploadError ? <span className="text-xs text-rose-600">{uploadError}</span> : null}
-                    </div>
-                    {uploadResponse ? (
-                      <div className="mt-3 rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-700">
-                        Manifest root: {uploadResponse.manifest_root}
+                      <div className="mt-3 flex flex-wrap items-center gap-2">
+                        <button
+                          type="button"
+                          className="control-btn control-btn-primary control-btn-inline"
+                          onClick={handleUpload}
+                          disabled={uploadBusy || phase !== "online"}
+                        >
+                          {uploadBusy ? "Uploading..." : "Upload file"}
+                        </button>
+                        {uploadError ? <span className="text-xs text-rose-600">{uploadError}</span> : null}
                       </div>
-                    ) : null}
-                  </div>
-
-                  <div className="border-t border-slate-100 pt-5">
-                    <p className="text-xs uppercase tracking-[0.16em] text-slate-500">
-                      List & download (gateway/list-files + gateway/fetch)
-                    </p>
-                    <div className="mt-3 grid gap-3 sm:grid-cols-3">
-                      <label className="text-sm text-slate-600">
-                        Manifest root
-                        <input
-                          className={formFieldClass}
-                          value={listManifestRoot}
-                          onChange={(event) => setListManifestRoot(event.target.value)}
-                        />
-                      </label>
-                      <label className="text-sm text-slate-600">
-                        Deal ID
-                        <input
-                          className={formFieldClass}
-                          value={listDealId}
-                          onChange={(event) => setListDealId(event.target.value)}
-                        />
-                      </label>
-                      <label className="text-sm text-slate-600">
-                        Owner
-                        <input
-                          className={formFieldClass}
-                          value={listOwner}
-                          onChange={(event) => setListOwner(event.target.value)}
-                        />
-                      </label>
-                    </div>
-
-                    <div className="mt-3 flex flex-wrap items-center gap-2">
-                      <button
-                        type="button"
-                        className="rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 disabled:opacity-60"
-                        onClick={handleListFiles}
-                        disabled={listBusy || phase !== "online"}
-                      >
-                        {listBusy ? "Listing..." : "List files"}
-                      </button>
-                      {listError ? <span className="text-xs text-rose-600">{listError}</span> : null}
-                      {downloadError ? (
-                        <span className="text-xs text-rose-600">{downloadError}</span>
+                      {uploadResponse ? (
+                        <div className="mt-3 rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-700">
+                          Manifest root: {uploadResponse.manifest_root}
+                        </div>
                       ) : null}
                     </div>
 
-                    <div className="mt-3 rounded-xl border border-slate-200 bg-white">
-                      <div className="grid grid-cols-[1.5fr_0.6fr_0.4fr] gap-3 border-b border-slate-200 px-3 py-2 text-[11px] uppercase tracking-wide text-slate-500">
-                        <span>Path</span>
-                        <span>Bytes</span>
-                        <span>Action</span>
+                    <div className="border-t subtle-divider pt-5">
+                      <p className="text-xs font-semibold text-slate-500">
+                        List and download (`/gateway/list-files` + `/gateway/fetch`)
+                      </p>
+                      <div className="mt-3 grid gap-3 sm:grid-cols-3">
+                        <label className="text-sm text-slate-600">
+                          Manifest root
+                          <input
+                            className={formFieldClass}
+                            value={listManifestRoot}
+                            onChange={(event) => setListManifestRoot(event.target.value)}
+                          />
+                        </label>
+                        <label className="text-sm text-slate-600">
+                          Deal ID
+                          <input
+                            className={formFieldClass}
+                            value={listDealId}
+                            onChange={(event) => setListDealId(event.target.value)}
+                          />
+                        </label>
+                        <label className="text-sm text-slate-600">
+                          Owner
+                          <input
+                            className={formFieldClass}
+                            value={listOwner}
+                            onChange={(event) => setListOwner(event.target.value)}
+                          />
+                        </label>
                       </div>
-                      {files.length === 0 ? (
-                        <div className="px-3 py-4 text-sm text-slate-500">No files listed yet.</div>
-                      ) : (
-                        files.map((entry) => (
-                          <div
-                            key={entry.path}
-                            className="grid grid-cols-[1.5fr_0.6fr_0.4fr] gap-3 border-b border-slate-100 px-3 py-2 text-sm text-slate-700 last:border-b-0"
-                          >
-                            <span className="truncate">{entry.path}</span>
-                            <span>{entry.size_bytes}</span>
-                            <button
-                              type="button"
-                              className="rounded-md border border-slate-200 px-2 py-1 text-xs font-semibold text-slate-700 disabled:opacity-60"
-                              onClick={() => void handleDownload(entry)}
-                              disabled={downloadBusy === entry.path}
+
+                      <div className="mt-3 flex flex-wrap items-center gap-2">
+                        <button
+                          type="button"
+                          className="control-btn control-btn-inline"
+                          onClick={handleListFiles}
+                          disabled={listBusy || phase !== "online"}
+                        >
+                          {listBusy ? "Listing..." : "List files"}
+                        </button>
+                        {listError ? <span className="text-xs text-rose-600">{listError}</span> : null}
+                        {downloadError ? <span className="text-xs text-rose-600">{downloadError}</span> : null}
+                      </div>
+
+                      <div className="metric-card mt-3">
+                        <div className="grid grid-cols-[1.5fr_0.6fr_0.4fr] gap-3 border-b subtle-divider px-3 py-2 text-[11px] font-semibold text-slate-500">
+                          <span>Path</span>
+                          <span>Bytes</span>
+                          <span>Action</span>
+                        </div>
+                        {files.length === 0 ? (
+                          <div className="px-3 py-4 text-sm text-slate-500">No files listed yet.</div>
+                        ) : (
+                          files.map((entry) => (
+                            <div
+                              key={entry.path}
+                              className="grid grid-cols-[1.5fr_0.6fr_0.4fr] gap-3 border-b border-slate-100 px-3 py-2 text-sm text-slate-700 last:border-b-0"
                             >
-                              {downloadBusy === entry.path ? "Saving..." : "Download"}
-                            </button>
-                          </div>
-                        ))
-                      )}
+                              <span className="truncate">{entry.path}</span>
+                              <span>{entry.size_bytes}</span>
+                              <button
+                                type="button"
+                                className="control-btn control-btn-inline px-2 py-1"
+                                onClick={() => void handleDownload(entry)}
+                                disabled={downloadBusy === entry.path}
+                              >
+                                {downloadBusy === entry.path ? "Saving..." : "Download"}
+                              </button>
+                            </div>
+                          ))
+                        )}
+                      </div>
                     </div>
+
+                    {gateway ? (
+                      <details className="metric-card bg-slate-50/70 p-3">
+                        <summary className="cursor-pointer text-xs font-semibold text-slate-600">
+                          Raw /status payload
+                        </summary>
+                        <pre className="mt-2 overflow-auto text-[11px] text-slate-700">
+                          {JSON.stringify(gateway, null, 2)}
+                        </pre>
+                      </details>
+                    ) : null}
                   </div>
-
-                  {gateway ? (
-                    <details className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-                      <summary className="cursor-pointer text-xs font-semibold uppercase tracking-wide text-slate-600">
-                        Raw /status payload
-                      </summary>
-                      <pre className="mt-2 overflow-auto text-[11px] text-slate-700">
-                        {JSON.stringify(gateway, null, 2)}
-                      </pre>
-                    </details>
-                  ) : null}
-                </div>
-              ) : null}
-            </details>
-          </div>
-
-          <div className="surface-card flex min-h-[480px] flex-col p-6">
-            <div className="flex items-center justify-between">
-              <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-500">
-                Live gateway logs
-              </h2>
-              <div className="flex items-center gap-3 text-xs text-slate-500">
-                <label className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    checked={autoScrollLogs}
-                    onChange={(event) => setAutoScrollLogs(event.target.checked)}
-                  />
-                  Auto-scroll
-                </label>
-                <button
-                  type="button"
-                  className="rounded-md border border-slate-200 px-2 py-1 text-xs font-semibold text-slate-700"
-                  onClick={() => setLogs([])}
-                >
-                  Clear
-                </button>
-              </div>
+                ) : null}
+              </details>
             </div>
-
-            <div
-              className="mt-3 flex-1 overflow-auto rounded-xl border border-slate-200 bg-slate-950 p-3 font-mono text-xs leading-relaxed text-emerald-200"
-              ref={(node) => {
-                if (node && autoScrollLogs) {
-                  node.scrollTop = node.scrollHeight;
-                }
-              }}
-            >
-              {logs.length === 0 ? (
-                <p className="text-slate-400">
-                  Waiting for gateway logs. Start or connect to the local Gateway to stream output.
-                </p>
-              ) : (
-                logs.map((line, index) => <p key={`${index}-${line}`}>{line}</p>)
-              )}
-            </div>
-          </div>
+          ) : null}
         </section>
       </div>
     </div>

--- a/nil_gateway_gui/src/lib/gateway.ts
+++ b/nil_gateway_gui/src/lib/gateway.ts
@@ -64,6 +64,33 @@ export type GatewayFileEntry = {
   flags: number;
 };
 
+export type GatewayStorageFileEntry = {
+  relative_path: string;
+  size_bytes: number;
+  modified_unix: number;
+  deal_id: string;
+};
+
+export type GatewayStorageDealEntry = {
+  deal_id: string;
+  file_count: number;
+  total_bytes: number;
+  manifest_count: number;
+};
+
+export type GatewayStorageSummary = {
+  gateway_dir: string;
+  uploads_dir: string;
+  session_db_path: string;
+  session_db_exists: boolean;
+  total_files: number;
+  total_bytes: number;
+  deal_count: number;
+  manifest_count: number;
+  deal_entries: GatewayStorageDealEntry[];
+  recent_files: GatewayStorageFileEntry[];
+};
+
 export type GatewayListFilesResponse = {
   manifest_root: string;
   total_size_bytes: number;
@@ -89,6 +116,10 @@ export async function gatewayStart(config?: {
 
 export async function gatewayStatus(): Promise<GatewayStatusResponse> {
   return invoke("gateway_status");
+}
+
+export async function gatewayLocalStorage(): Promise<GatewayStorageSummary> {
+  return invoke("gateway_local_storage");
 }
 
 export async function gatewayStop(): Promise<void> {


### PR DESCRIPTION
## Context from PR1 review
- PR1 approved with follow-ups:
  - launch the GUI at an intentional fixed starting size
  - no manual env flags should be required for normal local usage

## What changed
- set deterministic startup window geometry in Tauri config:
  - width 1240, height 860
  - min width 1080, min height 720
  - centered on launch
- moved local import behavior into sidecar defaults in Rust:
  - `NIL_LOCAL_IMPORT_ENABLED=1`
  - `NIL_LOCAL_IMPORT_ALLOW_ABS=1`
- kept local desktop defaults in one backend place (Rust sidecar), and removed redundant frontend env injection from `App.tsx`
- updated `nil_gateway_gui/README.md` prerequisites and default runtime behavior notes

## Validation
- `npm -C nil_gateway_gui test`
- `npm -C nil_gateway_gui run build`
- `env -u PKG_CONFIG_PATH npm -C nil_gateway_gui run tauri build`
  - `.deb` and `.rpm` bundles produced
  - `AppImage` step failed in this environment during `linuxdeploy` (non-blocking for local `.deb` flow)
- runtime check without manual flags:
  - launched `target/release/nil_gateway_gui` without extra env
  - verified sidecar process env included:
    - `NIL_P2P_ENABLED=0`
    - `NIL_DISABLE_SYSTEM_LIVENESS=1`
    - `NIL_LOCAL_IMPORT_ENABLED=1`
    - `NIL_LOCAL_IMPORT_ALLOW_ABS=1`

## Notes
- Linux GUI runtime already defaults `WEBKIT_DISABLE_DMABUF_RENDERER=1` inside Rust when unset.
