### PR TITLE
fix(gateway): derive deputy fetch provider from deal metadata

### DIFF
--- a/nil_gateway/fetch_test.go
+++ b/nil_gateway/fetch_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -115,6 +117,124 @@ func TestGatewayFetch_ByPath(t *testing.T) {
 		t.Fatalf("Fetch failed: %d, body: %s", w.Code, w.Body.String())
 	}
 
+	if w.Body.String() != string(fileContent) {
+		t.Errorf("Content mismatch. Want %q, got %q", string(fileContent), w.Body.String())
+	}
+}
+
+func TestGatewayFetch_DeputyUsesDealProviderWhenLocalProviderMissing(t *testing.T) {
+	requireOnchainSessionForTest(t, false)
+	useTempUploadDir(t)
+	resetProviderAddressCacheForTest(t)
+	t.Setenv("NIL_PROVIDER_ADDRESS", "")
+	t.Setenv("NIL_PROVIDER_KEY", "")
+	owner := testDealOwner(t)
+
+	if err := crypto_ffi.Init(trustedSetup); err != nil {
+		t.Fatalf("crypto_ffi.Init failed: %v", err)
+	}
+
+	fileContent := []byte("Hello World from Deputy")
+	commitmentBytes := 48
+	witnessPlain := make([]byte, niltypes.BLOBS_PER_MDU*commitmentBytes)
+	leafHashes := make([][32]byte, 0, niltypes.BLOBS_PER_MDU)
+	for i := 0; i < len(witnessPlain); i += commitmentBytes {
+		for j := 0; j < commitmentBytes; j++ {
+			witnessPlain[i+j] = byte(i / commitmentBytes)
+		}
+		leafHashes = append(leafHashes, blake2s.Sum256(witnessPlain[i:i+commitmentBytes]))
+	}
+	mduRootFr, _ := merkleRootAndPath(leafHashes, 0)
+
+	roots := make([][]byte, 3)
+	roots[0] = make([]byte, 32)
+	roots[1] = make([]byte, 32)
+	roots[2] = make([]byte, 32)
+	copy(roots[2], mduRootFr)
+	commitment, manifestBlob, err := crypto_ffi.ComputeManifestCommitment(roots)
+	if err != nil {
+		t.Fatalf("ComputeManifestCommitment failed: %v", err)
+	}
+	manifestRoot, err := parseManifestRoot("0x" + fmt.Sprintf("%x", commitment))
+	if err != nil {
+		t.Fatalf("parseManifestRoot(manifest commitment) failed: %v", err)
+	}
+
+	dealDir := filepath.Join(uploadDir, manifestRoot.Key)
+	os.MkdirAll(dealDir, 0o755)
+	defer os.RemoveAll(dealDir)
+
+	b := crypto_ffi.NewMdu0Builder(1)
+	defer b.Free()
+	b.AppendFile("video.mp4", uint64(len(fileContent)), 0)
+
+	mdu0Data, _ := b.Bytes()
+	os.WriteFile(filepath.Join(dealDir, "mdu_0.bin"), mdu0Data, 0o644)
+	os.WriteFile(filepath.Join(dealDir, "manifest.bin"), manifestBlob, 0o644)
+	os.WriteFile(filepath.Join(dealDir, "mdu_1.bin"), encodeRawToMdu(witnessPlain), 0o644)
+	os.WriteFile(filepath.Join(dealDir, "mdu_2.bin"), encodeRawToMdu(fileContent), 0o644)
+
+	const (
+		dealID           = 2
+		metadataProvider = "nil1metadataproviderfetch"
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nilchain/nilchain/v1/deals/2" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"deal": map[string]any{
+				"id":           "2",
+				"owner":        owner,
+				"cid":          manifestRoot.Canonical,
+				"service_hint": "",
+				"providers":    []string{metadataProvider},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	oldLCD := lcdBase
+	lcdBase = srv.URL
+	defer func() { lcdBase = oldLCD }()
+
+	dealProviderCache.Delete(uint64(dealID))
+	dealProvidersCache.Delete(uint64(dealID))
+	dealMode2SlotsCache.Delete(uint64(dealID))
+	dealHintCache.Delete(uint64(dealID))
+
+	r := testRouter()
+
+	nonce := uint64(2)
+	expiresAt := uint64(time.Now().Unix()) + 120
+	reqSig := signRetrievalRequest(t, dealID, "video.mp4", 0, 0, nonce, expiresAt)
+	u := fmt.Sprintf(
+		"/gateway/fetch/%s?deal_id=%d&owner=%s&file_path=video.mp4&deputy=1",
+		manifestRoot.Canonical,
+		dealID,
+		owner,
+	)
+	req := httptest.NewRequest(http.MethodGet, u, nil)
+	req.Header.Set("X-Nil-Req-Sig", reqSig)
+	req.Header.Set("X-Nil-Req-Nonce", fmt.Sprintf("%d", nonce))
+	req.Header.Set("X-Nil-Req-Expires-At", fmt.Sprintf("%d", expiresAt))
+	req.Header.Set("X-Nil-Req-Range-Start", "0")
+	req.Header.Set("X-Nil-Req-Range-Len", "0")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Fetch failed: %d, body: %s", w.Code, w.Body.String())
+	}
+	if got := strings.TrimSpace(w.Header().Get("X-Nil-Provider")); got != metadataProvider {
+		t.Fatalf("expected X-Nil-Provider=%q, got %q", metadataProvider, got)
+	}
+	if got := strings.TrimSpace(w.Header().Get("X-Nil-Deputy")); got != "1" {
+		t.Fatalf("expected X-Nil-Deputy=1, got %q", got)
+	}
 	if w.Body.String() != string(fileContent) {
 		t.Errorf("Content mismatch. Want %q, got %q", string(fileContent), w.Body.String())
 	}

--- a/nil_gateway/main.go
+++ b/nil_gateway/main.go
@@ -3315,28 +3315,26 @@ func GatewayFetch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Resolve Provider Address for the Header (for Client-Side Signing).
-	// In deputy mode, a gateway may serve cached bytes on behalf of the assigned provider
-	// even when no local provider key exists.
-	providerAddr := strings.TrimSpace(cachedProviderAddress(r.Context()))
-	if providerAddr == "" && allowDeputy {
+	// Resolve Provider Address for response/proof headers.
+	// User-gateway (deputy mode) must not depend on local provider identity;
+	// derive provider from deal metadata/session context whenever possible.
+	localProviderAddr := strings.TrimSpace(cachedProviderAddress(r.Context()))
+	providerAddr := localProviderAddr
+	if providerAddr == "" {
 		switch {
 		case isOnchainSession && onchainSession != nil && strings.TrimSpace(onchainSession.Provider) != "":
 			providerAddr = strings.TrimSpace(onchainSession.Provider)
-			w.Header().Set("X-Nil-Deputy", "1")
+			if allowDeputy {
+				w.Header().Set("X-Nil-Deputy", "1")
+			}
 		case isDownloadSession && !isOnchainSession && strings.TrimSpace(dlSession.Provider) != "":
 			providerAddr = strings.TrimSpace(dlSession.Provider)
-			w.Header().Set("X-Nil-Deputy", "1")
+			if allowDeputy {
+				w.Header().Set("X-Nil-Deputy", "1")
+			}
 		}
 	}
-	if providerAddr == "" {
-		writeJSONError(w, http.StatusInternalServerError, "provider address unavailable", "set NIL_PROVIDER_ADDRESS or NIL_PROVIDER_KEY to a valid local key")
-		return
-	}
-	if isDownloadSession && !allowDeputy && strings.TrimSpace(dlSession.Provider) != "" && strings.TrimSpace(providerAddr) != strings.TrimSpace(dlSession.Provider) {
-		writeJSONError(w, http.StatusBadRequest, "download_session does not match this provider", "provider mismatch")
-		return
-	}
+
 	if stripe.mode == 2 {
 		slot, serr := slotForLeafIndex(leafIndex, stripe)
 		if serr != nil {
@@ -3352,20 +3350,33 @@ func GatewayFetch(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusBadRequest, "slot exceeds provider set", "")
 			return
 		}
-		if !allowDeputy {
-			assign := slots[slot]
-			expectedActive := strings.TrimSpace(assign.Provider)
-			expectedPending := ""
-			if assign.Status == 2 {
-				expectedPending = strings.TrimSpace(assign.PendingProvider)
-			}
 
-			localProvider := strings.TrimSpace(providerAddr)
+		assign := slots[slot]
+		expectedActive := strings.TrimSpace(assign.Provider)
+		expectedPending := ""
+		if assign.Status == 2 {
+			expectedPending = strings.TrimSpace(assign.PendingProvider)
+		}
+		expectedForSlot := expectedActive
+		if expectedPending != "" {
+			expectedForSlot = expectedPending
+		}
+
+		if !allowDeputy {
+			if strings.TrimSpace(localProviderAddr) == "" {
+				writeJSONError(
+					w,
+					http.StatusInternalServerError,
+					"provider address unavailable",
+					"provider-daemon mode requires NIL_PROVIDER_ADDRESS or NIL_PROVIDER_KEY",
+				)
+				return
+			}
 			allowed := false
-			if expectedPending != "" && localProvider == expectedPending {
+			if expectedPending != "" && localProviderAddr == expectedPending {
 				allowed = true
 			}
-			if !allowed && expectedActive != "" && localProvider == expectedActive {
+			if !allowed && expectedActive != "" && localProviderAddr == expectedActive {
 				allowed = true
 			}
 
@@ -3377,9 +3388,29 @@ func GatewayFetch(w http.ResponseWriter, r *http.Request) {
 				writeJSONError(w, http.StatusBadRequest, "provider slot mismatch", hint)
 				return
 			}
-		} else {
+			providerAddr = localProviderAddr
+		} else if providerAddr == "" && expectedForSlot != "" {
+			providerAddr = expectedForSlot
 			w.Header().Set("X-Nil-Deputy", "1")
 		}
+	}
+
+	if providerAddr == "" && allowDeputy {
+		providers, err := resolveDealProviders(r.Context(), dealID)
+		if err == nil && len(providers) > 0 {
+			providerAddr = strings.TrimSpace(providers[0])
+			if providerAddr != "" {
+				w.Header().Set("X-Nil-Deputy", "1")
+			}
+		}
+	}
+	if providerAddr == "" {
+		writeJSONError(w, http.StatusInternalServerError, "provider address unavailable", "unable to resolve provider from deal/session metadata")
+		return
+	}
+	if isDownloadSession && !allowDeputy && strings.TrimSpace(dlSession.Provider) != "" && strings.TrimSpace(providerAddr) != strings.TrimSpace(dlSession.Provider) {
+		writeJSONError(w, http.StatusBadRequest, "download_session does not match this provider", "provider mismatch")
+		return
 	}
 
 	epochID := currentEpochID(r.Context())


### PR DESCRIPTION
## Summary\n- removes user-gateway fetch dependency on local provider key/address in deputy mode\n- resolves fetch response provider from on-chain deal/session metadata when local provider identity is absent\n- keeps provider-daemon strictness for non-deputy slot enforcement\n- adds regression coverage for deputy fetch without local provider env\n\n## Issue\n- closes #131\n\n## Validation\n- cd nil_gateway && LD_LIBRARY_PATH="../nil_core/target/release:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib:/home/mikers/.gvm/pkgsets/go1.25/global/overlay/lib" go test . -run 'TestGatewayFetch_(ByPath|DeputyUsesDealProviderWhenLocalProviderMissing)$|TestGatewayPlanRetrievalSession_(UsesMetadataProviderWithoutLocalProvider|PrefersMetadataProviderOverLocalEnv|ProviderResolutionStatusMapping)$'