### PR TITLE
feat(cache): atomic generation activation + recovery guards

### DIFF
--- a/nil-website/src/components/FileSharder.tsx
+++ b/nil-website/src/components/FileSharder.tsx
@@ -13,11 +13,7 @@ import {
   readManifestRoot,
   readMdu,
   readShard,
-  writeManifestBlob,
-  writeManifestRoot,
-  writeMdu,
-  writeSlabMetadata,
-  writeShard,
+  writeSlabGenerationAtomically,
 } from '../lib/storage/OpfsAdapter';
 import { parseNilfsFilesFromMdu0 } from '../lib/nilfsLocal';
 import { inferWitnessCountFromOpfs, RAW_MDU_CAPACITY } from '../lib/nilfsOpfsFetch';
@@ -342,24 +338,6 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
 
       try {
         addLog('> Saving committed slab to OPFS...')
-        await writeManifestRoot(dealId, safeRoot)
-        if (manifestBlob && manifestBlob.byteLength > 0) {
-          await writeManifestBlob(dealId, manifestBlob)
-        }
-        for (const mdu of mdus) {
-          await writeMdu(dealId, mdu.index, mdu.data)
-        }
-        if (isMode2 && shards.length > 0) {
-          for (const mdu of shards) {
-            const slabIndex = 1 + witnessCount + mdu.index
-            for (let slot = 0; slot < mdu.shards.length; slot++) {
-              const shard = mdu.shards[slot]
-              if (!shard) continue
-              await writeShard(dealId, slabIndex, slot, shard)
-            }
-          }
-        }
-
         const mdu0Bytes = mdus.find((mdu) => mdu.index === 0)?.data
         const parsedFiles = mdu0Bytes ? parseNilfsFilesFromMdu0(mdu0Bytes) : []
         const fileRecords = parsedFiles.map((file) => ({
@@ -377,23 +355,38 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
         const userMdus = Math.max(userMdusByOffsets, userMdusByIndices)
         const totalMdus = 1 + safeWitnessCount + userMdus
         const generationId = safeRoot.replace(/^0x/i, '').trim() || safeRoot
-        await writeSlabMetadata(dealId, {
-          schema_version: 1,
-          generation_id: generationId,
-          deal_id: dealId,
-          manifest_root: safeRoot,
-          owner: address || undefined,
-          redundancy:
-            isMode2 && stripeParams
-              ? { k: stripeParams.k, m: stripeParams.m, n: stripeParams.k + stripeParams.m }
-              : undefined,
-          source: isMode2 ? 'browser_mode2_commit' : 'browser_mode1_commit',
-          created_at: new Date().toISOString(),
-          last_validated_at: null,
-          witness_mdus: safeWitnessCount,
-          user_mdus: userMdus,
-          total_mdus: totalMdus,
-          file_records: fileRecords,
+        const shardWrites =
+          isMode2 && shards.length > 0
+            ? shards.flatMap((mdu) => {
+                const slabIndex = 1 + witnessCount + mdu.index
+                return mdu.shards.flatMap((shard, slot) =>
+                  shard ? [{ mduIndex: slabIndex, slot, data: shard }] : [],
+                )
+              })
+            : []
+        await writeSlabGenerationAtomically(dealId, {
+          manifestRoot: safeRoot,
+          manifestBlob,
+          mdus: mdus.map((mdu) => ({ index: mdu.index, data: mdu.data })),
+          shards: shardWrites,
+          metadata: {
+            schema_version: 1,
+            generation_id: generationId,
+            deal_id: dealId,
+            manifest_root: safeRoot,
+            owner: address || undefined,
+            redundancy:
+              isMode2 && stripeParams
+                ? { k: stripeParams.k, m: stripeParams.m, n: stripeParams.k + stripeParams.m }
+                : undefined,
+            source: isMode2 ? 'browser_mode2_commit' : 'browser_mode1_commit',
+            created_at: new Date().toISOString(),
+            last_validated_at: null,
+            witness_mdus: safeWitnessCount,
+            user_mdus: userMdus,
+            total_mdus: totalMdus,
+            file_records: fileRecords,
+          },
         })
 
         lastPersistedManifestRootRef.current = safeRoot

--- a/nil-website/src/lib/storage/OpfsAdapter.test.ts
+++ b/nil-website/src/lib/storage/OpfsAdapter.test.ts
@@ -127,6 +127,30 @@ test.beforeEach(() => {
     mockRootDirectoryHandle.entries.clear();
 });
 
+function makeMetadata(opts: {
+    dealId: string
+    manifestRoot: string
+    generationId: string
+    witnessMdus?: number
+    userMdus?: number
+}): OpfsAdapter.SlabMetadata {
+    const witness = opts.witnessMdus ?? 0
+    const user = opts.userMdus ?? 1
+    return {
+        schema_version: 1,
+        generation_id: opts.generationId,
+        deal_id: opts.dealId,
+        manifest_root: opts.manifestRoot,
+        source: 'browser_test',
+        created_at: new Date().toISOString(),
+        last_validated_at: null,
+        witness_mdus: witness,
+        user_mdus: user,
+        total_mdus: 1 + witness + user,
+        file_records: [{ path: 'test.bin', start_offset: 0, size_bytes: 3, flags: 0 }],
+    }
+}
+
 test('OpfsAdapter: writeMdu and readMdu', async () => {
     const dealId = 'test-deal-write-read';
     const mduIndex = 0;
@@ -280,3 +304,88 @@ test('OpfsAdapter: cached file write/read/clear', async () => {
     assert.strictEqual(await OpfsAdapter.hasCachedFile(dealId, filePathB), false);
     assert.deepStrictEqual(await OpfsAdapter.readMdu(dealId, 0), new Uint8Array([9]));
 });
+
+test('OpfsAdapter: atomic slab generation swap preserves prior active generation on failed write', async () => {
+    const dealId = 'test-deal-atomic-swap-failure'
+    const rootA = '0x' + 'aa'.repeat(48)
+    const rootB = '0x' + 'bb'.repeat(48)
+
+    await OpfsAdapter.writeSlabGenerationAtomically(dealId, {
+        manifestRoot: rootA,
+        manifestBlob: new Uint8Array([1, 2, 3]),
+        mdus: [
+            { index: 0, data: new Uint8Array([10]) },
+            { index: 1, data: new Uint8Array([11]) },
+        ],
+        metadata: makeMetadata({
+            dealId,
+            manifestRoot: rootA,
+            generationId: rootA.slice(2),
+        }),
+    })
+    assert.deepStrictEqual(await OpfsAdapter.readMdu(dealId, 0), new Uint8Array([10]))
+    assert.strictEqual(await OpfsAdapter.readManifestRoot(dealId), rootA)
+
+    await assert.rejects(async () => {
+        await OpfsAdapter.writeSlabGenerationAtomically(dealId, {
+            manifestRoot: rootB,
+            manifestBlob: new Uint8Array([4, 5, 6]),
+            mdus: [{ index: 0, data: new Uint8Array([20]) }],
+            metadata: makeMetadata({
+                dealId,
+                manifestRoot: rootB,
+                generationId: rootB.slice(2),
+            }),
+        })
+    })
+
+    // Active generation remains unchanged after failed write.
+    assert.deepStrictEqual(await OpfsAdapter.readMdu(dealId, 0), new Uint8Array([10]))
+    assert.strictEqual(await OpfsAdapter.readManifestRoot(dealId), rootA)
+})
+
+test('OpfsAdapter: atomic slab generation swap serves new generation and cleans stale ones', async () => {
+    const dealId = 'test-deal-atomic-swap-success'
+    const rootA = '0x' + 'cc'.repeat(48)
+    const rootB = '0x' + 'dd'.repeat(48)
+
+    await OpfsAdapter.writeSlabGenerationAtomically(dealId, {
+        manifestRoot: rootA,
+        manifestBlob: new Uint8Array([1, 1, 1]),
+        mdus: [
+            { index: 0, data: new Uint8Array([30]) },
+            { index: 1, data: new Uint8Array([31]) },
+        ],
+        metadata: makeMetadata({
+            dealId,
+            manifestRoot: rootA,
+            generationId: rootA.slice(2),
+        }),
+    })
+    assert.deepStrictEqual(await OpfsAdapter.readMdu(dealId, 1), new Uint8Array([31]))
+
+    await OpfsAdapter.writeSlabGenerationAtomically(dealId, {
+        manifestRoot: rootB,
+        manifestBlob: new Uint8Array([2, 2, 2]),
+        mdus: [
+            { index: 0, data: new Uint8Array([40]) },
+            { index: 1, data: new Uint8Array([41]) },
+        ],
+        metadata: makeMetadata({
+            dealId,
+            manifestRoot: rootB,
+            generationId: rootB.slice(2),
+        }),
+    })
+
+    assert.deepStrictEqual(await OpfsAdapter.readMdu(dealId, 0), new Uint8Array([40]))
+    assert.deepStrictEqual(await OpfsAdapter.readMdu(dealId, 1), new Uint8Array([41]))
+    assert.strictEqual(await OpfsAdapter.readManifestRoot(dealId), rootB)
+    assert.strictEqual((await OpfsAdapter.readSlabMetadata(dealId))?.manifest_root, rootB)
+
+    // Listing should expose active generation files only.
+    const files = await OpfsAdapter.listDealFiles(dealId)
+    assert.ok(files.includes('mdu_0.bin'))
+    assert.ok(files.includes('mdu_1.bin'))
+    assert.ok(files.includes('manifest.bin'))
+})

--- a/nil-website/src/lib/storage/OpfsAdapter.ts
+++ b/nil-website/src/lib/storage/OpfsAdapter.ts
@@ -4,6 +4,29 @@ import { sha256 } from '@noble/hashes/sha2.js'
 import { bytesToHex } from '@noble/hashes/utils.js'
 
 const SLAB_METADATA_FILE = 'slab_meta.json'
+const GENERATIONS_DIR = 'generations'
+const ACTIVE_GENERATION_POINTER_FILE = 'active_generation.txt'
+const GENERATION_COMPLETE_MARKER_FILE = '.generation_complete'
+const GENERATION_DIR_PREFIX = 'gen-'
+
+export interface GenerationMduWrite {
+    index: number
+    data: Uint8Array
+}
+
+export interface GenerationShardWrite {
+    mduIndex: number
+    slot: number
+    data: Uint8Array
+}
+
+export interface AtomicSlabGenerationWriteInput {
+    manifestRoot: string
+    manifestBlob?: Uint8Array | null
+    mdus: GenerationMduWrite[]
+    shards?: GenerationShardWrite[]
+    metadata: SlabMetadata
+}
 
 export interface SlabMetadataFileRecord {
     path: string
@@ -47,46 +70,159 @@ async function getOpfsRoot(): Promise<FileSystemDirectoryHandle> {
  * @param dealId The ID of the deal.
  * @returns A FileSystemDirectoryHandle for the deal's directory.
  */
-async function getDealDirectory(dealId: string): Promise<FileSystemDirectoryHandle> {
+async function getDealDirectory(dealId: string, create = true): Promise<FileSystemDirectoryHandle> {
     const root = await getOpfsRoot();
-    return root.getDirectoryHandle(`deal-${dealId}`, { create: true });
+    return root.getDirectoryHandle(`deal-${dealId}`, { create });
 }
 
-async function writeBlob(dealId: string, name: string, data: BlobPart | Uint8Array<ArrayBufferLike>): Promise<void> {
-    const dealDir = await getDealDirectory(dealId);
-    const fileHandle = await dealDir.getFileHandle(name, { create: true });
-    const writable = await fileHandle.createWritable();
+async function writeBlobToDirectory(
+    dir: FileSystemDirectoryHandle,
+    name: string,
+    data: BlobPart | Uint8Array<ArrayBufferLike>,
+): Promise<void> {
+    const fileHandle = await dir.getFileHandle(name, { create: true })
+    const writable = await fileHandle.createWritable()
     // NOTE: Newer TS DOM lib defines `BlobPart` in a way that rejects `Uint8Array<ArrayBufferLike>`
     // (because it might be backed by `SharedArrayBuffer`). For OPFS writes, we accept it and rely
     // on runtime support; tests exercise the path.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await writable.write(data as any);
-    await writable.close();
+    await writable.write(data as any)
+    await writable.close()
+}
+
+async function readBlobFromDirectory(dir: FileSystemDirectoryHandle, name: string): Promise<Uint8Array | null> {
+    try {
+        const fileHandle = await dir.getFileHandle(name)
+        const file = await fileHandle.getFile()
+        const buffer = await file.arrayBuffer()
+        return new Uint8Array(buffer)
+    } catch (e: unknown) {
+        if (e instanceof Error && e.name === 'NotFoundError') return null
+        throw e
+    }
+}
+
+async function removeEntryIfExists(dir: FileSystemDirectoryHandle, name: string, recursive = false): Promise<void> {
+    try {
+        await dir.removeEntry(name, recursive ? { recursive: true } : undefined)
+    } catch (e: unknown) {
+        if (e instanceof Error && e.name === 'NotFoundError') return
+        throw e
+    }
+}
+
+async function getGenerationsDirectory(
+    dealDir: FileSystemDirectoryHandle,
+    create: boolean,
+): Promise<FileSystemDirectoryHandle | null> {
+    try {
+        return await dealDir.getDirectoryHandle(GENERATIONS_DIR, { create })
+    } catch (e: unknown) {
+        if (!create && e instanceof Error && e.name === 'NotFoundError') return null
+        throw e
+    }
+}
+
+function sanitizeGenerationName(raw: string): string {
+    return String(raw || '').trim().replace(/[^a-zA-Z0-9._-]/g, '')
+}
+
+async function readActiveGenerationName(dealDir: FileSystemDirectoryHandle): Promise<string | null> {
+    const raw = await readBlobFromDirectory(dealDir, ACTIVE_GENERATION_POINTER_FILE)
+    if (!raw) return null
+    const parsed = sanitizeGenerationName(new TextDecoder().decode(raw))
+    return parsed || null
+}
+
+async function writeActiveGenerationName(dealDir: FileSystemDirectoryHandle, generationName: string): Promise<void> {
+    const safe = sanitizeGenerationName(generationName)
+    if (!safe) throw new Error('generation name is required')
+    await writeBlobToDirectory(dealDir, ACTIVE_GENERATION_POINTER_FILE, new TextEncoder().encode(`${safe}\n`))
+}
+
+async function generationLooksComplete(dir: FileSystemDirectoryHandle): Promise<boolean> {
+    const marker = await readBlobFromDirectory(dir, GENERATION_COMPLETE_MARKER_FILE)
+    if (!marker) return false
+    const meta = await readBlobFromDirectory(dir, SLAB_METADATA_FILE)
+    const mdu0 = await readBlobFromDirectory(dir, 'mdu_0.bin')
+    const manifest = await readBlobFromDirectory(dir, 'manifest.bin')
+    return !!meta && !!mdu0 && !!manifest
+}
+
+async function removeIncompleteGenerationIfAny(
+    generationsDir: FileSystemDirectoryHandle,
+    generationName: string,
+): Promise<void> {
+    try {
+        const handle = await generationsDir.getDirectoryHandle(generationName)
+        const complete = await generationLooksComplete(handle)
+        if (!complete) {
+            await removeEntryIfExists(generationsDir, generationName, true)
+        }
+    } catch (e: unknown) {
+        if (e instanceof Error && e.name === 'NotFoundError') return
+        throw e
+    }
+}
+
+async function cleanupInactiveGenerations(
+    dealDir: FileSystemDirectoryHandle,
+    activeGenerationName: string,
+): Promise<void> {
+    const generationsDir = await getGenerationsDirectory(dealDir, false)
+    if (!generationsDir) return
+    const keep = sanitizeGenerationName(activeGenerationName)
+    // @ts-expect-error - FileSystemDirectoryHandle is iterable
+    for await (const entry of generationsDir.values()) {
+        if (entry.kind !== 'directory') continue
+        const name = sanitizeGenerationName(entry.name)
+        if (!name || name === keep) continue
+        await removeEntryIfExists(generationsDir, name, true)
+    }
+}
+
+async function resolveActiveStorageDirectory(dealId: string, create: boolean): Promise<FileSystemDirectoryHandle> {
+    const dealDir = await getDealDirectory(dealId, create)
+    const activeGenerationName = await readActiveGenerationName(dealDir)
+    if (!activeGenerationName) return dealDir
+
+    const generationsDir = await getGenerationsDirectory(dealDir, false)
+    if (!generationsDir) {
+        await removeEntryIfExists(dealDir, ACTIVE_GENERATION_POINTER_FILE)
+        return dealDir
+    }
+
+    await removeIncompleteGenerationIfAny(generationsDir, activeGenerationName)
+    try {
+        const activeDir = await generationsDir.getDirectoryHandle(activeGenerationName)
+        if (!(await generationLooksComplete(activeDir))) {
+            await removeEntryIfExists(generationsDir, activeGenerationName, true)
+            await removeEntryIfExists(dealDir, ACTIVE_GENERATION_POINTER_FILE)
+            return dealDir
+        }
+        return activeDir
+    } catch (e: unknown) {
+        if (e instanceof Error && e.name === 'NotFoundError') {
+            await removeEntryIfExists(dealDir, ACTIVE_GENERATION_POINTER_FILE)
+            return dealDir
+        }
+        throw e
+    }
+}
+
+async function writeBlob(dealId: string, name: string, data: BlobPart | Uint8Array<ArrayBufferLike>): Promise<void> {
+    const dir = await resolveActiveStorageDirectory(dealId, true)
+    await writeBlobToDirectory(dir, name, data)
 }
 
 async function readBlob(dealId: string, name: string): Promise<Uint8Array | null> {
-    const dealDir = await getDealDirectory(dealId);
-    try {
-        const fileHandle = await dealDir.getFileHandle(name);
-        const file = await fileHandle.getFile();
-        const buffer = await file.arrayBuffer();
-        return new Uint8Array(buffer);
-    } catch (e: unknown) {
-        if (e instanceof Error && e.name === 'NotFoundError') {
-            return null;
-        }
-        throw e;
-    }
+    const dir = await resolveActiveStorageDirectory(dealId, true)
+    return readBlobFromDirectory(dir, name)
 }
 
 async function deleteDealFile(dealId: string, name: string): Promise<void> {
-    const dealDir = await getDealDirectory(dealId);
-    try {
-        await dealDir.removeEntry(name);
-    } catch (e: unknown) {
-        if (e instanceof Error && e.name === 'NotFoundError') return;
-        throw e;
-    }
+    const dir = await resolveActiveStorageDirectory(dealId, true)
+    await removeEntryIfExists(dir, name)
 }
 
 /**
@@ -127,7 +263,7 @@ export async function readShard(dealId: string, mduIndex: number, slot: number):
  * @returns A Promise that resolves to an array of file names.
  */
 export async function listDealFiles(dealId: string): Promise<string[]> {
-    const dealDir = await getDealDirectory(dealId);
+    const dealDir = await resolveActiveStorageDirectory(dealId, true)
     const fileNames: string[] = [];
     // @ts-expect-error - FileSystemDirectoryHandle is iterable
     for await (const entry of dealDir.values()) {
@@ -145,13 +281,98 @@ export async function listDealFiles(dealId: string): Promise<string[]> {
 export async function deleteDealDirectory(dealId: string): Promise<void> {
     const root = await getOpfsRoot();
     try {
-        await root.removeEntry(`deal-${dealId}`, { recursive: true });
+        await root.removeEntry(`deal-${dealId}`, { recursive: true })
     } catch (e: unknown) {
-        // If the directory doesn't exist, it's already "deleted", so just ignore the error.
-        if (e instanceof Error && e.name === 'NotFoundError') {
-            return;
+        if (e instanceof Error && e.name === 'NotFoundError') return
+        throw e
+    }
+}
+
+function normalizeManifestRootString(value: string): string {
+    const trimmed = String(value || '').trim()
+    if (!trimmed) return ''
+    return trimmed.startsWith('0x') ? trimmed.toLowerCase() : `0x${trimmed.toLowerCase()}`
+}
+
+function ensureContiguousMduSet(mdus: GenerationMduWrite[], expectedTotalMdus: number): void {
+    const present = new Set<number>()
+    for (const mdu of mdus) {
+        const index = Math.floor(Number(mdu.index))
+        if (!Number.isFinite(index) || index < 0) continue
+        present.add(index)
+    }
+    for (let i = 0; i < expectedTotalMdus; i++) {
+        if (!present.has(i)) {
+            throw new Error(`generation payload is incomplete: missing mdu_${i}.bin`)
         }
-        throw e;
+    }
+}
+
+export async function writeSlabGenerationAtomically(
+    dealId: string,
+    input: AtomicSlabGenerationWriteInput,
+): Promise<void> {
+    const manifestRoot = normalizeManifestRootString(input.manifestRoot)
+    if (!manifestRoot) {
+        throw new Error('manifestRoot is required')
+    }
+    const mdus = Array.isArray(input.mdus) ? input.mdus.slice() : []
+    const shards = Array.isArray(input.shards) ? input.shards.slice() : []
+    const metadata = { ...input.metadata }
+    if (!mdus.length) {
+        throw new Error('at least one MDU is required for atomic generation write')
+    }
+    if (metadata.total_mdus !== 1 + metadata.witness_mdus + metadata.user_mdus) {
+        throw new Error('slab metadata counts are inconsistent')
+    }
+    ensureContiguousMduSet(mdus, metadata.total_mdus)
+
+    const dealDir = await getDealDirectory(dealId, true)
+    const generationsDir = await getGenerationsDirectory(dealDir, true)
+    if (!generationsDir) {
+        throw new Error('failed to create generations directory')
+    }
+
+    const generationName = `${GENERATION_DIR_PREFIX}${Date.now()}-${Math.random().toString(16).slice(2, 10)}`
+    const generationDir = await generationsDir.getDirectoryHandle(generationName, { create: true })
+    const generationIdFallback = manifestRoot.replace(/^0x/i, '')
+
+    try {
+        await writeBlobToDirectory(generationDir, 'manifest_root.txt', new TextEncoder().encode(`${manifestRoot}\n`))
+        if (input.manifestBlob && input.manifestBlob.byteLength > 0) {
+            await writeBlobToDirectory(generationDir, 'manifest.bin', input.manifestBlob)
+        } else {
+            throw new Error('manifest blob is required for atomic generation write')
+        }
+
+        for (const mdu of mdus) {
+            await writeBlobToDirectory(generationDir, `mdu_${Math.floor(mdu.index)}.bin`, mdu.data)
+        }
+        for (const shard of shards) {
+            await writeBlobToDirectory(
+                generationDir,
+                `mdu_${Math.floor(shard.mduIndex)}_slot_${Math.floor(shard.slot)}.bin`,
+                shard.data,
+            )
+        }
+
+        metadata.generation_id = String(metadata.generation_id || generationIdFallback).trim() || generationIdFallback
+        metadata.manifest_root = manifestRoot
+        if (metadata.source.trim() === '') {
+            metadata.source = 'browser_generation_swap'
+        }
+        if (metadata.created_at.trim() === '') {
+            metadata.created_at = new Date().toISOString()
+        }
+        const payload = JSON.stringify(metadata, null, 2)
+        await writeBlobToDirectory(generationDir, SLAB_METADATA_FILE, new TextEncoder().encode(payload))
+        await writeBlobToDirectory(generationDir, GENERATION_COMPLETE_MARKER_FILE, new TextEncoder().encode('ok\n'))
+
+        await writeActiveGenerationName(dealDir, generationName)
+        await cleanupInactiveGenerations(dealDir, generationName)
+    } catch (e) {
+        await removeEntryIfExists(generationsDir, generationName, true)
+        throw e
     }
 }
 

--- a/nil_gateway/main.go
+++ b/nil_gateway/main.go
@@ -620,6 +620,7 @@ func main() {
 	if err := os.MkdirAll(uploadDir, 0o755); err != nil {
 		log.Fatalf("failed to create upload dir %s: %v", uploadDir, err)
 	}
+	recoverDealGenerationStateOnStartup()
 
 	if !routerMode {
 		if err := initSessionDB(sessionDBPath); err != nil {
@@ -2391,6 +2392,16 @@ func GatewayProveRetrieval(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			writeJSONError(w, http.StatusNotFound, "slab not found on disk", "")
+			return
+		}
+		if errors.Is(err, ErrDealGenerationNotReady) {
+			setCacheFreshnessHeaders(w, "unknown", "generation_not_ready")
+			writeJSONError(
+				w,
+				http.StatusServiceUnavailable,
+				"slab generation not ready yet",
+				"reason=generation_not_ready; retry shortly while cache refresh finalizes",
+			)
 			return
 		}
 		if errors.Is(err, ErrDealDirConflict) {

--- a/nil_gateway/manifest_root.go
+++ b/nil_gateway/manifest_root.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	ErrInvalidManifestRoot = errors.New("invalid manifest_root")
-	ErrDealDirConflict     = errors.New("deal directory conflict")
+	ErrInvalidManifestRoot    = errors.New("invalid manifest_root")
+	ErrDealDirConflict        = errors.New("deal directory conflict")
+	ErrDealGenerationNotReady = errors.New("deal generation not ready")
 )
 
 type ManifestRoot struct {
@@ -104,12 +105,225 @@ func dealScopedDir(dealID uint64, root ManifestRoot) string {
 	return filepath.Join(uploadDir, "deals", strconv.FormatUint(dealID, 10), root.Key)
 }
 
-func resolveDealDirForDeal(dealID uint64, root ManifestRoot, rawParam string) (string, error) {
-	cand := dealScopedDir(dealID, root)
-	if info, err := os.Stat(cand); err == nil && info.IsDir() {
-		return cand, nil
+func dealScopedBaseDir(dealID uint64) string {
+	return filepath.Join(uploadDir, "deals", strconv.FormatUint(dealID, 10))
+}
+
+func activeDealGenerationPointerPath(dealID uint64) string {
+	return filepath.Join(dealScopedBaseDir(dealID), ".active_generation")
+}
+
+func readActiveDealGeneration(dealID uint64) (ManifestRoot, error) {
+	data, err := os.ReadFile(activeDealGenerationPointerPath(dealID))
+	if err != nil {
+		return ManifestRoot{}, err
 	}
-	return resolveDealDir(root, rawParam)
+	raw := strings.TrimSpace(string(data))
+	if raw == "" {
+		return ManifestRoot{}, os.ErrNotExist
+	}
+	if !strings.HasPrefix(strings.ToLower(raw), "0x") {
+		raw = "0x" + raw
+	}
+	return parseManifestRoot(raw)
+}
+
+func writeActiveDealGeneration(dealID uint64, root ManifestRoot) error {
+	base := dealScopedBaseDir(dealID)
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		return err
+	}
+	tmpPath := filepath.Join(base, fmt.Sprintf(".active_generation.%d.tmp", time.Now().UnixNano()))
+	if err := os.WriteFile(tmpPath, []byte(root.Canonical+"\n"), 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, activeDealGenerationPointerPath(dealID)); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+func clearActiveDealGeneration(dealID uint64) {
+	_ = os.Remove(activeDealGenerationPointerPath(dealID))
+}
+
+func validateDealGenerationReadyStrict(dealDir string) error {
+	if !mode2DirLooksComplete(dealDir) {
+		return fmt.Errorf("slab core files are incomplete")
+	}
+	meta, err := loadSlabMetadataWithFallback(dealDir)
+	if err != nil {
+		return fmt.Errorf("failed to load slab metadata: %w", err)
+	}
+	if !slabMetadataManifestMatchesDealDir(meta.ManifestRoot, dealDir) {
+		return fmt.Errorf("slab metadata manifest_root does not match generation directory")
+	}
+	requiredLocalMdus := uint64(1) + meta.WitnessMdus
+	if requiredLocalMdus == 0 {
+		requiredLocalMdus = 1
+	}
+	for i := uint64(0); i < requiredLocalMdus; i++ {
+		path := filepath.Join(dealDir, fmt.Sprintf("mdu_%d.bin", i))
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			return fmt.Errorf("missing mdu_%d.bin: %w", i, statErr)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("mdu_%d.bin is not a regular file", i)
+		}
+	}
+	return nil
+}
+
+func validateDealGenerationReadyBestEffort(dealDir string) error {
+	if mode2DirLooksComplete(dealDir) {
+		return validateDealGenerationReadyStrict(dealDir)
+	}
+	mdu0Path := filepath.Join(dealDir, "mdu_0.bin")
+	info, err := os.Stat(mdu0Path)
+	if err != nil {
+		return fmt.Errorf("missing mdu_0.bin: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("mdu_0.bin is not a regular file")
+	}
+	return nil
+}
+
+func cleanupInterruptedDealGenerations(dealID uint64) {
+	baseDealDir := dealScopedBaseDir(dealID)
+	entries, err := os.ReadDir(baseDealDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Printf("Gateway cache recovery: failed to list deal dir deal_id=%d err=%v", dealID, err)
+		}
+		return
+	}
+
+	activeRoot := ""
+	if root, err := readActiveDealGeneration(dealID); err == nil {
+		activeRoot = root.Key
+	} else if err != nil && !os.IsNotExist(err) {
+		log.Printf("Gateway cache recovery: invalid active pointer deal_id=%d err=%v", dealID, err)
+		clearActiveDealGeneration(dealID)
+	}
+
+	for _, entry := range entries {
+		name := strings.TrimSpace(entry.Name())
+		if name == "" {
+			continue
+		}
+		fullPath := filepath.Join(baseDealDir, name)
+		if !entry.IsDir() && strings.HasPrefix(name, ".") && strings.HasSuffix(name, ".lock") {
+			lockInfo, statErr := os.Stat(fullPath)
+			if statErr != nil || lockInfo.IsDir() {
+				continue
+			}
+			targetRoot := strings.TrimSuffix(strings.TrimPrefix(name, "."), ".lock")
+			targetDir := filepath.Join(baseDealDir, targetRoot)
+			if time.Since(lockInfo.ModTime()) > 2*time.Minute && !mode2DirLooksComplete(targetDir) {
+				_ = os.Remove(fullPath)
+			}
+			continue
+		}
+		if !entry.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(name, "staging-") || strings.HasPrefix(name, ".staging-") || strings.HasPrefix(name, ".tmp-") {
+			if err := os.RemoveAll(fullPath); err != nil && !os.IsNotExist(err) {
+				log.Printf("Gateway cache recovery: failed to remove staging dir deal_id=%d dir=%s err=%v", dealID, name, err)
+			}
+			continue
+		}
+		if !isManifestRootDirName(name) {
+			continue
+		}
+		if activeRoot != "" && name == activeRoot {
+			continue
+		}
+		if _, markerErr := os.Stat(filepath.Join(fullPath, mode2SlabCompleteMarker)); markerErr != nil {
+			continue
+		}
+		if err := validateDealGenerationReadyStrict(fullPath); err != nil {
+			if rmErr := os.RemoveAll(fullPath); rmErr != nil && !os.IsNotExist(rmErr) {
+				log.Printf("Gateway cache recovery: failed to remove incomplete generation deal_id=%d generation=%s err=%v", dealID, name, rmErr)
+			}
+		}
+	}
+}
+
+func recoverDealGenerationStateOnStartup() {
+	baseDealsDir := filepath.Join(uploadDir, "deals")
+	entries, err := os.ReadDir(baseDealsDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Printf("Gateway cache recovery: failed to list base deal dir %s err=%v", baseDealsDir, err)
+		}
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dealID, parseErr := strconv.ParseUint(strings.TrimSpace(entry.Name()), 10, 64)
+		if parseErr != nil {
+			continue
+		}
+		cleanupInterruptedDealGenerations(dealID)
+	}
+}
+
+func resolveDealDirForDeal(dealID uint64, root ManifestRoot, rawParam string) (string, error) {
+	cleanupInterruptedDealGenerations(dealID)
+	requestedDir := dealScopedDir(dealID, root)
+
+	if activeRoot, err := readActiveDealGeneration(dealID); err == nil {
+		activeDir := dealScopedDir(dealID, activeRoot)
+		if _, markerErr := os.Stat(filepath.Join(activeDir, mode2SlabCompleteMarker)); markerErr == nil {
+			if activeRoot.Key != root.Key {
+				if info, statErr := os.Stat(requestedDir); statErr == nil && info.IsDir() {
+					if readyErr := validateDealGenerationReadyStrict(requestedDir); readyErr != nil {
+						return "", fmt.Errorf("%w: %v", ErrDealGenerationNotReady, readyErr)
+					}
+					if setErr := writeActiveDealGeneration(dealID, root); setErr != nil {
+						return "", fmt.Errorf("failed to update active generation pointer: %w", setErr)
+					}
+					return requestedDir, nil
+				}
+				return "", os.ErrNotExist
+			}
+
+			if info, statErr := os.Stat(activeDir); statErr == nil && info.IsDir() {
+				if readyErr := validateDealGenerationReadyStrict(activeDir); readyErr != nil {
+					return "", fmt.Errorf("%w: %v", ErrDealGenerationNotReady, readyErr)
+				}
+				return activeDir, nil
+			}
+		}
+		clearActiveDealGeneration(dealID)
+	}
+
+	if info, err := os.Stat(requestedDir); err == nil && info.IsDir() {
+		if readyErr := validateDealGenerationReadyBestEffort(requestedDir); readyErr != nil {
+			return "", fmt.Errorf("%w: %v", ErrDealGenerationNotReady, readyErr)
+		}
+		if _, markerErr := os.Stat(filepath.Join(requestedDir, mode2SlabCompleteMarker)); markerErr == nil {
+			if setErr := writeActiveDealGeneration(dealID, root); setErr != nil {
+				return "", fmt.Errorf("failed to set active generation pointer: %w", setErr)
+			}
+		}
+		return requestedDir, nil
+	}
+
+	legacyDir, err := resolveDealDir(root, rawParam)
+	if err != nil {
+		return "", err
+	}
+	if readyErr := validateDealGenerationReadyBestEffort(legacyDir); readyErr != nil {
+		return "", fmt.Errorf("%w: %v", ErrDealGenerationNotReady, readyErr)
+	}
+	return legacyDir, nil
 }
 
 func isManifestRootDirName(name string) bool {
@@ -174,5 +388,9 @@ func cleanupStaleDealGenerations(dealID uint64, keepRoot ManifestRoot) {
 			name,
 			keepRoot.Key,
 		)
+	}
+
+	if err := writeActiveDealGeneration(dealID, keepRoot); err != nil {
+		log.Printf("Gateway cache cleanup: failed to persist active generation pointer deal_id=%d manifest_root=%s err=%v", dealID, keepRoot.Key, err)
 	}
 }

--- a/nil_gateway/manifest_root_test.go
+++ b/nil_gateway/manifest_root_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"nilchain/x/crypto_ffi"
+	"nilchain/x/nilchain/types"
+)
+
+func writeTestDealGeneration(t *testing.T, dealID uint64, root ManifestRoot, totalMdus uint64, omitLastMdu bool) string {
+	t.Helper()
+	if totalMdus < 1 {
+		t.Fatalf("totalMdus must be >= 1")
+	}
+	dealDir := dealScopedDir(dealID, root)
+	if err := os.MkdirAll(dealDir, 0o755); err != nil {
+		t.Fatalf("mkdir generation dir: %v", err)
+	}
+
+	builder := crypto_ffi.NewMdu0Builder(1)
+	defer builder.Free()
+	if err := builder.AppendFileWithFlags("test.bin", 64, 0, 0); err != nil {
+		t.Fatalf("append record: %v", err)
+	}
+	mdu0, err := builder.Bytes()
+	if err != nil {
+		t.Fatalf("builder bytes: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dealDir, "mdu_0.bin"), mdu0, 0o644); err != nil {
+		t.Fatalf("write mdu_0.bin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dealDir, "manifest.bin"), []byte{0x01}, 0o644); err != nil {
+		t.Fatalf("write manifest.bin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dealDir, mode2SlabCompleteMarker), []byte("ok\n"), 0o644); err != nil {
+		t.Fatalf("write complete marker: %v", err)
+	}
+
+	userMdus := totalMdus - 1
+	meta := &slabMetadataDocument{
+		SchemaVersion: slabMetadataSchemaVersion,
+		GenerationID:  root.Key,
+		DealID:        &dealID,
+		ManifestRoot:  root.Canonical,
+		Source:        "gateway_test",
+		CreatedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+		WitnessMdus:   0,
+		UserMdus:      userMdus,
+		TotalMdus:     totalMdus,
+		FileRecords: []slabMetadataFileRecord{
+			{
+				Path:        "test.bin",
+				StartOffset: 0,
+				SizeBytes:   64,
+				Flags:       0,
+			},
+		},
+	}
+	if err := writeSlabMetadataFile(dealDir, meta); err != nil {
+		t.Fatalf("write slab metadata: %v", err)
+	}
+
+	for i := uint64(1); i < totalMdus; i++ {
+		if omitLastMdu && i == totalMdus-1 {
+			continue
+		}
+		path := filepath.Join(dealDir, fmt.Sprintf("mdu_%d.bin", i))
+		if err := os.WriteFile(path, make([]byte, types.MDU_SIZE), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	return dealDir
+}
+
+func TestActiveDealGenerationPointerRoundTrip(t *testing.T) {
+	useTempUploadDir(t)
+	dealID := uint64(7)
+	root := mustTestManifestRoot(t, "pointer-roundtrip")
+
+	if err := writeActiveDealGeneration(dealID, root); err != nil {
+		t.Fatalf("writeActiveDealGeneration failed: %v", err)
+	}
+	got, err := readActiveDealGeneration(dealID)
+	if err != nil {
+		t.Fatalf("readActiveDealGeneration failed: %v", err)
+	}
+	if got.Key != root.Key {
+		t.Fatalf("pointer mismatch: got=%s want=%s", got.Key, root.Key)
+	}
+}
+
+func TestResolveDealDirForDealRejectsIncompleteGeneration(t *testing.T) {
+	useTempUploadDir(t)
+	dealID := uint64(42)
+	root := mustTestManifestRoot(t, "incomplete-generation")
+	dealDir := writeTestDealGeneration(t, dealID, root, 3, false)
+
+	meta, err := readSlabMetadataFile(dealDir)
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+	meta.WitnessMdus = 1
+	meta.UserMdus = 1
+	meta.TotalMdus = 3
+	if err := writeSlabMetadataFile(dealDir, meta); err != nil {
+		t.Fatalf("rewrite metadata: %v", err)
+	}
+	if err := os.Remove(filepath.Join(dealDir, "mdu_1.bin")); err != nil {
+		t.Fatalf("remove witness mdu: %v", err)
+	}
+
+	if err := writeActiveDealGeneration(dealID, root); err != nil {
+		t.Fatalf("write pointer: %v", err)
+	}
+	if _, err := resolveDealDirForDeal(dealID, root, root.Canonical); !errors.Is(err, ErrDealGenerationNotReady) {
+		t.Fatalf("expected ErrDealGenerationNotReady, got %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dealDir, "mdu_1.bin"), make([]byte, types.MDU_SIZE), 0o644); err != nil {
+		t.Fatalf("write missing witness mdu: %v", err)
+	}
+	got, err := resolveDealDirForDeal(dealID, root, root.Canonical)
+	if err != nil {
+		t.Fatalf("resolveDealDirForDeal failed after completing generation: %v", err)
+	}
+	if got != dealDir {
+		t.Fatalf("resolved deal dir mismatch: got=%s want=%s", got, dealDir)
+	}
+}
+
+func TestCleanupInterruptedDealGenerationsRemovesStagingAndStaleLocks(t *testing.T) {
+	useTempUploadDir(t)
+	dealID := uint64(77)
+	baseDir := dealScopedBaseDir(dealID)
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatalf("mkdir base dir: %v", err)
+	}
+
+	stagingDir := filepath.Join(baseDir, "staging-deadbeef")
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
+		t.Fatalf("mkdir staging: %v", err)
+	}
+
+	lockName := ".deadbeef.lock"
+	lockPath := filepath.Join(baseDir, lockName)
+	if err := os.WriteFile(lockPath, []byte("stale\n"), 0o644); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
+	old := time.Now().Add(-5 * time.Minute)
+	if err := os.Chtimes(lockPath, old, old); err != nil {
+		t.Fatalf("chtimes lock: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(baseDir, "deadbeef"), 0o755); err != nil {
+		t.Fatalf("mkdir lock target dir: %v", err)
+	}
+
+	cleanupInterruptedDealGenerations(dealID)
+
+	if _, err := os.Stat(stagingDir); !os.IsNotExist(err) {
+		t.Fatalf("expected staging dir removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("expected stale lock removed, stat err=%v", err)
+	}
+}
+
+func TestResolveDealDirForDealReconcilesPointerToRequestedGeneration(t *testing.T) {
+	useTempUploadDir(t)
+	dealID := uint64(91)
+	oldRoot := mustTestManifestRoot(t, "old-generation")
+	newRoot := mustTestManifestRoot(t, "new-generation")
+	writeTestDealGeneration(t, dealID, oldRoot, 2, false)
+	newDir := writeTestDealGeneration(t, dealID, newRoot, 2, false)
+
+	if err := writeActiveDealGeneration(dealID, oldRoot); err != nil {
+		t.Fatalf("write old pointer: %v", err)
+	}
+
+	gotDir, err := resolveDealDirForDeal(dealID, newRoot, newRoot.Canonical)
+	if err != nil {
+		t.Fatalf("resolveDealDirForDeal failed: %v", err)
+	}
+	if gotDir != newDir {
+		t.Fatalf("resolved dir mismatch: got=%s want=%s", gotDir, newDir)
+	}
+	active, err := readActiveDealGeneration(dealID)
+	if err != nil {
+		t.Fatalf("read pointer after reconcile: %v", err)
+	}
+	if active.Key != newRoot.Key {
+		t.Fatalf("active pointer mismatch after reconcile: got=%s want=%s", active.Key, newRoot.Key)
+	}
+}


### PR DESCRIPTION
## Summary\n- add gateway active-generation pointer semantics for deal-scoped caches with startup recovery\n- enforce strict readiness checks for pointer-managed generations while keeping legacy compatibility\n- add OPFS atomic generation activation path () with pointer swap and stale generation cleanup\n- switch browser slab persistence to atomic generation writes\n\n## Issue\n- closes #130\n\n## Validation\n- ok  	nil_gateway	(cached)
?   	nil_gateway/cmd/p2p-relay	[no test files]\n- 
> nil-website@0.0.0 test:unit
> tsx --test $(find src/lib -name '*.test.ts') src/lib/storage/OpfsAdapter.test.ts

✔ normalizeManifestRoot normalizes casing and 0x prefix (0.968163ms)
✔ evaluateCacheFreshness reports unknown when chain manifest is missing (0.893007ms)
✔ evaluateCacheFreshness reports unknown when local manifest is missing (0.176243ms)
✔ evaluateCacheFreshness reports fresh when roots match (0.151613ms)
✔ evaluateCacheFreshness reports stale on mismatch (0.275453ms)
✔ normalizeDealId trims and validates (1.361807ms)
✔ CreateDeal typed data hashes to chain digest (11.71851ms)
✔ UpdateContent typed data hashes to chain digest (4.133862ms)
✔ faucet auth token is trimmed and stored in localStorage (1.149787ms)
✔ fetchWithTimeout aborts a hanging fetch (13.222395ms)
✔ normalizeLcdParamsResponse parses retrieval params (1.775917ms)
✔ normalizeLcdParamsResponse returns null for invalid payload (0.228091ms)
✔ Mdu0Builder WASM (46.368233ms)
✔ Mdu0Builder WASM rejects paths > 40 bytes (NilFS V1) (8.733568ms)
✔ sanitizeNilfsRecordPath produces a path acceptable to Mdu0Builder (3.249064ms)
✔ buildBlake2sMerkleLayers returns empty for no leaves (1.725974ms)
✔ buildBlake2sMerkleLayers builds expected layers (duplicate-last) (2.194842ms)
✔ mode2-artifacts-v1 fixture: WASM matches golden hashes (3991.119138ms)
✔ multiaddrToHttpUrl parses http multiaddr (1.505172ms)
✔ multiaddrToP2pTarget parses ws multiaddr (0.342016ms)
✔ multiaddrToP2pTarget rejects missing p2p segment (0.181108ms)
✔ multiaddrToP2pTarget rejects non-ws transports (0.262358ms)
✔ sanitizeNilfsRecordPath: takes basename and truncates to 40 bytes (1.545501ms)
✔ sanitizeNilfsRecordPath: returns fallback for empty/whitespace (0.21341ms)
✔ planNilfsFileRangeChunks splits across blob/MDU boundaries (1.233712ms)
✔ fetchStatus keeps last known gateway state when optional probe is skipped (34.666894ms)
✔ OpfsAdapter: writeMdu and readMdu (2.733066ms)
✔ OpfsAdapter: writeShard and readShard (0.561819ms)
✔ OpfsAdapter: writeManifestBlob and readManifestBlob (0.505993ms)
✔ OpfsAdapter: write/read/delete slab metadata (1.62971ms)
✔ OpfsAdapter: readMdu returns null for non-existent file (0.380378ms)
✔ OpfsAdapter: listDealFiles (0.592352ms)
✔ OpfsAdapter: deleteDealDirectory (1.376617ms)
✔ OpfsAdapter: delete non-existent directory (0.261364ms)
✔ OpfsAdapter: slab metadata removed when deleting deal directory (0.586512ms)
✔ OpfsAdapter: cached file write/read/clear (2.615637ms)
✔ OpfsAdapter: atomic slab generation swap preserves prior active generation on failed write (2.015953ms)
✔ OpfsAdapter: atomic slab generation swap serves new generation and cleans stale ones (1.682655ms)
✔ resolveTransportPreference maps auto+connected to prefer_gateway (1.021358ms)
✔ resolveTransportPreference keeps auto when gateway is not connected (0.197157ms)
✔ resolveTransportPreference forces direct_sp when gateway is disabled (0.148912ms)
✔ resolveTransportPreference keeps prefer_p2p only when enabled (0.139334ms)
✔ allowNonGatewayBackends blocks direct/p2p fallback in prefer_gateway mode (0.203048ms)
✔ executeWithFallback falls back to direct SP when gateway is down (1.70981ms)
✔ executeWithFallback does not retry 4xx on the same backend (0.424964ms)
✔ executeWithFallback retries on 429 with the same backend (250.45235ms)
✔ executeWithFallback treats provider mismatch as terminal per-backend and falls back (0.378825ms)
✔ executeWithFallback classifies timeouts and falls back (5.021608ms)
✔ executeWithFallback honors prefer_p2p ordering (0.237226ms)
✔ resolveActiveEvmAddress prefers connected wallet when creator omitted (0.975196ms)
✔ resolveActiveEvmAddress accepts matching creator and connected wallet (0.203411ms)
✔ resolveActiveEvmAddress rejects stale creator when connected wallet changed (0.481659ms)
✔ resolveActiveEvmAddress rejects invalid address (0.168358ms)
✔ classifyWalletError flags rejected wallet requests (0.811101ms)
✔ classifyWalletError flags unauthorized wallet access (0.138936ms)
✔ classifyWalletError falls back to original message for non-wallet failures (0.109255ms)
ℹ tests 56
ℹ suites 0
ℹ pass 56
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 4341.18975\n- 
> nil-website@0.0.0 lint
> eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0\n\n## Acceptance mapping\n- Partial generations are not served once a generation is pointer-managed and marked complete\n- Active generation pointer is written after successful generation completion\n- Startup recovery removes stale staging/lock artifacts and clears invalid pointers