### PR TITLE
feat(cache): enforce gateway/browser manifest freshness

### DIFF
--- a/nil-website/src/components/DealDetail.tsx
+++ b/nil-website/src/components/DealDetail.tsx
@@ -10,7 +10,7 @@ import { DealLivenessHeatmap } from './DealLivenessHeatmap'
 import type { ManifestInfoData, MduKzgData, NilfsFileEntry, SlabLayoutData } from '../domain/nilfs'
 import { buildBlake2sMerkleLayers } from '../lib/merkle'
 import type { LcdDeal } from '../domain/lcd'
-import { deleteCachedFile, hasCachedFile, readCachedFile, readMdu, readManifestRoot, writeCachedFile } from '../lib/storage/OpfsAdapter'
+import { deleteCachedFile, deleteDealDirectory, hasCachedFile, readCachedFile, readMdu, readManifestRoot, writeCachedFile } from '../lib/storage/OpfsAdapter'
 import { parseNilfsFilesFromMdu0 } from '../lib/nilfsLocal'
 import { inferWitnessCountFromOpfs, readNilfsFileFromOpfs } from '../lib/nilfsOpfsFetch'
 import { workerClient } from '../lib/worker-client'
@@ -466,6 +466,30 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
     setTimeout(() => window.URL.revokeObjectURL(url), 1000)
   }
 
+  const reconcileLocalMduCache = useCallback(async (dealId: string, chainManifestRoot: string): Promise<boolean> => {
+    const normalizedChainRoot = String(chainManifestRoot || '').trim().toLowerCase()
+    if (!normalizedChainRoot) return false
+
+    const localManifest = await readManifestRoot(String(dealId)).catch(() => null)
+    if (!localManifest) return false
+
+    const normalizedLocalRoot = localManifest.trim().toLowerCase()
+    if (normalizedLocalRoot === normalizedChainRoot) return true
+
+    try {
+      await deleteDealDirectory(String(dealId))
+      setBrowserCachedByPath({})
+      console.info('Cleared stale browser MDU cache', {
+        dealId,
+        localManifestRoot: normalizedLocalRoot,
+        chainManifestRoot: normalizedChainRoot,
+      })
+    } catch (e) {
+      console.warn('Failed to clear stale browser MDU cache', { dealId, error: e })
+    }
+    return false
+  }, [])
+
   const fetchSlab = useCallback(async (cid: string, dealId?: string, owner?: string) => {
     setLoadingSlab(true)
     try {
@@ -494,8 +518,8 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
       // Fall back to local OPFS slab layout if available (thick client / multi-tab).
       try {
         if (!dealId) return
-        const localManifest = await readManifestRoot(String(dealId)).catch(() => null)
-        if (!localManifest || localManifest.trim() !== cid.trim()) return
+        const canUseLocalSlab = await reconcileLocalMduCache(String(dealId), cid)
+        if (!canUseLocalSlab) return
         const mdu0 = await readMdu(String(dealId), 0)
         if (!mdu0) return
         const localFiles = parseNilfsFilesFromMdu0(mdu0)
@@ -529,7 +553,7 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
     } finally {
       setLoadingSlab(false)
     }
-  }, [fetchSlabLayout, resolveProviderHttpBase, resolveProviderP2pTarget])
+  }, [fetchSlabLayout, resolveProviderHttpBase, resolveProviderP2pTarget, reconcileLocalMduCache])
 
   const fetchFiles = useCallback(async (cid: string, dealId: string, owner: string) => {
     if (!cid || !dealId || !owner) return
@@ -550,9 +574,8 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
         return
       }
 
-      const localManifest = await readManifestRoot(String(dealId)).catch(() => null)
-      if (localManifest && localManifest.trim() !== cid.trim()) {
-        // Local slab doesn't match chain; still show gateway result (empty) to avoid confusion.
+      const canUseLocalSlab = await reconcileLocalMduCache(String(dealId), cid)
+      if (!canUseLocalSlab) {
         setFiles(list)
         return
       }
@@ -569,7 +592,7 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
     } finally {
       setLoadingFiles(false)
     }
-  }, [fetchLocalFiles, resolveProviderHttpBase, resolveProviderP2pTarget, listFilesTransport])
+  }, [fetchLocalFiles, resolveProviderHttpBase, resolveProviderP2pTarget, listFilesTransport, reconcileLocalMduCache])
 
   const fetchManifestInfo = useCallback(async (cid: string, dealId?: string, owner?: string) => {
     setLoadingManifestInfo(true)
@@ -594,9 +617,8 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
       // Local OPFS fallback: compute manifest info from locally stored MDUs.
       try {
         if (!dealId) throw new Error('missing deal id')
-        const localManifest = await readManifestRoot(String(dealId)).catch(() => null)
-        if (!localManifest) throw new Error('missing local manifest root')
-        if (cid && localManifest.trim() !== cid.trim()) throw new Error('local slab does not match chain CID')
+        const canUseLocalSlab = await reconcileLocalMduCache(String(dealId), cid)
+        if (!canUseLocalSlab) throw new Error('local slab not available')
 
         const mdu0 = await readMdu(String(dealId), 0)
         if (!mdu0) throw new Error('missing local MDU #0')
@@ -650,7 +672,7 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
     } finally {
       setLoadingManifestInfo(false)
     }
-  }, [manifestInfoTransport, resolveProviderHttpBase, resolveProviderP2pTarget])
+  }, [manifestInfoTransport, resolveProviderHttpBase, resolveProviderP2pTarget, reconcileLocalMduCache])
 
   async function fetchMduKzg(cid: string, mduIndex: number, dealId?: string, owner?: string) {
     setLoadingMduKzg(true)
@@ -674,9 +696,8 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
       // Local OPFS fallback.
       try {
         if (!dealId) throw new Error('missing deal id')
-        const localManifest = await readManifestRoot(String(dealId)).catch(() => null)
-        if (!localManifest) throw new Error('missing local manifest root')
-        if (cid && localManifest.trim() !== cid.trim()) throw new Error('local slab does not match chain CID')
+        const canUseLocalSlab = await reconcileLocalMduCache(String(dealId), cid)
+        if (!canUseLocalSlab) throw new Error('local slab not available')
 
         const bytes = await readMdu(String(dealId), mduIndex)
         if (!bytes) throw new Error(`missing local MDU #${mduIndex}`)
@@ -1234,14 +1255,12 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
                                         onClick={async () => {
                                           setFileActionError(null)
                                           setBusyFilePath(f.path)
-                                          const dealId = String(deal.id)
-                                          const safeStart = Math.max(0, Number(downloadRangeStart || 0) || 0)
-                                          const safeLen = Math.max(0, Number(downloadRangeLen || 0) || 0)
+                                            const dealId = String(deal.id)
+                                            const safeStart = Math.max(0, Number(downloadRangeStart || 0) || 0)
+                                            const safeLen = Math.max(0, Number(downloadRangeLen || 0) || 0)
                                           try {
                                             const chainCid = String(deal.cid || '').trim()
-                                            const localManifest = await readManifestRoot(dealId).catch(() => null)
-                                            const canUseLocalSlab =
-                                              !!localManifest && !!chainCid && localManifest.trim() === chainCid
+                                            const canUseLocalSlab = await reconcileLocalMduCache(dealId, chainCid)
                                             if (!canUseLocalSlab) throw new Error('local slab not available')
 
                                             const bytes = await readNilfsFileFromOpfs({

--- a/nil_gateway/ingest_mode2.go
+++ b/nil_gateway/ingest_mode2.go
@@ -404,6 +404,7 @@ func mode2BuildArtifacts(ctx context.Context, filePath string, dealID uint64, hi
 	if profile != nil {
 		profile.addDuration("mode2_finalize_dir_ms", time.Since(finalizeStarted))
 	}
+	cleanupStaleDealGenerations(dealID, parsedRoot)
 	rollback = false
 	if job != nil {
 		job.setSteps(totalSteps, totalSteps)
@@ -1150,6 +1151,7 @@ func mode2BuildArtifactsAppend(
 	if profile != nil {
 		profile.addDuration("mode2_finalize_dir_ms", time.Since(finalizeStarted))
 	}
+	cleanupStaleDealGenerations(dealID, parsedRoot)
 	rollback = false
 	if job != nil {
 		job.setSteps(totalSteps, totalSteps)

--- a/nil_gateway/main.go
+++ b/nil_gateway/main.go
@@ -2821,6 +2821,7 @@ func GatewayFetch(w http.ResponseWriter, r *http.Request) {
 	}
 	rawManifestRoot = dealRoot.Canonical
 	manifestRoot = dealRoot
+	cleanupStaleDealGenerations(dealID, manifestRoot)
 
 	serviceHint, serr := fetchDealServiceHintFromLCD(r.Context(), dealID)
 	if serr != nil {
@@ -3738,6 +3739,7 @@ func GatewayListFiles(w http.ResponseWriter, r *http.Request) {
 		)
 		return
 	}
+	cleanupStaleDealGenerations(dealID, manifestRoot)
 
 	dealDir, err := resolveDealDirForDeal(dealID, manifestRoot, rawManifestRoot)
 	if err != nil {
@@ -3793,10 +3795,10 @@ func GatewayListFiles(w http.ResponseWriter, r *http.Request) {
 		name := string(bytes.TrimRight(rec.Path[:], "\x00"))
 		length, flags := crypto_ffi.UnpackLengthAndFlags(rec.LengthAndFlags)
 		entry := nilfsFileEntry{
-			Path:        name,
-			SizeBytes:   length,
-			StartOffset: rec.StartOffset,
-			Flags:       flags,
+			Path:         name,
+			SizeBytes:    length,
+			StartOffset:  rec.StartOffset,
+			Flags:        flags,
 			CachePresent: true,
 		}
 		if hdr, ok, err := readNilceHeaderForNilfsFile(dealDir, slabStartIdx, rec.StartOffset, length); err == nil && ok {
@@ -3905,6 +3907,7 @@ func GatewaySlab(w http.ResponseWriter, r *http.Request) {
 			)
 			return
 		}
+		cleanupStaleDealGenerations(dealID, manifestRoot)
 	}
 
 	var dealDir string

--- a/nil_gateway/manifest_root.go
+++ b/nil_gateway/manifest_root.go
@@ -4,10 +4,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	gnarkBls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 )
@@ -108,4 +110,69 @@ func resolveDealDirForDeal(dealID uint64, root ManifestRoot, rawParam string) (s
 		return cand, nil
 	}
 	return resolveDealDir(root, rawParam)
+}
+
+func isManifestRootDirName(name string) bool {
+	if len(name) != 96 {
+		return false
+	}
+	_, err := hex.DecodeString(name)
+	return err == nil
+}
+
+func cleanupStaleDealGenerations(dealID uint64, keepRoot ManifestRoot) {
+	baseDealDir := filepath.Join(uploadDir, "deals", strconv.FormatUint(dealID, 10))
+	entries, err := os.ReadDir(baseDealDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Printf("Gateway cache cleanup: failed to list deal dir deal_id=%d err=%v", dealID, err)
+		}
+		return
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := strings.TrimSpace(entry.Name())
+		if name == "" || name == keepRoot.Key {
+			continue
+		}
+		if strings.HasPrefix(name, "staging-") || strings.HasPrefix(name, ".") {
+			continue
+		}
+		if !isManifestRootDirName(name) {
+			continue
+		}
+
+		srcDir := filepath.Join(baseDealDir, name)
+		quarantineDir := filepath.Join(baseDealDir, fmt.Sprintf(".gc-%s-%d", name, time.Now().UnixNano()))
+		if err := os.Rename(srcDir, quarantineDir); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			log.Printf(
+				"Gateway cache cleanup: failed to quarantine stale generation deal_id=%d stale_manifest_root=%s err=%v",
+				dealID,
+				name,
+				err,
+			)
+			continue
+		}
+		if err := os.RemoveAll(quarantineDir); err != nil && !os.IsNotExist(err) {
+			log.Printf(
+				"Gateway cache cleanup: failed to remove stale generation deal_id=%d stale_manifest_root=%s err=%v",
+				dealID,
+				name,
+				err,
+			)
+			continue
+		}
+		log.Printf(
+			"Gateway cache cleanup: removed stale generation deal_id=%d stale_manifest_root=%s keep_manifest_root=%s",
+			dealID,
+			name,
+			keepRoot.Key,
+		)
+	}
 }


### PR DESCRIPTION
## Summary
- enforce deal-scoped gateway cache freshness on download/list/slab paths by validating against on-chain manifest root and pruning stale slab generations
- keep Mode 2 artifact finalization atomic, then perform stale-generation GC after successful finalize (both initial and append ingest)
- add browser OPFS MDU cache reconciliation in Deal Detail: stale local manifest roots are cleared before local MDU fallback is used

## Why
- guarantees gateway serves only cache content that matches current on-chain manifest root
- removes stale local gateway generations after content updates
- prevents browser OPFS MDU fallbacks from using stale slab generations after deal content changes

## Validation
- `npm run build` in `nil-website`
- `LD_LIBRARY_PATH=/home/mikers/dev/nil-store/nil-store/nil_core/target/release:$LD_LIBRARY_PATH go test ./... -run "(Mode2ArtifactsV1|GatewayListFiles|GatewaySlab|GatewayFetch|IngestMode2Finalize|Mode2IntegrationMinimal)" -count=1` in `nil_gateway`
