### PR TITLE
feat(cache): enforce pre-serve freshness contract

### DIFF
--- a/nil-website/src/components/DealDetail.tsx
+++ b/nil-website/src/components/DealDetail.tsx
@@ -10,7 +10,17 @@ import { DealLivenessHeatmap } from './DealLivenessHeatmap'
 import type { ManifestInfoData, MduKzgData, NilfsFileEntry, SlabLayoutData } from '../domain/nilfs'
 import { buildBlake2sMerkleLayers } from '../lib/merkle'
 import type { LcdDeal } from '../domain/lcd'
-import { deleteCachedFile, deleteDealDirectory, hasCachedFile, readCachedFile, readMdu, readManifestRoot, readSlabMetadata, writeCachedFile } from '../lib/storage/OpfsAdapter'
+import {
+  deleteCachedFile,
+  deleteDealDirectory,
+  hasCachedFile,
+  readCachedFile,
+  readMdu,
+  readManifestRoot,
+  readSlabMetadata,
+  writeCachedFile,
+  writeSlabMetadata,
+} from '../lib/storage/OpfsAdapter'
 import { parseNilfsFilesFromMdu0 } from '../lib/nilfsLocal'
 import { inferWitnessCountFromOpfs, readNilfsFileFromOpfs } from '../lib/nilfsOpfsFetch'
 import { workerClient } from '../lib/worker-client'
@@ -18,6 +28,7 @@ import { multiaddrToHttpUrl, multiaddrToP2pTarget } from '../lib/multiaddr'
 import { useTransportRouter } from '../hooks/useTransportRouter'
 import { parseServiceHint } from '../lib/serviceHint'
 import { toHexFromBase64OrHex } from '../domain/hex'
+import { evaluateCacheFreshness, normalizeManifestRoot } from '../lib/cacheFreshness'
 
 let wasmReadyPromise: Promise<void> | null = null
 
@@ -113,6 +124,14 @@ interface FileActivity {
   action: 'download'
   status: 'pending' | 'success' | 'failed'
   error?: string
+}
+
+interface LocalCacheFreshnessResult {
+  usable: boolean
+  status: 'fresh' | 'stale' | 'unknown'
+  reason: string
+  localManifestRoot: string
+  chainManifestRoot: string
 }
 
 export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealDetailProps) {
@@ -449,11 +468,6 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
   const fetchLocalFiles = useCallback(async (dealId: string) => {
     setLoadingFiles(true)
     try {
-      const normalizeManifestRoot = (value: string | null | undefined): string => {
-        const trimmed = String(value || '').trim().toLowerCase()
-        if (!trimmed) return ''
-        return trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`
-      }
       const localMeta = await readSlabMetadata(String(dealId))
       const persistedManifestRoot = normalizeManifestRoot(await readManifestRoot(String(dealId)))
       const metadataManifestRoot = normalizeManifestRoot(localMeta?.manifest_root)
@@ -627,28 +641,57 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
     throw lastError ?? new Error('gateway cache download failed')
   }, [gatewayDownloadBases, slab?.blob_size_bytes])
 
-  const reconcileLocalMduCache = useCallback(async (dealId: string, chainManifestRoot: string): Promise<boolean> => {
-    const normalizedChainRoot = String(chainManifestRoot || '').trim().toLowerCase()
-    if (!normalizedChainRoot) return false
-
-    const localManifest = await readManifestRoot(String(dealId)).catch(() => null)
-    if (!localManifest) return false
-
-    const normalizedLocalRoot = localManifest.trim().toLowerCase()
-    if (normalizedLocalRoot === normalizedChainRoot) return true
-
-    try {
-      await deleteDealDirectory(String(dealId))
-      setBrowserCachedByPath({})
-      console.info('Cleared stale browser MDU cache', {
-        dealId,
-        localManifestRoot: normalizedLocalRoot,
-        chainManifestRoot: normalizedChainRoot,
-      })
-    } catch (e) {
-      console.warn('Failed to clear stale browser MDU cache', { dealId, error: e })
+  const reconcileLocalMduCache = useCallback(async (dealId: string, chainManifestRoot: string): Promise<LocalCacheFreshnessResult> => {
+    const localManifestRoot = await readManifestRoot(String(dealId)).catch(() => null)
+    const freshness = evaluateCacheFreshness(localManifestRoot, chainManifestRoot)
+    const base: LocalCacheFreshnessResult = {
+      usable: freshness.status === 'fresh',
+      status: freshness.status,
+      reason: freshness.reason,
+      localManifestRoot: freshness.localManifestRoot,
+      chainManifestRoot: freshness.chainManifestRoot,
     }
-    return false
+
+    if (freshness.status === 'fresh') {
+      try {
+        const localMeta = await readSlabMetadata(String(dealId))
+        if (localMeta) {
+          await writeSlabMetadata(String(dealId), {
+            ...localMeta,
+            last_validated_at: new Date().toISOString(),
+          })
+        }
+      } catch (e) {
+        console.warn('Failed to update local slab metadata freshness timestamp', { dealId, error: e })
+      }
+      return base
+    }
+
+    if (freshness.status === 'stale') {
+      try {
+        await deleteDealDirectory(String(dealId))
+        setBrowserCachedByPath({})
+        console.info('Cleared stale browser MDU cache', {
+          dealId,
+          reason: freshness.reason,
+          localManifestRoot: freshness.localManifestRoot,
+          chainManifestRoot: freshness.chainManifestRoot,
+        })
+      } catch (e) {
+        console.warn('Failed to clear stale browser MDU cache', {
+          dealId,
+          reason: freshness.reason,
+          error: e,
+        })
+        return {
+          ...base,
+          status: 'unknown',
+          reason: 'stale_cleanup_failed',
+          usable: false,
+        }
+      }
+    }
+    return base
   }, [])
 
   const fetchSlab = useCallback(async (cid: string, dealId?: string, owner?: string) => {
@@ -679,15 +722,10 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
       // Fall back to local OPFS slab layout if available (thick client / multi-tab).
       try {
         if (!dealId) return
-        const canUseLocalSlab = await reconcileLocalMduCache(String(dealId), cid)
-        if (!canUseLocalSlab) return
+        const cacheFreshness = await reconcileLocalMduCache(String(dealId), cid)
+        if (!cacheFreshness.usable) return
 
         const localMeta = await readSlabMetadata(String(dealId))
-        const normalizeManifestRoot = (value: string | null | undefined): string => {
-          const trimmed = String(value || '').trim().toLowerCase()
-          if (!trimmed) return ''
-          return trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`
-        }
         const persistedManifestRoot = normalizeManifestRoot(await readManifestRoot(String(dealId)))
         const expectedManifestRoot = normalizeManifestRoot(cid)
         const metadataManifestRoot = normalizeManifestRoot(localMeta?.manifest_root)
@@ -783,8 +821,8 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
         return
       }
 
-      const canUseLocalSlab = await reconcileLocalMduCache(String(dealId), cid)
-      if (!canUseLocalSlab) {
+      const cacheFreshness = await reconcileLocalMduCache(String(dealId), cid)
+      if (!cacheFreshness.usable) {
         setFiles(list)
         return
       }
@@ -826,8 +864,8 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
       // Local OPFS fallback: compute manifest info from locally stored MDUs.
       try {
         if (!dealId) throw new Error('missing deal id')
-        const canUseLocalSlab = await reconcileLocalMduCache(String(dealId), cid)
-        if (!canUseLocalSlab) throw new Error('local slab not available')
+        const cacheFreshness = await reconcileLocalMduCache(String(dealId), cid)
+        if (!cacheFreshness.usable) throw new Error(`local slab not available (${cacheFreshness.reason})`)
 
         const mdu0 = await readMdu(String(dealId), 0)
         if (!mdu0) throw new Error('missing local MDU #0')
@@ -905,8 +943,8 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
       // Local OPFS fallback.
       try {
         if (!dealId) throw new Error('missing deal id')
-        const canUseLocalSlab = await reconcileLocalMduCache(String(dealId), cid)
-        if (!canUseLocalSlab) throw new Error('local slab not available')
+        const cacheFreshness = await reconcileLocalMduCache(String(dealId), cid)
+        if (!cacheFreshness.usable) throw new Error(`local slab not available (${cacheFreshness.reason})`)
 
         const bytes = await readMdu(String(dealId), mduIndex)
         if (!bytes) throw new Error(`missing local MDU #${mduIndex}`)
@@ -1446,6 +1484,13 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
                                           setBusyFilePath(f.path)
                                           const dealId = String(deal.id)
                                           try {
+                                            const chainCid = String(deal.cid || '').trim()
+                                            if (chainCid) {
+                                              const cacheFreshness = await reconcileLocalMduCache(dealId, chainCid)
+                                              if (!cacheFreshness.usable) {
+                                                throw new Error(`browser cache unavailable (${cacheFreshness.reason})`)
+                                              }
+                                            }
                                             const cachedBytes = await readCachedFile(dealId, f.path)
                                             if (!cachedBytes) throw new Error('not cached in browser')
                                             downloadBytesAsFile(cachedBytes, f.path)
@@ -1473,8 +1518,8 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
                                             const safeLen = Math.max(0, Number(downloadRangeLen || 0) || 0)
                                           try {
                                             const chainCid = String(deal.cid || '').trim()
-                                            const canUseLocalSlab = await reconcileLocalMduCache(dealId, chainCid)
-                                            if (!canUseLocalSlab) throw new Error('local slab not available')
+                                            const cacheFreshness = await reconcileLocalMduCache(dealId, chainCid)
+                                            if (!cacheFreshness.usable) throw new Error(`local slab not available (${cacheFreshness.reason})`)
 
                                             const bytes = await readNilfsFileFromOpfs({
                                               dealId,
@@ -1530,14 +1575,16 @@ export function DealDetail({ deal, nilAddress, onFileActivity, topPanel }: DealD
                                           const safeStart = Math.max(0, Number(downloadRangeStart || 0) || 0)
                                           const safeLen = Math.max(0, Number(downloadRangeLen || 0) || 0)
                                           try {
-                                            const cachedBytes = await readCachedFile(dealId, f.path)
-                                            if (cachedBytes) {
-                                              downloadBytesAsFile(cachedBytes, f.path)
-                                              return
-                                            }
-
                                             if (!deal.cid) throw new Error('commit required (no on-chain CID)')
                                             const manifestHex = toHexFromBase64OrHex(deal.cid) || deal.cid
+                                            const cacheFreshness = await reconcileLocalMduCache(dealId, manifestHex)
+                                            if (cacheFreshness.usable) {
+                                              const cachedBytes = await readCachedFile(dealId, f.path)
+                                              if (cachedBytes) {
+                                                downloadBytesAsFile(cachedBytes, f.path)
+                                                return
+                                              }
+                                            }
                                             onFileActivity?.({
                                               dealId,
                                               filePath: f.path,

--- a/nil-website/src/lib/cacheFreshness.test.ts
+++ b/nil-website/src/lib/cacheFreshness.test.ts
@@ -1,0 +1,50 @@
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { evaluateCacheFreshness, normalizeManifestRoot } from './cacheFreshness'
+
+test('normalizeManifestRoot normalizes casing and 0x prefix', () => {
+  assert.strictEqual(normalizeManifestRoot('ABCDEF'), '0xabcdef')
+  assert.strictEqual(normalizeManifestRoot('0xAbCd'), '0xabcd')
+  assert.strictEqual(normalizeManifestRoot('  '), '')
+  assert.strictEqual(normalizeManifestRoot(null), '')
+})
+
+test('evaluateCacheFreshness reports unknown when chain manifest is missing', () => {
+  const result = evaluateCacheFreshness('0x11', '')
+  assert.deepStrictEqual(result, {
+    status: 'unknown',
+    reason: 'chain_manifest_missing',
+    localManifestRoot: '0x11',
+    chainManifestRoot: '',
+  })
+})
+
+test('evaluateCacheFreshness reports unknown when local manifest is missing', () => {
+  const result = evaluateCacheFreshness('', '0x22')
+  assert.deepStrictEqual(result, {
+    status: 'unknown',
+    reason: 'local_manifest_missing',
+    localManifestRoot: '',
+    chainManifestRoot: '0x22',
+  })
+})
+
+test('evaluateCacheFreshness reports fresh when roots match', () => {
+  const result = evaluateCacheFreshness('AABB', '0xaabb')
+  assert.deepStrictEqual(result, {
+    status: 'fresh',
+    reason: 'fresh',
+    localManifestRoot: '0xaabb',
+    chainManifestRoot: '0xaabb',
+  })
+})
+
+test('evaluateCacheFreshness reports stale on mismatch', () => {
+  const result = evaluateCacheFreshness('0xaaaa', '0xbbbb')
+  assert.deepStrictEqual(result, {
+    status: 'stale',
+    reason: 'stale_manifest_mismatch',
+    localManifestRoot: '0xaaaa',
+    chainManifestRoot: '0xbbbb',
+  })
+})

--- a/nil-website/src/lib/cacheFreshness.ts
+++ b/nil-website/src/lib/cacheFreshness.ts
@@ -1,0 +1,58 @@
+export type CacheFreshnessStatus = 'fresh' | 'stale' | 'unknown'
+
+export type CacheFreshnessReason =
+  | 'fresh'
+  | 'chain_manifest_missing'
+  | 'local_manifest_missing'
+  | 'stale_manifest_mismatch'
+
+export interface CacheFreshnessResult {
+  status: CacheFreshnessStatus
+  reason: CacheFreshnessReason
+  localManifestRoot: string
+  chainManifestRoot: string
+}
+
+export function normalizeManifestRoot(value: string | null | undefined): string {
+  const trimmed = String(value || '').trim().toLowerCase()
+  if (!trimmed) return ''
+  return trimmed.startsWith('0x') ? trimmed : `0x${trimmed}`
+}
+
+export function evaluateCacheFreshness(
+  localManifestRoot: string | null | undefined,
+  chainManifestRoot: string | null | undefined,
+): CacheFreshnessResult {
+  const local = normalizeManifestRoot(localManifestRoot)
+  const chain = normalizeManifestRoot(chainManifestRoot)
+  if (!chain) {
+    return {
+      status: 'unknown',
+      reason: 'chain_manifest_missing',
+      localManifestRoot: local,
+      chainManifestRoot: chain,
+    }
+  }
+  if (!local) {
+    return {
+      status: 'unknown',
+      reason: 'local_manifest_missing',
+      localManifestRoot: local,
+      chainManifestRoot: chain,
+    }
+  }
+  if (local === chain) {
+    return {
+      status: 'fresh',
+      reason: 'fresh',
+      localManifestRoot: local,
+      chainManifestRoot: chain,
+    }
+  }
+  return {
+    status: 'stale',
+    reason: 'stale_manifest_mismatch',
+    localManifestRoot: local,
+    chainManifestRoot: chain,
+  }
+}

--- a/nil_gateway/main.go
+++ b/nil_gateway/main.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/btcsuite/btcutil/bech32"
@@ -2869,19 +2870,28 @@ func GatewayFetch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 1) Guard: ensure the caller's owner matches the on-chain Deal owner.
+	// 1) Guard: ensure the caller's owner and manifest root are fresh against chain state
+	// before serving from local cache.
 	meta, err := fetchDealMeta(dealID)
 	if err != nil {
 		if errors.Is(err, ErrDealNotFound) {
+			setCacheFreshnessHeaders(w, "unknown", "deal_not_found")
 			writeJSONError(w, http.StatusNotFound, "deal not found", "")
 			return
 		}
 		log.Printf("GatewayFetch: failed to fetch deal %d: %v", dealID, err)
-		writeJSONError(w, http.StatusInternalServerError, "failed to validate deal owner", "")
+		setCacheFreshnessHeaders(w, "unknown", "chain_lookup_failed")
+		writeJSONError(
+			w,
+			http.StatusServiceUnavailable,
+			"cache freshness unknown",
+			"reason=chain_lookup_failed; unable to validate deal owner/manifest_root against chain",
+		)
 		return
 	}
 	if meta.Owner == "" || meta.Owner != owner {
-		writeJSONError(w, http.StatusForbidden, "forbidden: owner does not match deal", "")
+		setCacheFreshnessHeaders(w, "unknown", "owner_mismatch")
+		writeJSONError(w, http.StatusForbidden, "forbidden: owner does not match deal", "reason=owner_mismatch")
 		return
 	}
 
@@ -2894,28 +2904,32 @@ func GatewayFetch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if strings.TrimSpace(meta.ManifestRoot) == "" {
+		setCacheFreshnessHeaders(w, "unknown", "deal_manifest_missing")
 		writeJSONError(
 			w,
 			http.StatusConflict,
 			"deal has no committed manifest_root yet",
-			"Commit content via /gateway/update-deal-content-evm (or update-deal-content) first",
+			"reason=deal_manifest_missing; commit content via /gateway/update-deal-content-evm (or update-deal-content) first",
 		)
 		return
 	}
 	dealRoot, err := parseManifestRoot(meta.ManifestRoot)
 	if err != nil {
+		setCacheFreshnessHeaders(w, "unknown", "chain_lookup_failed")
 		writeJSONError(w, http.StatusInternalServerError, "invalid on-chain manifest_root", err.Error())
 		return
 	}
 	if manifestRootFromPath && dealRoot.Canonical != manifestRoot.Canonical {
+		setCacheFreshnessHeaders(w, "stale", "stale_manifest_mismatch")
 		writeJSONError(
 			w,
 			http.StatusConflict,
 			"stale manifest_root (does not match on-chain deal state)",
-			fmt.Sprintf("Query the deal and retry with manifest_root=%s", dealRoot.Canonical),
+			fmt.Sprintf("reason=stale_manifest_mismatch; query the deal and retry with manifest_root=%s", dealRoot.Canonical),
 		)
 		return
 	}
+	setCacheFreshnessHeaders(w, freshnessReasonFresh, freshnessReasonFresh)
 	rawManifestRoot = dealRoot.Canonical
 	manifestRoot = dealRoot
 	cleanupStaleDealGenerations(dealID, manifestRoot)
@@ -4813,8 +4827,29 @@ type dealMeta struct {
 	EndBlock     uint64
 }
 
-// fetchDealMeta calls the LCD to retrieve the deal owner, manifest_root, and end_block.
-func fetchDealMeta(dealID uint64) (dealMeta, error) {
+type dealMetaCacheEntry struct {
+	meta      dealMeta
+	expiresAt time.Time
+}
+
+var (
+	dealMetaCache        sync.Map // map[uint64]dealMetaCacheEntry
+	dealMetaCacheTTL     = time.Duration(envInt("NIL_DEAL_META_CACHE_TTL_MS", 3000)) * time.Millisecond
+	freshnessMemoTTL     = time.Duration(envInt("NIL_MANIFEST_FRESHNESS_TTL_MS", 3000)) * time.Millisecond
+	freshnessReasonFresh = "fresh"
+)
+
+func clearDealMetaCache() {
+	dealMetaCache = sync.Map{}
+}
+
+func setCacheFreshnessHeaders(w http.ResponseWriter, status, reason string) {
+	w.Header().Set("X-Nil-Cache-Freshness", strings.TrimSpace(status))
+	w.Header().Set("X-Nil-Cache-Freshness-Reason", strings.TrimSpace(reason))
+}
+
+// fetchDealMetaUncached calls the LCD to retrieve the deal owner, manifest_root, and end_block.
+func fetchDealMetaUncached(dealID uint64) (dealMeta, error) {
 	url := fmt.Sprintf("%s/nilchain/nilchain/v1/deals/%d", lcdBase, dealID)
 	resp, err := lcdHTTPClient.Get(url)
 	if err != nil {
@@ -4884,6 +4919,33 @@ func fetchDealMeta(dealID uint64) (dealMeta, error) {
 		}
 	}
 
+	return meta, nil
+}
+
+// fetchDealMeta returns deal metadata with short TTL memoization to avoid
+// repeated LCD calls across chunked retrieval flow.
+func fetchDealMeta(dealID uint64) (dealMeta, error) {
+	if freshnessMemoTTL <= 0 || dealMetaCacheTTL <= 0 {
+		return fetchDealMetaUncached(dealID)
+	}
+	now := time.Now()
+	if cachedAny, ok := dealMetaCache.Load(dealID); ok {
+		if cached, ok := cachedAny.(dealMetaCacheEntry); ok && now.Before(cached.expiresAt) {
+			return cached.meta, nil
+		}
+	}
+	meta, err := fetchDealMetaUncached(dealID)
+	if err != nil {
+		return dealMeta{}, err
+	}
+	ttl := dealMetaCacheTTL
+	if freshnessMemoTTL > 0 && freshnessMemoTTL < ttl {
+		ttl = freshnessMemoTTL
+	}
+	dealMetaCache.Store(dealID, dealMetaCacheEntry{
+		meta:      meta,
+		expiresAt: now.Add(ttl),
+	})
 	return meta, nil
 }
 

--- a/nil_gateway/main_test.go
+++ b/nil_gateway/main_test.go
@@ -438,6 +438,96 @@ func TestGatewayFetch_CIDMismatch(t *testing.T) {
 	if w.Code != http.StatusConflict {
 		t.Fatalf("expected 409 for cid mismatch, got %d", w.Code)
 	}
+	if got := strings.TrimSpace(w.Header().Get("X-Nil-Cache-Freshness")); got != "stale" {
+		t.Fatalf("expected stale cache freshness header, got %q", got)
+	}
+	if got := strings.TrimSpace(w.Header().Get("X-Nil-Cache-Freshness-Reason")); got != "stale_manifest_mismatch" {
+		t.Fatalf("expected stale_manifest_mismatch reason, got %q", got)
+	}
+}
+
+func TestGatewayFetch_ChainLookupFailureSetsFreshnessReason(t *testing.T) {
+	requireOnchainSessionForTest(t, false)
+	r := testRouter()
+
+	owner := testDealOwner(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	oldLCD := lcdBase
+	lcdBase = srv.URL
+	defer func() { lcdBase = oldLCD }()
+
+	manifestRoot := mustTestManifestRoot(t, "chain-lookup-failure")
+	q := url.Values{}
+	q.Set("deal_id", "7")
+	q.Set("owner", owner)
+	q.Set("file_path", "missing.txt")
+	req := httptest.NewRequest("GET", "/gateway/fetch/"+manifestRoot.Canonical+"?"+q.Encode(), nil)
+	req.Header.Set("Range", "bytes=0-127")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 for chain lookup failure, got %d", w.Code)
+	}
+	if got := strings.TrimSpace(w.Header().Get("X-Nil-Cache-Freshness")); got != "unknown" {
+		t.Fatalf("expected unknown cache freshness header, got %q", got)
+	}
+	if got := strings.TrimSpace(w.Header().Get("X-Nil-Cache-Freshness-Reason")); got != "chain_lookup_failed" {
+		t.Fatalf("expected chain_lookup_failed reason, got %q", got)
+	}
+}
+
+func TestFetchDealMeta_UsesShortTTLCache(t *testing.T) {
+	clearDealMetaCache()
+	origTTL := dealMetaCacheTTL
+	origFreshnessTTL := freshnessMemoTTL
+	dealMetaCacheTTL = 30 * time.Millisecond
+	freshnessMemoTTL = 30 * time.Millisecond
+	t.Cleanup(func() {
+		dealMetaCacheTTL = origTTL
+		freshnessMemoTTL = origFreshnessTTL
+		clearDealMetaCache()
+	})
+
+	requestCount := 0
+	owner := testDealOwner(t)
+	manifestRoot := mustTestManifestRoot(t, "deal-meta-cache").Canonical
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"deal":{"id":"11","owner":"` + owner + `","cid":"` + manifestRoot + `","end_block":"100"}}`))
+	}))
+	defer srv.Close()
+	oldLCD := lcdBase
+	lcdBase = srv.URL
+	defer func() { lcdBase = oldLCD }()
+
+	meta1, err := fetchDealMeta(11)
+	if err != nil {
+		t.Fatalf("first fetchDealMeta failed: %v", err)
+	}
+	meta2, err := fetchDealMeta(11)
+	if err != nil {
+		t.Fatalf("second fetchDealMeta failed: %v", err)
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected one LCD request within TTL, got %d", requestCount)
+	}
+	if meta1.ManifestRoot != manifestRoot || meta2.ManifestRoot != manifestRoot {
+		t.Fatalf("unexpected manifest roots: %q / %q", meta1.ManifestRoot, meta2.ManifestRoot)
+	}
+
+	time.Sleep(40 * time.Millisecond)
+	if _, err := fetchDealMeta(11); err != nil {
+		t.Fatalf("third fetchDealMeta after TTL failed: %v", err)
+	}
+	if requestCount < 2 {
+		t.Fatalf("expected cache expiry to trigger a new LCD request, got %d", requestCount)
+	}
 }
 
 // TestHelperProcess is used to mock exec.Command


### PR DESCRIPTION
## Summary
- enforce cache freshness contract in `GatewayFetch` with explicit freshness status/reason headers and fail-closed behavior on chain lookup failure
- add short TTL memoization for deal manifest lookups in gateway (`fetchDealMeta` cache)
- enforce browser-side cache freshness before serving browser cache or OPFS slab paths
- persist browser metadata freshness timestamps and stale-cache purge flow
- add unit/integration coverage for freshness reason codes and TTL cache behavior

## Issue
- Closes #129

## Validation
- `gofmt -w nil_gateway/main.go nil_gateway/main_test.go`
- `cd nil_gateway && LD_LIBRARY_PATH="$PWD/../nil_core/target/release:${LD_LIBRARY_PATH}" go test ./...`
- `cd nil-website && npm run test:unit && npm run lint`
