### PR TITLE
Devnet chain-id sync: 20260211 + dynamic EVM chain id

### DIFF
--- a/docs/TRUSTED_DEVNET_COLLABORATOR_PACKET.md
+++ b/docs/TRUSTED_DEVNET_COLLABORATOR_PACKET.md
@@ -18,7 +18,7 @@ If you are the hub operator, also read: `docs/TRUSTED_DEVNET_SOFT_LAUNCH.md`.
 You should receive:
 - Website URL: `https://web.<domain>`
 - EVM RPC: `https://evm.<domain>`
-- Chain ID: `<chain-id>` (e.g. `31337`)
+- Chain ID: `<chain-id>` (e.g. `20260211`)
 - Faucet URL (optional): `https://faucet.<domain>/faucet`
 - Faucet auth token (optional): a secret string you paste into the website UI (do **not** share publicly)
 - Local gateway endpoint (optional): `http://localhost:8080`

--- a/docs/TRUSTED_DEVNET_COLLABORATOR_PACKET_NILSTORE_ORG.md
+++ b/docs/TRUSTED_DEVNET_COLLABORATOR_PACKET_NILSTORE_ORG.md
@@ -9,12 +9,12 @@ This is the concrete collaborator packet for the current trusted devnet hub depl
 - Hub RPC: `https://rpc.nilstore.org`
 - Hub LCD: `https://lcd.nilstore.org`
 - Faucet: `https://faucet.nilstore.org/faucet`
-- Chain ID: `31337` (`0x7a69`)
+- Chain ID: `20260211` (`0x1352573`)
 
 Provider public endpoints (Mode 2 `2+1` baseline):
-- `https://sp1.nilstore.org` → provider `nil1tw3q590k5uphtsk9k5ts0vfjynjpep0glx3cqx`
-- `https://sp2.nilstore.org` → provider `nil1989447ygkvh96e2ua2mmmlnmz4q2zv96sh94mq`
-- `https://sp3.nilstore.org` → provider `nil13z0nyrtuwj25eh3zeah75eukagc2epjrqt35ne`
+- `https://sp1.nilstore.org` → provider `nil1jtqzjx7y9kh3un3a86u774mucsq4q3vshh8sr0`
+- `https://sp2.nilstore.org` → provider `nil1w98n98a8gnrwnyz62wfvya9wzvdr92uwz7dssk`
+- `https://sp3.nilstore.org` → provider `nil182f6qy5taazj5fa722p2ut4d0v5j2gkap0dprj`
 
 ## What Collaborators Need From Hub Operator
 
@@ -26,7 +26,7 @@ Provider public endpoints (Mode 2 `2+1` baseline):
 1) Open `https://web.nilstore.org`.
 2) Connect MetaMask and switch to:
 - RPC URL: `https://evm.nilstore.org`
-- Chain ID: `31337`
+- Chain ID: `20260211`
 - Currency: `ATOM`
 3) Fund test address:
 - Use website faucet flow (this deployment may include a preconfigured faucet token), or
@@ -53,7 +53,7 @@ Recommended env bootstrap:
 ```bash
 export HUB_NODE="https://rpc.nilstore.org"
 export HUB_LCD="https://lcd.nilstore.org"
-export CHAIN_ID="31337"
+export CHAIN_ID="20260211"
 export PROVIDER_KEY="provider1"
 export NIL_GATEWAY_SP_AUTH="<shared-secret-from-hub>"
 ```
@@ -69,7 +69,7 @@ scripts/devnet_healthcheck.sh hub \
   --rpc https://rpc.nilstore.org \
   --lcd https://lcd.nilstore.org \
   --evm https://evm.nilstore.org \
-  --gateway http://127.0.0.1:8080 \
+  --gateway http://127.0.0.1:18080 \
   --faucet https://faucet.nilstore.org
 ```
 
@@ -79,7 +79,7 @@ Provider operator baseline:
 scripts/devnet_healthcheck.sh provider \
   --provider https://sp1.nilstore.org \
   --hub-lcd https://lcd.nilstore.org \
-  --provider-addr nil1tw3q590k5uphtsk9k5ts0vfjynjpep0glx3cqx
+  --provider-addr nil1jtqzjx7y9kh3un3a86u774mucsq4q3vshh8sr0
 ```
 
 ## Reporting Template For Issues

--- a/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
+++ b/docs/TRUSTED_DEVNET_SOFT_LAUNCH.md
@@ -382,8 +382,8 @@ npm ci
 VITE_API_BASE=https://faucet.<domain> \
 VITE_LCD_BASE=https://lcd.<domain> \
 VITE_EVM_RPC=https://evm.<domain> \
-VITE_COSMOS_CHAIN_ID=31337 \
-VITE_CHAIN_ID=31337 \
+VITE_COSMOS_CHAIN_ID=20260211 \
+VITE_CHAIN_ID=20260211 \
 VITE_ENABLE_FAUCET=1 \
 # Optional (public/demo convenience): embed faucet auth token in web build.
 # WARNING: anyone with browser access can extract and use this token.
@@ -406,7 +406,7 @@ Note: the canonical list of env vars lives in `nil-website/website-spec.md`.
 In MetaMask → **Add network manually**:
 - Network name: `NilStore Devnet`
 - New RPC URL: `https://evm.<domain>`
-- Chain ID: `31337` (`0x7a69`)
+- Chain ID: `20260211` (`0x1352573`)
 - Currency symbol: `ATOM` (EVM gas denom is `aatom` in the current devnet profile)
 - Block explorer URL: (leave blank)
 

--- a/nil-website/src/config.ts
+++ b/nil-website/src/config.ts
@@ -118,7 +118,8 @@ const FAUCET_ENABLED = (() => {
   // Keep local/dev default off unless explicitly enabled.
   return PUBLIC_DOMAIN !== ''
 })()
-const COSMOS_CHAIN_ID = envString(ENV.VITE_COSMOS_CHAIN_ID) || '31337'
+// Trusted devnet default (Feb 2026 soft launch).
+const COSMOS_CHAIN_ID = envString(ENV.VITE_COSMOS_CHAIN_ID) || '20260211'
 const BRIDGE_ADDRESS = envString(ENV.VITE_BRIDGE_ADDRESS) || '0x0000000000000000000000000000000000000000'
 const NILSTORE_PRECOMPILE =
   envString(ENV.VITE_NILSTORE_PRECOMPILE) || '0x0000000000000000000000000000000000000900'
@@ -132,7 +133,7 @@ export const appConfig = {
   lcdBase: LCD_BASE.replace(/\/$/, ''),
   evmRpc: EVM_RPC.replace(/\/$/, ''),
   walletConnectProjectId: WALLETCONNECT_PROJECT_ID,
-  chainId: Number(ENV.VITE_CHAIN_ID || 31337),
+  chainId: Number(ENV.VITE_CHAIN_ID || 20260211),
   gatewayBase: GATEWAY_BASE.replace(/\/$/, ''),
   spBase: SP_BASE.replace(/\/$/, ''),
   gatewayDisabled: GATEWAY_DISABLED,

--- a/nil-website/website-spec.md
+++ b/nil-website/website-spec.md
@@ -71,9 +71,9 @@ The application uses Vite for building and handling environment variables. Confi
 | `VITE_GATEWAY_BASE` | `http://127.0.0.1:8080` | Local gateway base URL. Non-loopback values are ignored; loopback values are normalized to `127.0.0.1` for consistent browser connectivity. |
 | `VITE_EXPLORER_BASE` | runtime origin or `http://localhost:5173` | Block-explorer URL shown to wallets (`wallet_addEthereumChain`). |
 | `VITE_SP_BASE` | `http://localhost:8082` | Default Storage Provider base for direct uploads/fetches when provider discovery is unavailable. |
-| `VITE_COSMOS_CHAIN_ID` | `31337` | Chain ID for the Cosmos layer. |
+| `VITE_COSMOS_CHAIN_ID` | `20260211` | Chain ID for the Cosmos layer (trusted devnet soft launch default). |
 | `VITE_EVM_RPC` | `http://localhost:8545` | EVM JSON-RPC endpoint (auto-falls back to `https://evm.<domain>` when hosted on matching public domain). |
-| `VITE_CHAIN_ID` | `31337` | Chain ID for the EVM layer. **For shared/public devnets, set a NilStore-specific value (do not reuse `31337`) to avoid collisions with other local chains in MetaMask.** |
+| `VITE_CHAIN_ID` | `20260211` | Chain ID for the EVM layer (trusted devnet soft launch default). For local-only stacks, override explicitly if you keep using `31337`. |
 | `VITE_ENABLE_FAUCET` | auto (`1` on `*.nilstore.org`, else `0`) | Faucet UI/actions override (`1` force on, `0` force off). |
 | `VITE_FAUCET_AUTH_TOKEN` | *(empty)* | Optional build-time faucet auth token. When set, the website sends this token automatically on faucet requests. |
 | `VITE_DEFAULT_RS_K` | `2` | Default RS K used by web deal creation when not explicitly overridden. |

--- a/nilchain/app/app.go
+++ b/nilchain/app/app.go
@@ -16,7 +16,6 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
-	gogogrpc "github.com/cosmos/gogoproto/grpc"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -45,6 +44,7 @@ import (
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	gogogrpc "github.com/cosmos/gogoproto/grpc"
 	icacontrollerkeeper "github.com/cosmos/ibc-go/v10/modules/apps/27-interchain-accounts/controller/keeper"
 	icahostkeeper "github.com/cosmos/ibc-go/v10/modules/apps/27-interchain-accounts/host/keeper"
 	icatypes "github.com/cosmos/ibc-go/v10/modules/apps/27-interchain-accounts/types"
@@ -56,6 +56,7 @@ import (
 	// EVM Imports
 	codecaddress "github.com/cosmos/cosmos-sdk/codec/address"
 	evmante "github.com/cosmos/evm/ante"
+	evmsrvflags "github.com/cosmos/evm/server/flags"
 	feemarket "github.com/cosmos/evm/x/feemarket"
 	feemarketkeeper "github.com/cosmos/evm/x/feemarket/keeper"
 	feemarkettypes "github.com/cosmos/evm/x/feemarket/types"
@@ -63,6 +64,7 @@ import (
 	evmkeeper "github.com/cosmos/evm/x/vm/keeper"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cast"
 
 	"nilchain/docs"
 	nilstoreprecompile "nilchain/precompiles/nilstore"
@@ -161,7 +163,7 @@ func New(
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *App {
 	var (
-		app        = &App{
+		app = &App{
 			appOpts: appOpts,
 			logger:  logger,
 		}
@@ -262,6 +264,13 @@ func New(
 	)
 	app.FeeMarketKeeper = &fmKeeper
 
+	// Read EIP-155 chain ID from app options (CLI flag / app.toml).
+	// Keep 31337 fallback for legacy localhost behavior when unset.
+	evmChainID := cast.ToUint64(appOpts.Get(evmsrvflags.EVMChainID))
+	if evmChainID == 0 {
+		evmChainID = 31337
+	}
+
 	evmKeeper := evmkeeper.NewKeeper(
 		app.appCodec,
 		evmKey,
@@ -274,7 +283,7 @@ func New(
 		app.FeeMarketKeeper,
 		app.ConsensusParamsKeeper,
 		nil, // Erc20Keeper
-		31337,
+		evmChainID,
 		"",
 	)
 	app.EVMKeeper = evmKeeper.WithDefaultEvmCoinInfo(
@@ -297,12 +306,12 @@ func New(
 
 	// Set EVM ante handler using the DI-provided keepers.
 	options := evmante.HandlerOptions{
-		Cdc:               app.appCodec,
-		AccountKeeper:     app.AuthKeeper,
-		BankKeeper:        app.BankKeeper,
-		IBCKeeper:         app.IBCKeeper,
-		FeeMarketKeeper:   app.FeeMarketKeeper,
-		EvmKeeper:         app.EVMKeeper,
+		Cdc:             app.appCodec,
+		AccountKeeper:   app.AuthKeeper,
+		BankKeeper:      app.BankKeeper,
+		IBCKeeper:       app.IBCKeeper,
+		FeeMarketKeeper: app.FeeMarketKeeper,
+		EvmKeeper:       app.EVMKeeper,
 		FeegrantKeeper:  app.FeegrantKeeper,
 		SignModeHandler: app.txConfig.SignModeHandler(),
 		SigGasConsumer:  sdkante.DefaultSigVerificationGasConsumer,

--- a/scripts/build_website_public.sh
+++ b/scripts/build_website_public.sh
@@ -16,7 +16,8 @@ DOMAIN="$1"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WEB_DIR="$ROOT_DIR/nil-website"
 
-CHAIN_ID="${CHAIN_ID:-31337}"
+# Trusted devnet default (Feb 2026 soft launch).
+CHAIN_ID="${CHAIN_ID:-20260211}"
 ENABLE_FAUCET="${ENABLE_FAUCET:-1}"
 FAUCET_AUTH_TOKEN="${FAUCET_AUTH_TOKEN:-${VITE_FAUCET_AUTH_TOKEN:-}}"
 


### PR DESCRIPTION
## Summary\n- make  EVM chain id configurable from app options () instead of hardcoding \n- set trusted-devnet website defaults to chain id \n- update public build helper default chain id to \n- refresh trusted-devnet docs/collaborator packet for chain-id and live provider addresses\n\n## Validation\n- \n- \n- 
> nil-website@0.0.0 prebuild
> npm run wasm:build


> nil-website@0.0.0 wasm:build
> command -v wasm-pack >/dev/null 2>&1 || { echo "wasm-pack not found"; exit 1; }; cd ../nil_core && wasm-pack build --release --target web --out-dir ../nil-website/public/wasm --out-name nil_core


> nil-website@0.0.0 build
> tsc && vite build

vite v5.4.21 building for production...
transforming...
✓ 8147 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                                                    1.03 kB │ gzip:     0.46 kB
dist/assets/commit.worker-CoxG2lcQ.js                              7.03 kB
dist/assets/montserrat-vietnamese-700-normal-DnwGT2D9.woff         7.30 kB
dist/assets/montserrat-vietnamese-800-normal-Chy8GRiB.woff         7.33 kB
dist/assets/montserrat-vietnamese-800-normal-BDwqwvSG.woff2        7.90 kB
dist/assets/montserrat-vietnamese-700-normal-C0x1De3p.woff2        7.90 kB
dist/assets/montserrat-cyrillic-800-normal-B_mUCQ9O.woff          10.92 kB
dist/assets/montserrat-cyrillic-700-normal-BvLYcGP1.woff          10.93 kB
dist/assets/montserrat-cyrillic-700-normal-D-Pqjtdp.woff2         11.16 kB
dist/assets/montserrat-cyrillic-800-normal-DDmpGQGC.woff2         11.18 kB
dist/assets/montserrat-cyrillic-ext-800-normal-mB3PmEeV.woff      12.04 kB
dist/assets/montserrat-cyrillic-ext-700-normal-MyDreaeu.woff2     12.06 kB
dist/assets/montserrat-cyrillic-ext-700-normal-D-Mk2xRJ.woff      12.08 kB
dist/assets/montserrat-cyrillic-ext-800-normal-GOAQXnVZ.woff2     12.14 kB
dist/assets/gateway.worker-C1VzUJD2.js                            13.53 kB
dist/assets/montserrat-latin-700-normal-BdjcYUrC.woff2            18.82 kB
dist/assets/montserrat-latin-800-normal-axpkC1rd.woff2            19.01 kB
dist/assets/montserrat-latin-800-normal-C3dfDxXV.woff             20.66 kB
dist/assets/montserrat-latin-700-normal-BWkrl476.woff             20.67 kB
dist/assets/montserrat-latin-ext-700-normal-BOP2Nhf0.woff2        33.53 kB
dist/assets/montserrat-latin-ext-800-normal-BBvmbyWk.woff2        33.62 kB
dist/assets/montserrat-latin-ext-700-normal-DdDFr05Z.woff         41.34 kB
dist/assets/montserrat-latin-ext-800-normal-Wjq_OapB.woff         41.69 kB
dist/assets/index--IjFPuJu.css                                    94.66 kB │ gzip:    15.68 kB
dist/assets/cursor-CnxhdenE.js                                     0.32 kB │ gzip:     0.25 kB
dist/assets/chevron-left-COgDWStN.js                               0.45 kB │ gzip:     0.31 kB
dist/assets/chevron-top-DjchadHk.js                                0.46 kB │ gzip:     0.31 kB
dist/assets/external-link-Bhf6-IVO.js                              0.46 kB │ gzip:     0.31 kB
dist/assets/chevron-bottom-DzJ6a-O0.js                             0.46 kB │ gzip:     0.31 kB
dist/assets/chevron-right-CgAwAfUg.js                              0.46 kB │ gzip:     0.30 kB
dist/assets/arrow-top-GGyFNFt0.js                                  0.47 kB │ gzip:     0.31 kB
dist/assets/arrow-bottom-Bj4Kg_ki.js                               0.47 kB │ gzip:     0.31 kB
dist/assets/arrow-left-DeiIURrp.js                                 0.47 kB │ gzip:     0.31 kB
dist/assets/arrow-right-BbyqC9Ee.js                                0.47 kB │ gzip:     0.32 kB
dist/assets/off-f53XtVnv.js                                        0.49 kB │ gzip:     0.32 kB
dist/assets/search-BrearY9g.js                                     0.50 kB │ gzip:     0.33 kB
dist/assets/close-WzvyLU9i.js                                      0.50 kB │ gzip:     0.32 kB
dist/assets/all-wallets-cFi8Z96f.js                                0.51 kB │ gzip:     0.29 kB
dist/assets/filters-CvYMKc9M.js                                    0.51 kB │ gzip:     0.30 kB
dist/assets/celo-GEP4TUHG-CenIBYLU.js                              0.51 kB │ gzip:     0.31 kB
dist/assets/Windows-PPTHQER6-BlyV2p7Y.js                           0.52 kB │ gzip:     0.29 kB
dist/assets/info-circle-CV9bQrGD.js                                0.53 kB │ gzip:     0.32 kB
dist/assets/more-B9UlgcC9.js                                       0.55 kB │ gzip:     0.33 kB
dist/assets/refresh-CznJka8f.js                                    0.55 kB │ gzip:     0.35 kB
dist/assets/warning-circle-BQRf2tyG.js                             0.55 kB │ gzip:     0.34 kB
dist/assets/coinPlaceholder-C91JiUg4.js                            0.56 kB │ gzip:     0.38 kB
dist/assets/compass-DOjJwUit.js                                    0.58 kB │ gzip:     0.37 kB
dist/assets/zetachain-TLDS5IPW-Udhyw16T.js                         0.60 kB │ gzip:     0.38 kB
dist/assets/base-OAXLRA4F-CoYTVIiL.js                              0.60 kB │ gzip:     0.33 kB
dist/assets/swapVertical-Uq7mJrsa.js                               0.60 kB │ gzip:     0.37 kB
dist/assets/swapHorizontal-JgauEiZI.js                             0.61 kB │ gzip:     0.36 kB
dist/assets/x-BotEi6nB.js                                          0.63 kB │ gzip:     0.42 kB
dist/assets/cursor-transparent-CP3B1dXk.js                         0.64 kB │ gzip:     0.38 kB
dist/assets/twitterIcon-moz9_9C7.js                                0.64 kB │ gzip:     0.41 kB
dist/assets/mobile-B2YjE8O3.js                                     0.65 kB │ gzip:     0.35 kB
dist/assets/checkmark-bold-Cs3ssBv5.js                             0.71 kB │ gzip:     0.46 kB
dist/assets/hyperevm-VKPAA4SA-CHwraEsx.js                          0.73 kB │ gzip:     0.41 kB
dist/assets/optimism-HAF2GUT7-ec6Nqxs9.js                          0.73 kB │ gzip:     0.38 kB
dist/assets/monad-4KWC6TSS-DVXSkpiz.js                             0.74 kB │ gzip:     0.40 kB
dist/assets/etherscan-CVVZ6Nw5.js                                  0.76 kB │ gzip:     0.48 kB
dist/assets/checkmark-BKibuap6.js                                  0.76 kB │ gzip:     0.50 kB
dist/assets/help-circle-Cinju5pt.js                                0.77 kB │ gzip:     0.46 kB
dist/assets/wallet-KqZkdc1J.js                                     0.78 kB │ gzip:     0.45 kB
dist/assets/plus-DIB72fjj.js                                       0.82 kB │ gzip:     0.45 kB
dist/assets/verify-filled-BEQF_8AZ.js                              0.82 kB │ gzip:     0.50 kB
dist/assets/add-_vGdkn9M.js                                        0.83 kB │ gzip:     0.46 kB
dist/assets/flow-5FQJFCTK-CUie2reO.js                              0.86 kB │ gzip:     0.39 kB
dist/assets/google-w3o0jkrL.js                                     0.87 kB │ gzip:     0.48 kB
dist/assets/three-dots-YK87NBZP.js                                 0.90 kB │ gzip:     0.44 kB
dist/assets/clock-DNzIQ7Y0.js                                      0.90 kB │ gzip:     0.50 kB
dist/assets/baseAccount-44UITRK7-CsjdbWCf.js                       0.90 kB │ gzip:     0.39 kB
dist/assets/disconnect-BA5XIQ4V.js                                 0.95 kB │ gzip:     0.53 kB
dist/assets/index-nibyPLVP.js                                      0.95 kB │ gzip:     0.47 kB
dist/assets/twitch-CP-tiI9W.js                                     0.96 kB │ gzip:     0.53 kB
dist/assets/unichain-C5BWO2ZY-BfguYsnu.js                          0.98 kB │ gzip:     0.46 kB
dist/assets/superposition-HG6MMR2Y-bRkgatRO.js                     0.99 kB │ gzip:     0.55 kB
dist/assets/bank-BJwaMWbE.js                                       1.00 kB │ gzip:     0.55 kB
dist/assets/apple-DZA4Fr6z.js                                      1.02 kB │ gzip:     0.56 kB
dist/assets/linea-QRMVQ5DY-DuI3vv0d.js                             1.05 kB │ gzip:     0.47 kB
dist/assets/injectedWallet-AWJSZPMG-Df9x-YJA.js                    1.05 kB │ gzip:     0.48 kB
dist/assets/play-store-CUbLrsSY.js                                 1.06 kB │ gzip:     0.55 kB
dist/assets/farcaster-DwkNhUQ1.js                                  1.07 kB │ gzip:     0.56 kB
dist/assets/zksync-DH7HK5U4-Dt4usFw6.js                            1.11 kB │ gzip:     0.49 kB
dist/assets/arrow-bottom-circle-4XuE1ajI.js                        1.19 kB │ gzip:     0.56 kB
dist/assets/github-BADQ3zqA.js                                     1.19 kB │ gzip:     0.63 kB
dist/assets/swapHorizontalBold-Cr6Ozg9M.js                         1.22 kB │ gzip:     0.65 kB
dist/assets/app-store-B173_Qyp.js                                  1.26 kB │ gzip:     0.71 kB
dist/assets/mail-BZNnj-oX.js                                       1.26 kB │ gzip:     0.68 kB
dist/assets/avalanche-KOMJD3XY-Dsn_JPR4.js                         1.27 kB │ gzip:     0.66 kB
dist/assets/facebook-Dw0Dh8kA.js                                   1.29 kB │ gzip:     0.67 kB
dist/assets/xdc-KJ3TDBYO-DNV6zchh.js                               1.31 kB │ gzip:     0.60 kB
dist/assets/wallet-placeholder-DLU_lKdS.js                         1.32 kB │ gzip:     0.62 kB
dist/assets/desktop-Ae20mvZ2.js                                    1.33 kB │ gzip:     0.67 kB
dist/assets/discord-B9J9MIBN.js                                    1.36 kB │ gzip:     0.68 kB
dist/assets/swapHorizontalMedium-CVB8LPSB.js                       1.36 kB │ gzip:     0.71 kB
dist/assets/ethereum-RGGVA4PY-SWGOlkuk.js                          1.37 kB │ gzip:     0.45 kB
dist/assets/ink-FZMYZWHG-62p-5IK5.js                               1.38 kB │ gzip:     0.61 kB
dist/assets/recycle-horizontal-C6bVbKoB.js                         1.40 kB │ gzip:     0.73 kB
dist/assets/apechain-SX5YFU6N-q5qBv-mp.js                          1.46 kB │ gzip:     0.64 kB
dist/assets/kaia-65D2U3PU-JmuLQ4gC.js                              1.48 kB │ gzip:     0.67 kB
dist/assets/degen-FQQ4XGHB-CeHTs88l.js                             1.49 kB │ gzip:     0.72 kB
dist/assets/extension-NyDizSG0.js                                  1.49 kB │ gzip:     0.73 kB
dist/assets/telegram-D3_hHQgf.js                                   1.51 kB │ gzip:     0.87 kB
dist/assets/swapHorizontalRoundedBold-5aHbUnDN.js                  1.51 kB │ gzip:     0.80 kB
dist/assets/cronos-HJPAQTAE-BEOvlOC4.js                            1.52 kB │ gzip:     0.61 kB
dist/assets/verify-CJl0AEFA.js                                     1.53 kB │ gzip:     0.74 kB
dist/assets/polygon-WW6ZI7PM-DXlmm4L1.js                           1.53 kB │ gzip:     0.63 kB
dist/assets/gravity-J5YQHTYH-Bj6B0uod.js                           1.54 kB │ gzip:     0.74 kB
dist/assets/qr-code-uezyr3ps.js                                    1.57 kB │ gzip:     0.55 kB
dist/assets/bsc-N647EYR2-B2nLKXWV.js                               1.59 kB │ gzip:     0.61 kB
dist/assets/browser-DY6cpEr8.js                                    1.64 kB │ gzip:     0.81 kB
dist/assets/blast-V555OVXZ-BbhJh1tj.js                             1.67 kB │ gzip:     0.73 kB
dist/assets/network-placeholder-B_4SoA2t.js                        1.71 kB │ gzip:     0.76 kB
dist/assets/Chrome-65Q5P54Y-DR9MQEVr.js                            1.72 kB │ gzip:     0.58 kB
dist/assets/gnosis-37ZC4RBL-B137OtHZ.js                            1.80 kB │ gzip:     0.72 kB
dist/assets/id-B6nsCHoQ.js                                         1.81 kB │ gzip:     0.84 kB
dist/assets/nftPlaceholder-BfsjIswh.js                             1.81 kB │ gzip:     0.90 kB
dist/assets/safeWallet-5MNKTR5Z-D-5imDLD.js                        1.82 kB │ gzip:     0.71 kB
dist/assets/walletConnectWallet-YHWKVTDY-D3lyiczV.js               1.88 kB │ gzip:     0.70 kB
dist/assets/Opera-KQZLSACL-Cwv5MDFy.js                             2.10 kB │ gzip:     0.76 kB
dist/assets/info-0iEuAQ8C.js                                       2.32 kB │ gzip:     1.17 kB
dist/assets/exclamation-triangle-BmYXH_0o.js                       2.48 kB │ gzip:     1.17 kB
dist/assets/send-UcN9Ocvb.js                                       2.48 kB │ gzip:     1.31 kB
dist/assets/arbitrum-WURIBY6W-CqVkHBr5.js                          2.59 kB │ gzip:     0.86 kB
dist/assets/scroll-5OBGQVOV-DJFECiai.js                            2.63 kB │ gzip:     1.02 kB
dist/assets/card-imMLosvz.js                                       2.65 kB │ gzip:     1.20 kB
dist/assets/chrome-store-BBq7PnE_.js                               2.65 kB │ gzip:     1.04 kB
dist/assets/reown-logo-CsJeJz7f.js                                 2.66 kB │ gzip:     1.10 kB
dist/assets/ronin-EMCPYXZT-N-QBHZdV.js                             2.67 kB │ gzip:     1.20 kB
dist/assets/ccip-DqNwfF5a.js                                       2.67 kB │ gzip:     1.26 kB
dist/assets/zora-FYL5H3IO-iB4wygST.js                              2.68 kB │ gzip:     0.59 kB
dist/assets/lightbulb-BkIRaNZb.js                                  2.77 kB │ gzip:     1.25 kB
dist/assets/refresh-S4T5V5GX-CwqIaaxK.js                           3.00 kB │ gzip:     0.95 kB
dist/assets/manta-SI27YFEJ-CpVOKa06.js                             3.20 kB │ gzip:     1.33 kB
dist/assets/connect-UA7M4XW6-IY3X6Bmr.js                           3.55 kB │ gzip:     1.08 kB
dist/assets/image-0xi1GTs-.js                                      3.55 kB │ gzip:     1.54 kB
dist/assets/berachain-NJECWIVC-DumxnFvf.js                         3.78 kB │ gzip:     1.25 kB
dist/assets/copy-Di99RiAv.js                                       3.87 kB │ gzip:     1.51 kB
dist/assets/walletconnect-DKOkEbXz.js                              4.12 kB │ gzip:     1.69 kB
dist/assets/hardhat-TX56IT5N-CV1FY-wE.js                           4.20 kB │ gzip:     1.35 kB
dist/assets/Brave-BRAKJXDS-mq-Xo37j.js                             4.26 kB │ gzip:     1.49 kB
dist/assets/create-FASO7PVG-D_rvSpre.js                            4.33 kB │ gzip:     1.09 kB
dist/assets/scan-4UYSQ56Q-CjMz6-XC.js                              4.59 kB │ gzip:     1.16 kB
dist/assets/rainbowWallet-O26YNBMX-DUhYus-9.js                     5.12 kB │ gzip:     0.96 kB
dist/assets/mantle-CKIUT334-DR2WgqzU.js                            5.27 kB │ gzip:     2.25 kB
dist/assets/sign-A7IJEUT5-CGsRnPrd.js                              5.55 kB │ gzip:     4.23 kB
dist/assets/Edge-XSPUTORV-DEoZslQE.js                              5.82 kB │ gzip:     1.34 kB
dist/assets/index-DPlxxy-s.js                                      5.92 kB │ gzip:     2.15 kB
dist/assets/events-CuRpzM7C.js                                     6.14 kB │ gzip:     2.12 kB
dist/assets/Arc-VDBY7LNS-BChRXCXW.js                               6.62 kB │ gzip:     1.62 kB
dist/assets/metaMaskWallet-SITXT2FV-BlemcphV.js                    8.51 kB │ gzip:     1.23 kB
dist/assets/Browser-76IHF3Y2-BMhRaC5Z.js                          11.82 kB │ gzip:     2.18 kB
dist/assets/login-UP3DZBGS-Db_wM5oQ.js                            12.00 kB │ gzip:     2.98 kB
dist/assets/Safari-ZPL37GXR-C4Ggg6rz.js                           13.75 kB │ gzip:     3.75 kB
dist/assets/Firefox-AAHGJQIP-Bp_Hm04m.js                          15.19 kB │ gzip:     3.39 kB
dist/assets/sanko-RHQYXGM5-OX010CbN.js                            21.93 kB │ gzip:    16.45 kB
dist/assets/assets-Q6ZU7ZJ5-P8HioiAD.js                           23.62 kB │ gzip:     4.10 kB
dist/assets/index-CqS1ZB-V.js                                     26.36 kB │ gzip:     7.51 kB
dist/assets/secp256k1-Djfma5Wt.js                                 31.95 kB │ gzip:    12.73 kB
dist/assets/secp256k1-5rSpcZhE.js                                 31.98 kB │ gzip:    12.75 kB
dist/assets/zh_CN-HJBN674C-Baf0GEeT.js                            37.20 kB │ gzip:     5.65 kB
dist/assets/zh_TW-VNNRNXY7-aWfg7Qp4.js                            37.57 kB │ gzip:     5.31 kB
dist/assets/zh_HK-JW3WLRKE-VztJKXL5.js                            37.81 kB │ gzip:     5.36 kB
dist/assets/index-BmhR_rhu.js                                     38.88 kB │ gzip:     9.40 kB
dist/assets/w3m-modal-jP9F9moJ.js                                 40.11 kB │ gzip:     9.41 kB
dist/assets/ko_KR-I2K7AIEP-B5gw8Mwb.js                            42.95 kB │ gzip:     6.40 kB
dist/assets/ja_JP-4WRQ63RX-Ct5pF4ug.js                            43.45 kB │ gzip:     6.46 kB
dist/assets/Macos-MW4AE7LN-Vvm8Drw3.js                            49.68 kB │ gzip:    35.82 kB
dist/assets/ar_AR-44JUQ6EW-BMX-am0v.js                            51.10 kB │ gzip:     6.06 kB
dist/assets/th_TH-3ZQCKCQE-BcHUN2Q4.js                            55.01 kB │ gzip:     7.53 kB
dist/assets/vi_VN-7BUVRNYY-CZ9S75qZ.js                            57.36 kB │ gzip:     5.34 kB
dist/assets/tr_TR-QUPUGMUF-CwpF6ZFn.js                            58.28 kB │ gzip:     5.63 kB
dist/assets/id_ID-KUOB4UAL-K9y-nRWm.js                            58.82 kB │ gzip:     5.39 kB
dist/assets/hi_IN-XSKAA3MF-C3QUpWyP.js                            59.21 kB │ gzip:     7.96 kB
dist/assets/pt_BR-N3XOZ4SV-CvVpfsHb.js                            59.39 kB │ gzip:     5.17 kB
dist/assets/ms_MY-6VZW6Q3Z-BtFD07hR.js                            59.65 kB │ gzip:     5.03 kB
dist/assets/es_419-HRGOJ6VT-D-qzxUM-.js                           59.68 kB │ gzip:     5.53 kB
dist/assets/uk_UA-SSN6SV5E-IlYYyRC6.js                            60.39 kB │ gzip:     6.18 kB
dist/assets/ru_RU-IITAPRET-DOj6Jzj7.js                            61.12 kB │ gzip:     6.85 kB
dist/assets/fr_FR-IGGVC6RM-D8LpUM75.js                            65.14 kB │ gzip:     5.48 kB
dist/assets/de_DE-PYAO5YD6-BWlqPWgO.js                            65.20 kB │ gzip:     5.43 kB
dist/assets/Linux-OO4TNCLJ-B0aw93n9.js                            91.13 kB │ gzip:    14.88 kB
dist/assets/basic-D0iay__j.js                                    143.02 kB │ gzip:    33.14 kB
dist/assets/index-DSBSj3f2.js                                    308.94 kB │ gzip:   117.30 kB
dist/assets/index.es-BMmiThGt.js                                 424.48 kB │ gzip:   120.97 kB
dist/assets/core-BLNTXI6_.js                                     518.45 kB │ gzip:   143.02 kB
dist/assets/metamask-sdk-a6Z41f3g.js                             556.77 kB │ gzip:   170.25 kB
dist/assets/index-DZAECqlM.js                                  4,111.65 kB │ gzip: 1,118.75 kB
✓ built in 22.85s\n- ==> NilStore devnet healthcheck (mode=hub, timeout=5s)
OK: RPC status height=718 catching_up=
OK: LCD node_info (https://lcd.nilstore.org/cosmos/base/tendermint/v1beta1/node_info)
OK: Nilchain params dynamic_pricing_enabled= storage_price=0.000000000000000000 retrieval_price_per_blob={
  "denom": "stake",
  "amount": "1"
}
OK: EVM eth_chainId=0x1352573
OK: Gateway /health (http://127.0.0.1:18080/health)
OK: Faucet /health (https://faucet.nilstore.org/health)
==> Healthcheck OK\n- 