### PR TITLE
feat(cache): add canonical slab metadata generation layout

### DIFF
--- a/nil-website/src/components/DealDetail.tsx
+++ b/nil-website/src/components/DealDetail.tsx
@@ -10,7 +10,7 @@ import { DealLivenessHeatmap } from './DealLivenessHeatmap'
 import type { ManifestInfoData, MduKzgData, NilfsFileEntry, SlabLayoutData } from '../domain/nilfs'
 import { buildBlake2sMerkleLayers } from '../lib/merkle'
 import type { LcdDeal } from '../domain/lcd'
-import { deleteCachedFile, deleteDealDirectory, hasCachedFile, readCachedFile, readMdu, readManifestRoot, writeCachedFile } from '../lib/storage/OpfsAdapter'
+import { deleteCachedFile, deleteDealDirectory, hasCachedFile, readCachedFile, readMdu, readManifestRoot, readSlabMetadata, writeCachedFile } from '../lib/storage/OpfsAdapter'
 import { parseNilfsFilesFromMdu0 } from '../lib/nilfsLocal'
 import { inferWitnessCountFromOpfs, readNilfsFileFromOpfs } from '../lib/nilfsOpfsFetch'
 import { workerClient } from '../lib/worker-client'
@@ -449,6 +449,33 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
   const fetchLocalFiles = useCallback(async (dealId: string) => {
     setLoadingFiles(true)
     try {
+      const normalizeManifestRoot = (value: string | null | undefined): string => {
+        const trimmed = String(value || '').trim().toLowerCase()
+        if (!trimmed) return ''
+        return trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`
+      }
+      const localMeta = await readSlabMetadata(String(dealId))
+      const persistedManifestRoot = normalizeManifestRoot(await readManifestRoot(String(dealId)))
+      const metadataManifestRoot = normalizeManifestRoot(localMeta?.manifest_root)
+      const metadataFresh = persistedManifestRoot !== '' && metadataManifestRoot !== '' && metadataManifestRoot === persistedManifestRoot
+      if (localMeta && metadataFresh && localMeta.file_records.length > 0) {
+        setFiles(
+          localMeta.file_records.map((rec) => ({
+            path: rec.path,
+            size_bytes: rec.size_bytes,
+            start_offset: rec.start_offset,
+            flags: rec.flags,
+          })),
+        )
+        return
+      }
+      if (localMeta && !metadataFresh) {
+        console.warn('Local slab metadata is stale for file listing; reparsing MDU #0', {
+          dealId,
+          metadataManifestRoot: localMeta.manifest_root,
+          persistedManifestRoot,
+        })
+      }
       const mdu0 = await readMdu(String(dealId), 0)
       if (!mdu0) {
         setFiles([])
@@ -654,11 +681,59 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
         if (!dealId) return
         const canUseLocalSlab = await reconcileLocalMduCache(String(dealId), cid)
         if (!canUseLocalSlab) return
-        const mdu0 = await readMdu(String(dealId), 0)
-        if (!mdu0) return
-        const localFiles = parseNilfsFilesFromMdu0(mdu0)
-        const { witnessCount, totalMdus, userCount } = await inferWitnessCountFromOpfs(String(dealId), localFiles)
-        const totalSizeBytes = localFiles.reduce((acc, f) => acc + (Number(f.size_bytes) || 0), 0)
+
+        const localMeta = await readSlabMetadata(String(dealId))
+        const normalizeManifestRoot = (value: string | null | undefined): string => {
+          const trimmed = String(value || '').trim().toLowerCase()
+          if (!trimmed) return ''
+          return trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`
+        }
+        const persistedManifestRoot = normalizeManifestRoot(await readManifestRoot(String(dealId)))
+        const expectedManifestRoot = normalizeManifestRoot(cid)
+        const metadataManifestRoot = normalizeManifestRoot(localMeta?.manifest_root)
+        const metadataFresh =
+          !!localMeta &&
+          persistedManifestRoot !== '' &&
+          metadataManifestRoot === persistedManifestRoot &&
+          (expectedManifestRoot === '' || metadataManifestRoot === expectedManifestRoot)
+
+        let localFiles: NilfsFileEntry[] = []
+        let witnessCount = 0
+        let totalMdus = 0
+        let userCount = 0
+        let fileRecords = 0
+        let totalSizeBytes = 0
+        if (localMeta && metadataFresh) {
+          localFiles = localMeta.file_records.map((rec) => ({
+            path: rec.path,
+            size_bytes: rec.size_bytes,
+            start_offset: rec.start_offset,
+            flags: rec.flags,
+          }))
+          witnessCount = localMeta.witness_mdus
+          totalMdus = localMeta.total_mdus
+          userCount = localMeta.user_mdus
+          fileRecords = localMeta.file_records.length
+          totalSizeBytes = localMeta.file_records.reduce((acc, rec) => acc + (Number(rec.size_bytes) || 0), 0)
+        } else {
+          if (localMeta && !metadataFresh) {
+            console.warn('Local slab metadata is stale; reparsing MDU #0', {
+              dealId,
+              metadataManifestRoot: localMeta.manifest_root,
+              persistedManifestRoot,
+              expectedManifestRoot: cid,
+            })
+          }
+          const mdu0 = await readMdu(String(dealId), 0)
+          if (!mdu0) return
+          localFiles = parseNilfsFilesFromMdu0(mdu0)
+          const inferred = await inferWitnessCountFromOpfs(String(dealId), localFiles)
+          witnessCount = inferred.witnessCount
+          totalMdus = inferred.totalMdus
+          userCount = inferred.userCount
+          fileRecords = localFiles.length
+          totalSizeBytes = localFiles.reduce((acc, f) => acc + (Number(f.size_bytes) || 0), 0)
+        }
         const mduSizeBytes = 8 * 1024 * 1024
         const blobSizeBytes = 128 * 1024
         const segments = [
@@ -669,13 +744,13 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
             : []),
         ] as SlabLayoutData['segments']
         setSlab({
-          manifest_root: cid,
+          manifest_root: localMeta?.manifest_root || cid,
           mdu_size_bytes: mduSizeBytes,
           blob_size_bytes: blobSizeBytes,
           total_mdus: totalMdus,
           witness_mdus: witnessCount,
           user_mdus: userCount,
-          file_records: localFiles.length,
+          file_records: fileRecords,
           file_count: localFiles.length,
           total_size_bytes: totalSizeBytes,
           segments,
@@ -789,7 +864,7 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
         }
 
         setManifestInfo({
-          manifest_root: cid || computedRoot,
+          manifest_root: computedRoot || cid,
           manifest_blob_hex: blobHex,
           total_mdus: totalMdus,
           witness_mdus: witnessCount,

--- a/nil-website/src/components/FileSharder.tsx
+++ b/nil-website/src/components/FileSharder.tsx
@@ -16,6 +16,7 @@ import {
   writeManifestBlob,
   writeManifestRoot,
   writeMdu,
+  writeSlabMetadata,
   writeShard,
 } from '../lib/storage/OpfsAdapter';
 import { parseNilfsFilesFromMdu0 } from '../lib/nilfsLocal';
@@ -182,7 +183,7 @@ const gatewayUploadHeartbeatStaleMs = 15_000
 const gatewayFallbackWasmMaxFileBytes = 32 * 1024 * 1024
 
 export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
-  const { isConnected } = useAccount();
+  const { isConnected, address } = useAccount();
   const { openConnectModal } = useConnectModal();
   const localGateway = useLocalGateway();
   const gatewayGuiReleaseUrl = 'https://github.com/Nil-Store/nil-store/releases/latest'
@@ -323,6 +324,7 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
     const mdus = collectedMdus.slice()
     const shards = mode2Shards.slice()
     const witnessCount = shardProgress.totalWitnessMdus
+    const safeWitnessCount = Number.isFinite(witnessCount) && witnessCount > 0 ? Math.floor(witnessCount) : 0
 
     const persistPromise = (async () => {
       const safeRoot = String(manifestRoot || '').trim()
@@ -358,6 +360,42 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
           }
         }
 
+        const mdu0Bytes = mdus.find((mdu) => mdu.index === 0)?.data
+        const parsedFiles = mdu0Bytes ? parseNilfsFilesFromMdu0(mdu0Bytes) : []
+        const fileRecords = parsedFiles.map((file) => ({
+          path: file.path,
+          start_offset: Number(file.start_offset) || 0,
+          size_bytes: Number(file.size_bytes) || 0,
+          flags: Number(file.flags) || 0,
+        }))
+        const maxEnd = fileRecords.reduce((max, file) => {
+          const end = file.start_offset + file.size_bytes
+          return end > max ? end : max
+        }, 0)
+        const userMdusByOffsets = maxEnd > 0 ? Math.ceil(maxEnd / RAW_MDU_CAPACITY) : 0
+        const userMdusByIndices = mdus.reduce((count, mdu) => (mdu.index > safeWitnessCount ? count + 1 : count), 0)
+        const userMdus = Math.max(userMdusByOffsets, userMdusByIndices)
+        const totalMdus = 1 + safeWitnessCount + userMdus
+        const generationId = safeRoot.replace(/^0x/i, '').trim() || safeRoot
+        await writeSlabMetadata(dealId, {
+          schema_version: 1,
+          generation_id: generationId,
+          deal_id: dealId,
+          manifest_root: safeRoot,
+          owner: address || undefined,
+          redundancy:
+            isMode2 && stripeParams
+              ? { k: stripeParams.k, m: stripeParams.m, n: stripeParams.k + stripeParams.m }
+              : undefined,
+          source: isMode2 ? 'browser_mode2_commit' : 'browser_mode1_commit',
+          created_at: new Date().toISOString(),
+          last_validated_at: null,
+          witness_mdus: safeWitnessCount,
+          user_mdus: userMdus,
+          total_mdus: totalMdus,
+          file_records: fileRecords,
+        })
+
         lastPersistedManifestRootRef.current = safeRoot
         addLog('> Saved MDUs locally (OPFS). Deal Explorer should show files now.')
       } catch (e: unknown) {
@@ -384,6 +422,8 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
     mode2Shards,
     onCommitSuccess,
     shardProgress.totalWitnessMdus,
+    address,
+    stripeParams,
   ]);
 
   const uploadMode2 = useCallback(async () => {

--- a/nil-website/src/lib/nilfsOpfsFetch.ts
+++ b/nil-website/src/lib/nilfsOpfsFetch.ts
@@ -1,5 +1,5 @@
 import type { NilfsFileEntry } from '../domain/nilfs'
-import { listDealFiles, readMdu } from './storage/OpfsAdapter'
+import { listDealFiles, readManifestRoot, readMdu, readSlabMetadata } from './storage/OpfsAdapter'
 
 const MDU_SIZE_BYTES = 8 * 1024 * 1024
 const NILFS_SCALAR_BYTES = 32
@@ -29,6 +29,20 @@ function inferMaxEnd(files: NilfsFileEntry[]): number {
   return maxEnd
 }
 
+function normalizeManifestRoot(value: string | null | undefined): string {
+  const trimmed = String(value || '').trim().toLowerCase()
+  if (!trimmed) return ''
+  return trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`
+}
+
+function hasContiguousMduRange(indices: Set<number>, totalMdus: number): boolean {
+  if (!Number.isFinite(totalMdus) || totalMdus <= 0) return false
+  for (let i = 0; i < totalMdus; i++) {
+    if (!indices.has(i)) return false
+  }
+  return true
+}
+
 export async function inferWitnessCountFromOpfs(dealId: string, files: NilfsFileEntry[]): Promise<{
   witnessCount: number
   slabStartIdx: number
@@ -37,11 +51,40 @@ export async function inferWitnessCountFromOpfs(dealId: string, files: NilfsFile
   maxEnd: number
 }> {
   const fileNames = await listDealFiles(dealId)
-  let totalMdus = 0
+  const mduIndices = new Set<number>()
   for (const name of fileNames) {
-    if (parseMduIndex(name) == null) continue
-    totalMdus += 1
+    const idx = parseMduIndex(name)
+    if (idx == null) continue
+    mduIndices.add(idx)
   }
+
+  const meta = await readSlabMetadata(dealId).catch(() => null)
+  if (meta) {
+    const persistedManifestRoot = normalizeManifestRoot(await readManifestRoot(dealId).catch(() => null))
+    const metadataManifestRoot = normalizeManifestRoot(meta.manifest_root)
+    const manifestMatches = persistedManifestRoot !== '' && persistedManifestRoot === metadataManifestRoot
+    const metadataCountsSane = meta.total_mdus === 1 + meta.witness_mdus + meta.user_mdus
+    const metadataMduLayoutSane = metadataCountsSane && hasContiguousMduRange(mduIndices, meta.total_mdus)
+
+    if (manifestMatches && metadataMduLayoutSane) {
+      const metadataFiles: NilfsFileEntry[] = meta.file_records.map((rec) => ({
+        path: rec.path,
+        size_bytes: rec.size_bytes,
+        start_offset: rec.start_offset,
+        flags: rec.flags,
+      }))
+      const maxEnd = Math.max(inferMaxEnd(files), inferMaxEnd(metadataFiles))
+      return {
+        witnessCount: meta.witness_mdus,
+        slabStartIdx: 1 + meta.witness_mdus,
+        totalMdus: meta.total_mdus,
+        userCount: meta.user_mdus,
+        maxEnd,
+      }
+    }
+  }
+
+  const totalMdus = mduIndices.size
   if (totalMdus === 0) throw new Error('no MDUs found in OPFS')
 
   const maxEnd = inferMaxEnd(files)
@@ -145,4 +188,3 @@ export async function readNilfsFileFromOpfs(opts: {
 
   return out
 }
-

--- a/nil-website/src/lib/storage/OpfsAdapter.test.ts
+++ b/nil-website/src/lib/storage/OpfsAdapter.test.ts
@@ -160,6 +160,35 @@ test('OpfsAdapter: writeManifestBlob and readManifestBlob', async () => {
     assert.deepStrictEqual(readBlob, blob, 'Read manifest blob should match written manifest blob');
 });
 
+test('OpfsAdapter: write/read/delete slab metadata', async () => {
+    const dealId = 'test-deal-slab-meta';
+    const metadata: OpfsAdapter.SlabMetadata = {
+        schema_version: 1,
+        generation_id: 'abcd',
+        deal_id: dealId,
+        manifest_root: '0x' + '11'.repeat(48),
+        owner: 'nil1owner',
+        redundancy: { k: 8, m: 4, n: 12 },
+        source: 'browser_test',
+        created_at: new Date().toISOString(),
+        last_validated_at: null,
+        witness_mdus: 2,
+        user_mdus: 3,
+        total_mdus: 6,
+        file_records: [
+            { path: 'a.txt', start_offset: 0, size_bytes: 12, flags: 1 },
+            { path: 'b.txt', start_offset: 1024, size_bytes: 34, flags: 0 },
+        ],
+    };
+
+    await OpfsAdapter.writeSlabMetadata(dealId, metadata);
+    const readMeta = await OpfsAdapter.readSlabMetadata(dealId);
+    assert.deepStrictEqual(readMeta, metadata, 'Read slab metadata should match written metadata');
+
+    await OpfsAdapter.deleteSlabMetadata(dealId);
+    assert.strictEqual(await OpfsAdapter.readSlabMetadata(dealId), null, 'Slab metadata should be deleted');
+});
+
 test('OpfsAdapter: readMdu returns null for non-existent file', async () => {
     const dealId = 'test-deal-non-existent';
     const mduIndex = 1;
@@ -201,6 +230,27 @@ test('OpfsAdapter: delete non-existent directory', async () => {
     // Should not throw an error
     await OpfsAdapter.deleteDealDirectory(dealId);
     assert.ok(true, 'Deleting a non-existent directory should not throw an error');
+});
+
+test('OpfsAdapter: slab metadata removed when deleting deal directory', async () => {
+    const dealId = 'test-deal-slab-meta-cleanup';
+    await OpfsAdapter.writeSlabMetadata(dealId, {
+        schema_version: 1,
+        generation_id: 'deadbeef',
+        deal_id: dealId,
+        manifest_root: '0x' + '22'.repeat(48),
+        source: 'browser_test',
+        created_at: new Date().toISOString(),
+        last_validated_at: null,
+        witness_mdus: 0,
+        user_mdus: 1,
+        total_mdus: 2,
+        file_records: [{ path: 'cleanup.txt', start_offset: 0, size_bytes: 7, flags: 0 }],
+    });
+    assert.ok(await OpfsAdapter.readSlabMetadata(dealId), 'Metadata should exist before deleting directory');
+
+    await OpfsAdapter.deleteDealDirectory(dealId);
+    assert.strictEqual(await OpfsAdapter.readSlabMetadata(dealId), null, 'Metadata should be gone after deleting directory');
 });
 
 test('OpfsAdapter: cached file write/read/clear', async () => {

--- a/nil-website/src/lib/storage/OpfsAdapter.ts
+++ b/nil-website/src/lib/storage/OpfsAdapter.ts
@@ -3,6 +3,37 @@
 import { sha256 } from '@noble/hashes/sha2.js'
 import { bytesToHex } from '@noble/hashes/utils.js'
 
+const SLAB_METADATA_FILE = 'slab_meta.json'
+
+export interface SlabMetadataFileRecord {
+    path: string
+    start_offset: number
+    size_bytes: number
+    flags: number
+}
+
+export interface SlabMetadataRedundancy {
+    k?: number
+    m?: number
+    n?: number
+}
+
+export interface SlabMetadata {
+    schema_version: number
+    generation_id: string
+    deal_id?: string | number
+    manifest_root: string
+    owner?: string
+    redundancy?: SlabMetadataRedundancy
+    source: string
+    created_at: string
+    last_validated_at: string | null
+    witness_mdus: number
+    user_mdus: number
+    total_mdus: number
+    file_records: SlabMetadataFileRecord[]
+}
+
 /**
  * Returns a handle to the root of the origin's private file system.
  * This handle is persistent across sessions for the same origin.
@@ -126,7 +157,7 @@ export async function deleteDealDirectory(dealId: string): Promise<void> {
 
 export async function writeManifestRoot(dealId: string, manifestRoot: string): Promise<void> {
     const normalized = String(manifestRoot || '').trim();
-    await writeBlob(dealId, 'manifest_root.txt', normalized);
+    await writeBlob(dealId, 'manifest_root.txt', new TextEncoder().encode(normalized));
 }
 
 export async function writeManifestBlob(dealId: string, manifestBlob: Uint8Array): Promise<void> {
@@ -143,6 +174,123 @@ export async function readManifestRoot(dealId: string): Promise<string | null> {
     const txt = new TextDecoder().decode(bytes);
     const trimmed = txt.trim();
     return trimmed ? trimmed : null;
+}
+
+function coerceNumber(value: unknown): number | null {
+    const n = typeof value === 'number' ? value : Number(value)
+    if (!Number.isFinite(n) || n < 0) return null
+    return Math.floor(n)
+}
+
+function normalizeSlabMetadata(value: unknown): SlabMetadata | null {
+    if (!value || typeof value !== 'object') return null
+    const raw = value as Record<string, unknown>
+
+    const schemaVersion = coerceNumber(raw.schema_version)
+    const generationId = typeof raw.generation_id === 'string' ? raw.generation_id.trim() : ''
+    const manifestRoot = typeof raw.manifest_root === 'string' ? raw.manifest_root.trim() : ''
+    const source = typeof raw.source === 'string' ? raw.source.trim() : ''
+    const createdAt = typeof raw.created_at === 'string' ? raw.created_at.trim() : ''
+    const witnessMdus = coerceNumber(raw.witness_mdus)
+    const userMdus = coerceNumber(raw.user_mdus)
+    const totalMdus = coerceNumber(raw.total_mdus)
+    const lastValidatedAt =
+        raw.last_validated_at == null
+            ? null
+            : typeof raw.last_validated_at === 'string'
+                ? raw.last_validated_at.trim()
+                : null
+
+    if (
+        schemaVersion == null ||
+        generationId === '' ||
+        manifestRoot === '' ||
+        source === '' ||
+        createdAt === '' ||
+        witnessMdus == null ||
+        userMdus == null ||
+        totalMdus == null
+    ) {
+        return null
+    }
+    if (totalMdus !== 1 + witnessMdus + userMdus) return null
+
+    const fileRecords: SlabMetadataFileRecord[] = []
+    if (Array.isArray(raw.file_records)) {
+        for (const item of raw.file_records) {
+            if (!item || typeof item !== 'object') continue
+            const rec = item as Record<string, unknown>
+            const path = typeof rec.path === 'string' ? rec.path.trim() : ''
+            const startOffset = coerceNumber(rec.start_offset)
+            const sizeBytes = coerceNumber(rec.size_bytes)
+            const flags = coerceNumber(rec.flags)
+            if (!path || startOffset == null || sizeBytes == null || flags == null) continue
+            fileRecords.push({
+                path,
+                start_offset: startOffset,
+                size_bytes: sizeBytes,
+                flags,
+            })
+        }
+    }
+
+    let redundancy: SlabMetadataRedundancy | undefined
+    if (raw.redundancy && typeof raw.redundancy === 'object') {
+        const r = raw.redundancy as Record<string, unknown>
+        const k = coerceNumber(r.k) ?? undefined
+        const m = coerceNumber(r.m) ?? undefined
+        const n = coerceNumber(r.n) ?? undefined
+        if (k != null || m != null || n != null) {
+            redundancy = { k, m, n }
+        }
+    }
+
+    const dealIdRaw = raw.deal_id
+    const dealId =
+        typeof dealIdRaw === 'string'
+            ? dealIdRaw.trim() || undefined
+            : typeof dealIdRaw === 'number'
+                ? Math.floor(dealIdRaw)
+                : undefined
+
+    const owner = typeof raw.owner === 'string' ? raw.owner.trim() : undefined
+
+    return {
+        schema_version: schemaVersion,
+        generation_id: generationId,
+        deal_id: dealId,
+        manifest_root: manifestRoot,
+        owner: owner || undefined,
+        redundancy,
+        source,
+        created_at: createdAt,
+        last_validated_at: lastValidatedAt,
+        witness_mdus: witnessMdus,
+        user_mdus: userMdus,
+        total_mdus: totalMdus,
+        file_records: fileRecords,
+    }
+}
+
+export async function writeSlabMetadata(dealId: string, metadata: SlabMetadata): Promise<void> {
+    const payload = JSON.stringify(metadata, null, 2)
+    await writeBlob(dealId, SLAB_METADATA_FILE, new TextEncoder().encode(payload))
+}
+
+export async function readSlabMetadata(dealId: string): Promise<SlabMetadata | null> {
+    const bytes = await readBlob(dealId, SLAB_METADATA_FILE)
+    if (!bytes) return null
+    try {
+        const decoded = new TextDecoder().decode(bytes)
+        const parsed = JSON.parse(decoded) as unknown
+        return normalizeSlabMetadata(parsed)
+    } catch {
+        return null
+    }
+}
+
+export async function deleteSlabMetadata(dealId: string): Promise<void> {
+    await deleteDealFile(dealId, SLAB_METADATA_FILE)
 }
 
 export function cachedFileNameForPath(filePath: string): string {

--- a/nil_gateway/fetch_cache.go
+++ b/nil_gateway/fetch_cache.go
@@ -20,25 +20,81 @@ type slabFileInfo struct {
 }
 
 type slabIndexEntry struct {
+	indexModTime int64
+	indexSource  string
+	metaModTime  int64
 	mdu0ModTime  int64
+	manifestKey  string
 	witnessCount uint64
 	files        map[string]slabFileInfo
 }
 
 var slabIndexCache sync.Map // map[string]*slabIndexEntry (key: dealDir)
 
+func slabIndexFilesFromMetadata(records []slabMetadataFileRecord) map[string]slabFileInfo {
+	files := make(map[string]slabFileInfo, len(records))
+	for _, rec := range records {
+		if rec.Path == "" {
+			continue
+		}
+		files[rec.Path] = slabFileInfo{
+			StartOffset: rec.StartOffset,
+			Length:      rec.SizeBytes,
+		}
+	}
+	return files
+}
+
 func loadSlabIndex(dealDir string) (*slabIndexEntry, error) {
+	metaPath := slabMetadataPathForDealDir(dealDir)
 	mdu0Path := filepath.Join(dealDir, "mdu_0.bin")
 	st, err := os.Stat(mdu0Path)
 	if err != nil {
 		return nil, err
 	}
-	mod := st.ModTime().UnixNano()
+	mdu0Mod := st.ModTime().UnixNano()
+	metaMod := int64(0)
+	if metaInfo, err := os.Stat(metaPath); err == nil {
+		metaMod = metaInfo.ModTime().UnixNano()
+	}
+
+	expectedManifestKey := ""
+	if key, ok := slabMetadataManifestKey(inferManifestRootForDealDir(dealDir)); ok {
+		expectedManifestKey = key
+	}
 
 	if cachedAny, ok := slabIndexCache.Load(dealDir); ok {
 		cached := cachedAny.(*slabIndexEntry)
-		if cached.mdu0ModTime == mod {
+		if cached.manifestKey == expectedManifestKey &&
+			((cached.indexSource == "meta" &&
+				cached.indexModTime == metaMod &&
+				cached.metaModTime == metaMod &&
+				cached.mdu0ModTime == mdu0Mod) ||
+				(cached.indexSource == "mdu0" &&
+					cached.indexModTime == mdu0Mod &&
+					cached.metaModTime == metaMod &&
+					cached.mdu0ModTime == mdu0Mod)) {
 			return cached, nil
+		}
+	}
+
+	if metaMod != 0 {
+		if meta, err := readSlabMetadataFile(dealDir); err == nil {
+			metaFresh := mdu0Mod <= metaMod
+			manifestMatches := slabMetadataManifestMatchesDealDir(meta.ManifestRoot, dealDir)
+			if metaFresh && manifestMatches {
+				entry := &slabIndexEntry{
+					indexModTime: metaMod,
+					indexSource:  "meta",
+					metaModTime:  metaMod,
+					mdu0ModTime:  mdu0Mod,
+					manifestKey:  expectedManifestKey,
+					witnessCount: meta.WitnessMdus,
+					files:        slabIndexFilesFromMetadata(meta.FileRecords),
+				}
+				slabIndexCache.Store(dealDir, entry)
+				return entry, nil
+			}
 		}
 	}
 
@@ -53,31 +109,31 @@ func loadSlabIndex(dealDir string) (*slabIndexEntry, error) {
 	}
 	defer b.Free()
 
-	count := b.GetRecordCount()
-	files := make(map[string]slabFileInfo, count)
-	for i := uint32(0); i < count; i++ {
-		rec, err := b.GetRecord(i)
-		if err != nil {
-			continue
-		}
-		if rec.Path[0] == 0 {
-			continue
-		}
-		name := string(bytes.TrimRight(rec.Path[:], "\x00"))
-		length, _ := crypto_ffi.UnpackLengthAndFlags(rec.LengthAndFlags)
-		files[name] = slabFileInfo{
-			StartOffset: rec.StartOffset,
-			Length:      length,
-		}
-	}
+	records := slabMetadataFileRecordsFromBuilder(b)
+	files := slabIndexFilesFromMetadata(records)
 
 	witnessCount, err := inferWitnessCount(dealDir, b)
 	if err != nil {
 		return nil, err
 	}
 
+	if fallbackMeta, err := newSlabMetadataDocument(slabMetadataBuildOptions{
+		GenerationID: inferGenerationIDForDealDir(dealDir),
+		DealID:       inferDealIDFromDealDir(dealDir),
+		ManifestRoot: inferManifestRootForDealDir(dealDir),
+		Source:       "gateway_fallback_mdu0",
+		WitnessMdus:  &witnessCount,
+		FileRecords:  records,
+	}); err == nil {
+		_ = writeSlabMetadataFile(dealDir, fallbackMeta)
+	}
+
 	entry := &slabIndexEntry{
-		mdu0ModTime:  mod,
+		indexModTime: mdu0Mod,
+		indexSource:  "mdu0",
+		metaModTime:  metaMod,
+		mdu0ModTime:  mdu0Mod,
+		manifestKey:  expectedManifestKey,
 		witnessCount: witnessCount,
 		files:        files,
 	}

--- a/nil_gateway/ingest.go
+++ b/nil_gateway/ingest.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -226,6 +227,23 @@ func IngestNewDeal(ctx context.Context, filePath string, maxUserMdus uint64, rec
 			b.Free()
 			return nil, "", 0, fmt.Errorf("failed to move User MDU %d: %w", mdu.Index, err)
 		}
+	}
+
+	witnessMdus := witnessMduCount
+	userMdus := uint64(len(shardOut.Mdus))
+	totalMdus := uint64(1) + witnessMdus + userMdus
+	meta, err := buildSlabMetadataFromBuilder(b, slabMetadataBuildOptions{
+		GenerationID: parsedRoot.Key,
+		ManifestRoot: parsedRoot.Canonical,
+		Source:       "gateway_mode1_new",
+		WitnessMdus:  &witnessMdus,
+		UserMdus:     &userMdus,
+		TotalMdus:    &totalMdus,
+	})
+	if err != nil {
+		log.Printf("IngestNewDeal: warning: failed to build slab metadata for manifest_root=%s: %v", parsedRoot.Canonical, err)
+	} else if err := writeSlabMetadataFile(dealDir, meta); err != nil {
+		log.Printf("IngestNewDeal: warning: failed to write slab metadata for manifest_root=%s: %v", parsedRoot.Canonical, err)
 	}
 
 	allocatedLength := uint64(len(allRoots))

--- a/nil_gateway/ingest_append.go
+++ b/nil_gateway/ingest_append.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -244,6 +245,23 @@ func IngestAppendToDeal(ctx context.Context, filePath, existingManifestRoot stri
 			b.Free()
 			return nil, "", 0, fmt.Errorf("failed to move new User MDU %d: %w", mdu.Index, err)
 		}
+	}
+
+	witnessMdus := witnessMduCount
+	userMdus := uint64(len(userRoots))
+	totalMdus := uint64(1) + witnessMdus + userMdus
+	meta, err := buildSlabMetadataFromBuilder(b, slabMetadataBuildOptions{
+		GenerationID: parsedNewRoot.Key,
+		ManifestRoot: parsedNewRoot.Canonical,
+		Source:       "gateway_mode1_append",
+		WitnessMdus:  &witnessMdus,
+		UserMdus:     &userMdus,
+		TotalMdus:    &totalMdus,
+	})
+	if err != nil {
+		log.Printf("IngestAppendToDeal: warning: failed to build slab metadata for manifest_root=%s: %v", parsedNewRoot.Canonical, err)
+	} else if err := writeSlabMetadataFile(newDir, meta); err != nil {
+		log.Printf("IngestAppendToDeal: warning: failed to write slab metadata for manifest_root=%s: %v", parsedNewRoot.Canonical, err)
 	}
 
 	allocatedLength := uint64(len(allRoots))

--- a/nil_gateway/ingest_fast.go
+++ b/nil_gateway/ingest_fast.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,6 +120,23 @@ func IngestNewDealFast(ctx context.Context, filePath string, maxUserMdus uint64,
 			b.Free()
 			return nil, "", 0, fmt.Errorf("failed to move User MDU %d: %w", mdu.Index, err)
 		}
+	}
+
+	witnessMdus := witnessMduCount
+	userMdus := uint64(len(shardOut.Mdus))
+	totalMdus := uint64(1) + witnessMdus + userMdus
+	meta, err := buildSlabMetadataFromBuilder(b, slabMetadataBuildOptions{
+		GenerationID: parsedRoot.Key,
+		ManifestRoot: parsedRoot.Canonical,
+		Source:       "gateway_mode1_new_fast",
+		WitnessMdus:  &witnessMdus,
+		UserMdus:     &userMdus,
+		TotalMdus:    &totalMdus,
+	})
+	if err != nil {
+		log.Printf("IngestNewDealFast: warning: failed to build slab metadata for manifest_root=%s: %v", parsedRoot.Canonical, err)
+	} else if err := writeSlabMetadataFile(dealDir, meta); err != nil {
+		log.Printf("IngestNewDealFast: warning: failed to write slab metadata for manifest_root=%s: %v", parsedRoot.Canonical, err)
 	}
 
 	allocatedLength := uint64(len(mdu0Out.Mdus)) // Dummy length

--- a/nil_gateway/ingest_mode2.go
+++ b/nil_gateway/ingest_mode2.go
@@ -386,6 +386,25 @@ func mode2BuildArtifacts(ctx context.Context, filePath string, dealID uint64, hi
 	if err := os.WriteFile(filepath.Join(stagingDir, "manifest.bin"), manifestBlob, 0o644); err != nil {
 		return nil, "", err
 	}
+	dealIDForMeta := dealID
+	meta, err := buildSlabMetadataFromBuilder(builder, slabMetadataBuildOptions{
+		GenerationID: parsedRoot.Key,
+		DealID:       &dealIDForMeta,
+		ManifestRoot: parsedRoot.Canonical,
+		Source:       "gateway_mode2_new",
+		Redundancy: &slabMetadataRedundancy{
+			K: stripe.k,
+			M: stripe.m,
+			N: stripe.slotCount,
+		},
+		WitnessMdus: &witnessCount,
+		UserMdus:    &userMdus,
+	})
+	if err != nil {
+		log.Printf("mode2BuildArtifacts: warning: failed to build slab metadata deal_id=%d manifest_root=%s: %v", dealID, parsedRoot.Canonical, err)
+	} else if err := writeSlabMetadataFile(stagingDir, meta); err != nil {
+		log.Printf("mode2BuildArtifacts: warning: failed to write slab metadata deal_id=%d manifest_root=%s: %v", dealID, parsedRoot.Canonical, err)
+	}
 	if err := os.WriteFile(filepath.Join(stagingDir, mode2SlabCompleteMarker), []byte("ok\n"), 0o644); err != nil {
 		return nil, "", err
 	}
@@ -1132,6 +1151,25 @@ func mode2BuildArtifactsAppend(
 	}
 	if err := os.WriteFile(filepath.Join(stagingDir, "manifest.bin"), manifestBlob, 0o644); err != nil {
 		return nil, "", err
+	}
+	dealIDForMeta := dealID
+	meta, err := buildSlabMetadataFromBuilder(builder, slabMetadataBuildOptions{
+		GenerationID: parsedRoot.Key,
+		DealID:       &dealIDForMeta,
+		ManifestRoot: parsedRoot.Canonical,
+		Source:       "gateway_mode2_append",
+		Redundancy: &slabMetadataRedundancy{
+			K: stripe.k,
+			M: stripe.m,
+			N: stripe.slotCount,
+		},
+		WitnessMdus: &witnessCount,
+		UserMdus:    &totalUserMdus,
+	})
+	if err != nil {
+		log.Printf("mode2BuildArtifactsAppend: warning: failed to build slab metadata deal_id=%d manifest_root=%s: %v", dealID, parsedRoot.Canonical, err)
+	} else if err := writeSlabMetadataFile(stagingDir, meta); err != nil {
+		log.Printf("mode2BuildArtifactsAppend: warning: failed to write slab metadata deal_id=%d manifest_root=%s: %v", dealID, parsedRoot.Canonical, err)
 	}
 	if err := os.WriteFile(filepath.Join(stagingDir, mode2SlabCompleteMarker), []byte("ok\n"), 0o644); err != nil {
 		return nil, "", err

--- a/nil_gateway/mdu_viewer.go
+++ b/nil_gateway/mdu_viewer.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"nilchain/x/crypto_ffi"
-	"nilchain/x/nilchain/types"
 )
 
 type manifestInfoResponse struct {
@@ -59,6 +58,11 @@ func (s *slabMeta) Close() {
 }
 
 func loadSlabMeta(dealDir string) (*slabMeta, error) {
+	metaDoc, err := loadSlabMetadataWithFallback(dealDir)
+	if err != nil {
+		return nil, err
+	}
+
 	mdu0Path := filepath.Join(dealDir, "mdu_0.bin")
 	mdu0Data, err := os.ReadFile(mdu0Path)
 	if err != nil {
@@ -69,110 +73,12 @@ func loadSlabMeta(dealDir string) (*slabMeta, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	var maxEnd uint64
-	count := b.GetRecordCount()
-	for i := uint32(0); i < count; i++ {
-		rec, err := b.GetRecord(i)
-		if err != nil {
-			continue
-		}
-		length, _ := crypto_ffi.UnpackLengthAndFlags(rec.LengthAndFlags)
-		end := rec.StartOffset + length
-		if end > maxEnd {
-			maxEnd = end
-		}
-	}
-
-	userMdus := uint64(0)
-	if maxEnd > 0 {
-		userMdus = (maxEnd + RawMduCapacity - 1) / RawMduCapacity
-	}
-
-	rootTableBytes := 16 * uint64(types.BLOB_SIZE)
-	totalRoots := 0
-	if uint64(len(mdu0Data)) >= rootTableBytes {
-		for off := uint64(0); off+32 <= rootTableBytes; off += 32 {
-			chunk := mdu0Data[off : off+32]
-			allZero := true
-			for _, v := range chunk {
-				if v != 0 {
-					allZero = false
-					break
-				}
-			}
-			if !allZero {
-				totalRoots++
-			}
-		}
-	}
-
-	if totalRoots > 0 {
-		if uint64(totalRoots) < userMdus {
-			b.Free()
-			return nil, fmt.Errorf("invalid slab layout: root table < user mdus")
-		}
-		witnessMdus := uint64(totalRoots) - userMdus
-		totalMdus := 1 + witnessMdus + userMdus
-		return &slabMeta{
-			dealDir:     dealDir,
-			builder:     b,
-			totalMdus:   totalMdus,
-			witnessMdus: witnessMdus,
-			userMdus:    userMdus,
-		}, nil
-	}
-
-	entries, err := os.ReadDir(dealDir)
-	if err != nil {
-		b.Free()
-		return nil, err
-	}
-
-	idxSet := map[uint64]struct{}{}
-	var maxIdx uint64
-	for _, e := range entries {
-		name := e.Name()
-		if !strings.HasPrefix(name, "mdu_") || !strings.HasSuffix(name, ".bin") {
-			continue
-		}
-		idxStr := strings.TrimSuffix(strings.TrimPrefix(name, "mdu_"), ".bin")
-		idx, err := strconv.ParseUint(idxStr, 10, 64)
-		if err != nil {
-			continue
-		}
-		idxSet[idx] = struct{}{}
-		if idx > maxIdx {
-			maxIdx = idx
-		}
-	}
-
-	if len(idxSet) == 0 {
-		b.Free()
-		return nil, os.ErrNotExist
-	}
-	if _, ok := idxSet[0]; !ok {
-		b.Free()
-		return nil, fmt.Errorf("invalid slab layout: mdu_0.bin missing")
-	}
-
-	totalMdus := maxIdx + 1
-	if uint64(len(idxSet)) != totalMdus {
-		b.Free()
-		return nil, fmt.Errorf("invalid slab layout: non-contiguous mdu files")
-	}
-	if totalMdus-1 < userMdus {
-		b.Free()
-		return nil, fmt.Errorf("invalid slab layout: file table exceeds user mdus")
-	}
-
-	witnessMdus := (totalMdus - 1) - userMdus
 	return &slabMeta{
 		dealDir:     dealDir,
 		builder:     b,
-		totalMdus:   totalMdus,
-		witnessMdus: witnessMdus,
-		userMdus:    userMdus,
+		totalMdus:   metaDoc.TotalMdus,
+		witnessMdus: metaDoc.WitnessMdus,
+		userMdus:    metaDoc.UserMdus,
 	}, nil
 }
 

--- a/nil_gateway/slab_metadata.go
+++ b/nil_gateway/slab_metadata.go
@@ -1,0 +1,421 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"nilchain/x/crypto_ffi"
+)
+
+const (
+	slabMetadataSchemaVersion = 1
+	slabMetadataFileName      = "slab_meta.json"
+)
+
+type slabMetadataRedundancy struct {
+	K uint64 `json:"k,omitempty"`
+	M uint64 `json:"m,omitempty"`
+	N uint64 `json:"n,omitempty"`
+}
+
+type slabMetadataFileRecord struct {
+	Path        string `json:"path"`
+	StartOffset uint64 `json:"start_offset"`
+	SizeBytes   uint64 `json:"size_bytes"`
+	Flags       uint8  `json:"flags"`
+}
+
+type slabMetadataDocument struct {
+	SchemaVersion   int                      `json:"schema_version"`
+	GenerationID    string                   `json:"generation_id"`
+	DealID          *uint64                  `json:"deal_id,omitempty"`
+	ManifestRoot    string                   `json:"manifest_root"`
+	Owner           string                   `json:"owner,omitempty"`
+	Redundancy      *slabMetadataRedundancy  `json:"redundancy,omitempty"`
+	Source          string                   `json:"source"`
+	CreatedAt       string                   `json:"created_at"`
+	LastValidatedAt *string                  `json:"last_validated_at"`
+	WitnessMdus     uint64                   `json:"witness_mdus"`
+	UserMdus        uint64                   `json:"user_mdus"`
+	TotalMdus       uint64                   `json:"total_mdus"`
+	FileRecords     []slabMetadataFileRecord `json:"file_records"`
+}
+
+type slabMetadataBuildOptions struct {
+	GenerationID    string
+	DealID          *uint64
+	ManifestRoot    string
+	Owner           string
+	Redundancy      *slabMetadataRedundancy
+	Source          string
+	CreatedAt       time.Time
+	LastValidatedAt *time.Time
+	WitnessMdus     *uint64
+	UserMdus        *uint64
+	TotalMdus       *uint64
+	FileRecords     []slabMetadataFileRecord
+}
+
+func slabMetadataPathForDealDir(dealDir string) string {
+	return filepath.Join(dealDir, slabMetadataFileName)
+}
+
+func inferGenerationIDForDealDir(dealDir string) string {
+	gen := strings.TrimSpace(filepath.Base(dealDir))
+	if gen == "" || gen == "." {
+		return "unknown"
+	}
+	return gen
+}
+
+func inferManifestRootForDealDir(dealDir string) string {
+	base := strings.TrimSpace(filepath.Base(dealDir))
+	if base == "" || base == "." {
+		return ""
+	}
+	if parsed, err := parseManifestRoot(base); err == nil {
+		return parsed.Canonical
+	}
+	if parsed, err := parseManifestRoot("0x" + base); err == nil {
+		return parsed.Canonical
+	}
+	return base
+}
+
+func slabMetadataManifestKey(raw string) (string, bool) {
+	parsed, err := parseManifestRoot(strings.TrimSpace(raw))
+	if err != nil {
+		return "", false
+	}
+	return parsed.Key, true
+}
+
+func slabMetadataManifestMatchesDealDir(manifestRoot string, dealDir string) bool {
+	manifestKey, ok := slabMetadataManifestKey(manifestRoot)
+	if !ok {
+		return false
+	}
+	dirKey, ok := slabMetadataManifestKey(inferManifestRootForDealDir(dealDir))
+	if !ok {
+		return false
+	}
+	return manifestKey == dirKey
+}
+
+func inferDealIDFromDealDir(dealDir string) *uint64 {
+	parent := strings.TrimSpace(filepath.Base(filepath.Dir(filepath.Clean(dealDir))))
+	if parent == "" {
+		return nil
+	}
+	dealID, err := strconv.ParseUint(parent, 10, 64)
+	if err != nil {
+		return nil
+	}
+	return &dealID
+}
+
+func normalizeSlabMetadataFileRecords(records []slabMetadataFileRecord) []slabMetadataFileRecord {
+	latest := make(map[string]slabMetadataFileRecord, len(records))
+	order := make([]string, 0, len(records))
+	for _, rec := range records {
+		path := strings.TrimSpace(rec.Path)
+		if path == "" {
+			continue
+		}
+		rec.Path = path
+		if _, ok := latest[path]; !ok {
+			order = append(order, path)
+		}
+		latest[path] = rec
+	}
+	out := make([]slabMetadataFileRecord, 0, len(order))
+	for _, path := range order {
+		out = append(out, latest[path])
+	}
+	return out
+}
+
+func slabMetadataMaxEnd(records []slabMetadataFileRecord) uint64 {
+	var maxEnd uint64
+	for _, rec := range records {
+		end := rec.StartOffset + rec.SizeBytes
+		if end > maxEnd {
+			maxEnd = end
+		}
+	}
+	return maxEnd
+}
+
+func slabMetadataFileRecordsFromBuilder(b *crypto_ffi.Mdu0Builder) []slabMetadataFileRecord {
+	if b == nil {
+		return nil
+	}
+	records := make([]slabMetadataFileRecord, 0, b.GetRecordCount())
+	count := b.GetRecordCount()
+	for i := uint32(0); i < count; i++ {
+		rec, err := b.GetRecord(i)
+		if err != nil {
+			continue
+		}
+		if rec.Path[0] == 0 {
+			continue
+		}
+		path := string(bytes.TrimRight(rec.Path[:], "\x00"))
+		if path == "" {
+			continue
+		}
+		sizeBytes, flags := crypto_ffi.UnpackLengthAndFlags(rec.LengthAndFlags)
+		records = append(records, slabMetadataFileRecord{
+			Path:        path,
+			StartOffset: rec.StartOffset,
+			SizeBytes:   sizeBytes,
+			Flags:       flags,
+		})
+	}
+	return normalizeSlabMetadataFileRecords(records)
+}
+
+func validateSlabMetadataDocument(meta *slabMetadataDocument) error {
+	if meta == nil {
+		return errors.New("slab metadata is nil")
+	}
+	if meta.SchemaVersion < slabMetadataSchemaVersion {
+		return fmt.Errorf("unsupported slab metadata schema_version=%d", meta.SchemaVersion)
+	}
+	if strings.TrimSpace(meta.GenerationID) == "" {
+		return errors.New("slab metadata generation_id is required")
+	}
+	if strings.TrimSpace(meta.ManifestRoot) == "" {
+		return errors.New("slab metadata manifest_root is required")
+	}
+	if strings.TrimSpace(meta.Source) == "" {
+		return errors.New("slab metadata source is required")
+	}
+	if strings.TrimSpace(meta.CreatedAt) == "" {
+		return errors.New("slab metadata created_at is required")
+	}
+	if meta.TotalMdus != 1+meta.WitnessMdus+meta.UserMdus {
+		return fmt.Errorf(
+			"invalid slab metadata counts: total_mdus=%d witness_mdus=%d user_mdus=%d",
+			meta.TotalMdus,
+			meta.WitnessMdus,
+			meta.UserMdus,
+		)
+	}
+	for i, rec := range meta.FileRecords {
+		if strings.TrimSpace(rec.Path) == "" {
+			return fmt.Errorf("slab metadata file_records[%d].path is required", i)
+		}
+	}
+	if meta.LastValidatedAt != nil && strings.TrimSpace(*meta.LastValidatedAt) == "" {
+		return errors.New("slab metadata last_validated_at must be null or non-empty")
+	}
+	return nil
+}
+
+func newSlabMetadataDocument(opts slabMetadataBuildOptions) (*slabMetadataDocument, error) {
+	records := normalizeSlabMetadataFileRecords(opts.FileRecords)
+
+	witnessMdus := uint64(0)
+	if opts.WitnessMdus != nil {
+		witnessMdus = *opts.WitnessMdus
+	}
+
+	userMdus := uint64(0)
+	if opts.UserMdus != nil {
+		userMdus = *opts.UserMdus
+	} else if maxEnd := slabMetadataMaxEnd(records); maxEnd > 0 {
+		userMdus = (maxEnd + RawMduCapacity - 1) / RawMduCapacity
+	}
+
+	totalMdus := uint64(1) + witnessMdus + userMdus
+	if opts.TotalMdus != nil {
+		totalMdus = *opts.TotalMdus
+	}
+
+	createdAt := opts.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+
+	var lastValidatedAt *string
+	if opts.LastValidatedAt != nil {
+		ts := opts.LastValidatedAt.UTC().Format(time.RFC3339Nano)
+		lastValidatedAt = &ts
+	}
+
+	manifestRoot := strings.TrimSpace(opts.ManifestRoot)
+	source := strings.TrimSpace(opts.Source)
+	if source == "" {
+		source = "unknown"
+	}
+	meta := &slabMetadataDocument{
+		SchemaVersion:   slabMetadataSchemaVersion,
+		GenerationID:    strings.TrimSpace(opts.GenerationID),
+		DealID:          opts.DealID,
+		ManifestRoot:    manifestRoot,
+		Owner:           strings.TrimSpace(opts.Owner),
+		Redundancy:      opts.Redundancy,
+		Source:          source,
+		CreatedAt:       createdAt.Format(time.RFC3339Nano),
+		LastValidatedAt: lastValidatedAt,
+		WitnessMdus:     witnessMdus,
+		UserMdus:        userMdus,
+		TotalMdus:       totalMdus,
+		FileRecords:     records,
+	}
+	if err := validateSlabMetadataDocument(meta); err != nil {
+		return nil, err
+	}
+	return meta, nil
+}
+
+func buildSlabMetadataFromBuilder(b *crypto_ffi.Mdu0Builder, opts slabMetadataBuildOptions) (*slabMetadataDocument, error) {
+	if b == nil {
+		return nil, errors.New("nil mdu0 builder")
+	}
+	if len(opts.FileRecords) == 0 {
+		opts.FileRecords = slabMetadataFileRecordsFromBuilder(b)
+	}
+	return newSlabMetadataDocument(opts)
+}
+
+func readSlabMetadataFile(dealDir string) (*slabMetadataDocument, error) {
+	data, err := os.ReadFile(slabMetadataPathForDealDir(dealDir))
+	if err != nil {
+		return nil, err
+	}
+	var meta slabMetadataDocument
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, err
+	}
+	meta.GenerationID = strings.TrimSpace(meta.GenerationID)
+	meta.ManifestRoot = strings.TrimSpace(meta.ManifestRoot)
+	meta.Owner = strings.TrimSpace(meta.Owner)
+	meta.Source = strings.TrimSpace(meta.Source)
+	meta.CreatedAt = strings.TrimSpace(meta.CreatedAt)
+	if meta.LastValidatedAt != nil {
+		trimmed := strings.TrimSpace(*meta.LastValidatedAt)
+		meta.LastValidatedAt = &trimmed
+	}
+	meta.FileRecords = normalizeSlabMetadataFileRecords(meta.FileRecords)
+	if err := validateSlabMetadataDocument(&meta); err != nil {
+		return nil, err
+	}
+	return &meta, nil
+}
+
+func writeSlabMetadataFile(dealDir string, meta *slabMetadataDocument) error {
+	if meta == nil {
+		return errors.New("nil slab metadata")
+	}
+	copyMeta := *meta
+	if copyMeta.SchemaVersion == 0 {
+		copyMeta.SchemaVersion = slabMetadataSchemaVersion
+	}
+	if copyMeta.GenerationID == "" {
+		copyMeta.GenerationID = inferGenerationIDForDealDir(dealDir)
+	}
+	if copyMeta.ManifestRoot == "" {
+		copyMeta.ManifestRoot = inferManifestRootForDealDir(dealDir)
+	}
+	if copyMeta.DealID == nil {
+		copyMeta.DealID = inferDealIDFromDealDir(dealDir)
+	}
+	if copyMeta.Source == "" {
+		copyMeta.Source = "unknown"
+	}
+	if copyMeta.CreatedAt == "" {
+		copyMeta.CreatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	copyMeta.GenerationID = strings.TrimSpace(copyMeta.GenerationID)
+	copyMeta.ManifestRoot = strings.TrimSpace(copyMeta.ManifestRoot)
+	copyMeta.Owner = strings.TrimSpace(copyMeta.Owner)
+	copyMeta.Source = strings.TrimSpace(copyMeta.Source)
+	copyMeta.CreatedAt = strings.TrimSpace(copyMeta.CreatedAt)
+	copyMeta.FileRecords = normalizeSlabMetadataFileRecords(copyMeta.FileRecords)
+	if copyMeta.TotalMdus == 0 {
+		copyMeta.TotalMdus = 1 + copyMeta.WitnessMdus + copyMeta.UserMdus
+	}
+	if err := validateSlabMetadataDocument(&copyMeta); err != nil {
+		return err
+	}
+	encoded, err := json.MarshalIndent(&copyMeta, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded = append(encoded, '\n')
+	return os.WriteFile(slabMetadataPathForDealDir(dealDir), encoded, 0o644)
+}
+
+func synthesizeSlabMetadataFromMdu0(dealDir string) (*slabMetadataDocument, error) {
+	mdu0Path := filepath.Join(dealDir, "mdu_0.bin")
+	mdu0Bytes, err := os.ReadFile(mdu0Path)
+	if err != nil {
+		return nil, err
+	}
+	b, err := crypto_ffi.LoadMdu0Builder(mdu0Bytes, 1)
+	if err != nil {
+		return nil, err
+	}
+	defer b.Free()
+
+	witnessMdus, err := inferWitnessCount(dealDir, b)
+	if err != nil {
+		return nil, err
+	}
+	records := slabMetadataFileRecordsFromBuilder(b)
+	userMdus := uint64(0)
+	if maxEnd := slabMetadataMaxEnd(records); maxEnd > 0 {
+		userMdus = (maxEnd + RawMduCapacity - 1) / RawMduCapacity
+	}
+	totalMdus := uint64(1) + witnessMdus + userMdus
+
+	return newSlabMetadataDocument(slabMetadataBuildOptions{
+		GenerationID: inferGenerationIDForDealDir(dealDir),
+		DealID:       inferDealIDFromDealDir(dealDir),
+		ManifestRoot: inferManifestRootForDealDir(dealDir),
+		Source:       "gateway_fallback_mdu0",
+		WitnessMdus:  &witnessMdus,
+		UserMdus:     &userMdus,
+		TotalMdus:    &totalMdus,
+		FileRecords:  records,
+	})
+}
+
+func loadSlabMetadataWithFallback(dealDir string) (*slabMetadataDocument, error) {
+	meta, err := readSlabMetadataFile(dealDir)
+	if err == nil {
+		return meta, nil
+	}
+
+	metaPath := slabMetadataPathForDealDir(dealDir)
+	metaExists := false
+	if _, statErr := os.Stat(metaPath); statErr == nil {
+		metaExists = true
+		log.Printf("loadSlabMetadataWithFallback: unreadable slab metadata at %s (using synthesized fallback): %v", metaPath, err)
+	}
+
+	synthesized, synthErr := synthesizeSlabMetadataFromMdu0(dealDir)
+	if synthErr != nil {
+		return nil, synthErr
+	}
+
+	// Preserve existing metadata files (including forward-compatible schemas) on read fallback.
+	if metaExists {
+		return synthesized, nil
+	}
+
+	if writeErr := writeSlabMetadataFile(dealDir, synthesized); writeErr != nil {
+		log.Printf("loadSlabMetadataWithFallback: failed to persist synthesized metadata at %s: %v", metaPath, writeErr)
+	}
+	return synthesized, nil
+}

--- a/nil_gateway/slab_metadata_test.go
+++ b/nil_gateway/slab_metadata_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"nilchain/x/crypto_ffi"
+)
+
+func TestSlabMetadataReadWriteRoundTrip(t *testing.T) {
+	dealDir := t.TempDir()
+	dealID := uint64(42)
+	validatedAt := time.Now().UTC().Round(time.Second)
+
+	meta := &slabMetadataDocument{
+		SchemaVersion: slabMetadataSchemaVersion,
+		GenerationID:  "abc123",
+		DealID:        &dealID,
+		ManifestRoot:  "0x" + stringsRepeat("a", 96),
+		Owner:         "nil1owner",
+		Redundancy: &slabMetadataRedundancy{
+			K: 8,
+			M: 4,
+			N: 12,
+		},
+		Source:      "gateway_test",
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339Nano),
+		WitnessMdus: 2,
+		UserMdus:    3,
+		TotalMdus:   6,
+		FileRecords: []slabMetadataFileRecord{{
+			Path:        "hello.txt",
+			StartOffset: 0,
+			SizeBytes:   123,
+			Flags:       1,
+		}},
+	}
+	validated := validatedAt.Format(time.RFC3339Nano)
+	meta.LastValidatedAt = &validated
+
+	if err := writeSlabMetadataFile(dealDir, meta); err != nil {
+		t.Fatalf("writeSlabMetadataFile failed: %v", err)
+	}
+
+	decoded, err := readSlabMetadataFile(dealDir)
+	if err != nil {
+		t.Fatalf("readSlabMetadataFile failed: %v", err)
+	}
+	if decoded.SchemaVersion != slabMetadataSchemaVersion {
+		t.Fatalf("unexpected schema_version: %d", decoded.SchemaVersion)
+	}
+	if decoded.GenerationID != meta.GenerationID {
+		t.Fatalf("unexpected generation_id: %q", decoded.GenerationID)
+	}
+	if decoded.DealID == nil || *decoded.DealID != dealID {
+		t.Fatalf("unexpected deal_id: %v", decoded.DealID)
+	}
+	if decoded.ManifestRoot != meta.ManifestRoot {
+		t.Fatalf("unexpected manifest_root: %q", decoded.ManifestRoot)
+	}
+	if decoded.Source != meta.Source {
+		t.Fatalf("unexpected source: %q", decoded.Source)
+	}
+	if decoded.WitnessMdus != meta.WitnessMdus || decoded.UserMdus != meta.UserMdus || decoded.TotalMdus != meta.TotalMdus {
+		t.Fatalf("unexpected mdu counts: witness=%d user=%d total=%d", decoded.WitnessMdus, decoded.UserMdus, decoded.TotalMdus)
+	}
+	if decoded.LastValidatedAt == nil || *decoded.LastValidatedAt != validated {
+		t.Fatalf("unexpected last_validated_at: %v", decoded.LastValidatedAt)
+	}
+	if len(decoded.FileRecords) != 1 {
+		t.Fatalf("unexpected file record count: %d", len(decoded.FileRecords))
+	}
+	if decoded.FileRecords[0].Path != "hello.txt" || decoded.FileRecords[0].StartOffset != 0 || decoded.FileRecords[0].SizeBytes != 123 || decoded.FileRecords[0].Flags != 1 {
+		t.Fatalf("unexpected file record: %+v", decoded.FileRecords[0])
+	}
+}
+
+func TestLoadSlabIndex_FallbackSynthesizesSlabMetadata(t *testing.T) {
+	useTempUploadDir(t)
+
+	manifestRoot := mustTestManifestRoot(t, "slab-metadata-fallback")
+	dealDir := filepath.Join(uploadDir, manifestRoot.Key)
+	if err := os.MkdirAll(dealDir, 0o755); err != nil {
+		t.Fatalf("mkdir deal dir: %v", err)
+	}
+	defer os.RemoveAll(dealDir)
+
+	builder := crypto_ffi.NewMdu0Builder(1)
+	defer builder.Free()
+	if err := builder.AppendFileWithFlags("a.txt", 5, 0, 3); err != nil {
+		t.Fatalf("AppendFileWithFlags failed: %v", err)
+	}
+	mdu0, err := builder.Bytes()
+	if err != nil {
+		t.Fatalf("builder.Bytes failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dealDir, "mdu_0.bin"), mdu0, 0o644); err != nil {
+		t.Fatalf("write mdu_0.bin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dealDir, "mdu_1.bin"), []byte{1}, 0o644); err != nil {
+		t.Fatalf("write mdu_1.bin: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dealDir, slabMetadataFileName), []byte("{corrupt"), 0o644); err != nil {
+		t.Fatalf("seed corrupt slab metadata: %v", err)
+	}
+
+	entry, err := loadSlabIndex(dealDir)
+	if err != nil {
+		t.Fatalf("loadSlabIndex failed: %v", err)
+	}
+	if entry.witnessCount != 0 {
+		t.Fatalf("unexpected witness count: %d", entry.witnessCount)
+	}
+	info, ok := entry.files["a.txt"]
+	if !ok {
+		t.Fatalf("expected file a.txt in slab index")
+	}
+	if info.StartOffset != 0 || info.Length != 5 {
+		t.Fatalf("unexpected file info: %+v", info)
+	}
+
+	meta, err := readSlabMetadataFile(dealDir)
+	if err != nil {
+		t.Fatalf("expected synthesized slab metadata file, got error: %v", err)
+	}
+	if meta.Source != "gateway_fallback_mdu0" {
+		t.Fatalf("unexpected source: %q", meta.Source)
+	}
+	if meta.ManifestRoot != manifestRoot.Canonical {
+		t.Fatalf("unexpected manifest_root: %q", meta.ManifestRoot)
+	}
+	if meta.TotalMdus != 2 || meta.WitnessMdus != 0 || meta.UserMdus != 1 {
+		t.Fatalf("unexpected mdu counts: witness=%d user=%d total=%d", meta.WitnessMdus, meta.UserMdus, meta.TotalMdus)
+	}
+	if len(meta.FileRecords) != 1 {
+		t.Fatalf("unexpected file record count: %d", len(meta.FileRecords))
+	}
+	if meta.FileRecords[0].Path != "a.txt" || meta.FileRecords[0].Flags != 3 {
+		t.Fatalf("unexpected synthesized file record: %+v", meta.FileRecords[0])
+	}
+}
+
+func stringsRepeat(ch string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	out := make([]byte, n)
+	for i := 0; i < n; i++ {
+		out[i] = ch[0]
+	}
+	return string(out)
+}


### PR DESCRIPTION
## Summary
- implement canonical `slab_meta.json` metadata contract in gateway (`nil_gateway/slab_metadata.go`)
- persist metadata during mode1/mode2 ingest paths and synthesize safe fallback metadata from `mdu_0.bin` when missing
- make fetch/index and DealDetail/OPFS consumers prefer fresh metadata, with manifest-root freshness checks
- add OPFS metadata helpers and tests in `OpfsAdapter`

## Issue
- Closes #128

## Validation
- `cd nil_gateway && LD_LIBRARY_PATH="$PWD/../nil_core/target/release:${LD_LIBRARY_PATH}" go test ./...`
- `cd nil-website && npm run test:unit && npm run lint`
