### PR TITLE
Technology: add NilFS filesystem-on-slab primer

### DIFF
--- a/nil-website/src/pages/Technology.tsx
+++ b/nil-website/src/pages/Technology.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { Check, Copy, Hash, Layers, Shield, Spline } from "lucide-react";
+import { ArrowRight, Check, Copy, FolderTree, HardDrive, Hash, Layers, Shield, Spline } from "lucide-react";
 import { ShardingDeepDive } from "./ShardingDeepDive";
 import { KZGDeepDive } from "./KZGDeepDive";
 import { PerformanceDeepDive } from "./PerformanceDeepDive";
@@ -9,6 +9,14 @@ import { DeputySystem } from "./DeputySystem";
 const MDU_SIZE_BYTES = 8 * 1024 * 1024;
 const BLOB_SIZE_BYTES = 128 * 1024;
 const BLOBS_PER_MDU = MDU_SIZE_BYTES / BLOB_SIZE_BYTES; // 64
+const KZG_COMMITMENT_BYTES = 48;
+
+// NilFS (filesystem-on-slab) layout constants for MDU #0 (Super-Manifest).
+const NILFS_ROOT_TABLE_BLOBS = 16; // blobs 0..15
+const NILFS_FILE_TABLE_BLOBS = 48; // blobs 16..63
+const NILFS_ROOT_SIZE_BYTES = 32;
+const NILFS_FILE_TABLE_HEADER_BYTES = 128;
+const NILFS_FILE_RECORD_BYTES = 64;
 
 function formatBytes(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes < 0) return "—";
@@ -36,6 +44,57 @@ function computeUserMdus(fileBytes: number): number {
 function toHexBytes(value: bigint): string {
   const hex = value.toString(16);
   return "0x" + (hex.length % 2 === 0 ? hex : "0" + hex);
+}
+
+function formatIntRange(start: number, end: number): string {
+  if (start === end) return `#${start}`;
+  return `#${start}..#${end}`;
+}
+
+function formatBigintRange(start: bigint, end: bigint): string {
+  if (start === end) return start.toString();
+  return `${start.toString()}..${end.toString()}`;
+}
+
+function computeNilfsRanges(args: {
+  witnessMdus: number;
+  startOffsetBytes: number;
+  sizeBytes: number;
+}): null | {
+  metaMdus: number;
+  userMduStart: number;
+  userMduEnd: number;
+  slabMduStart: number;
+  slabMduEnd: number;
+  globalBlobStart: bigint;
+  globalBlobEnd: bigint;
+} {
+  const witnessMdus = Math.max(0, Math.floor(args.witnessMdus));
+  const startOffset = Math.max(0, Math.floor(args.startOffsetBytes));
+  const sizeBytes = Math.max(0, Math.floor(args.sizeBytes));
+  if (sizeBytes <= 0) return null;
+
+  const metaMdus = 1 + witnessMdus;
+  const endOffset = startOffset + sizeBytes - 1;
+  const userMduStart = Math.floor(startOffset / MDU_SIZE_BYTES);
+  const userMduEnd = Math.floor(endOffset / MDU_SIZE_BYTES);
+  const slabMduStart = metaMdus + userMduStart;
+  const slabMduEnd = metaMdus + userMduEnd;
+
+  const startBlobInMdu = Math.floor((startOffset % MDU_SIZE_BYTES) / BLOB_SIZE_BYTES);
+  const endBlobInMdu = Math.floor((endOffset % MDU_SIZE_BYTES) / BLOB_SIZE_BYTES);
+  const globalBlobStart = BigInt(slabMduStart) * BigInt(BLOBS_PER_MDU) + BigInt(startBlobInMdu);
+  const globalBlobEnd = BigInt(slabMduEnd) * BigInt(BLOBS_PER_MDU) + BigInt(endBlobInMdu);
+
+  return {
+    metaMdus,
+    userMduStart,
+    userMduEnd,
+    slabMduStart,
+    slabMduEnd,
+    globalBlobStart,
+    globalBlobEnd,
+  };
 }
 
 export const Technology = () => {
@@ -67,6 +126,32 @@ export const Technology = () => {
   const [exampleBytes, setExampleBytes] = useState<number>(128 * 1024 * 1024);
   const exampleUserMdus = computeUserMdus(exampleBytes);
   const exampleBlobCount = exampleUserMdus * BLOBS_PER_MDU;
+
+  const [nilfsWitnessMdus, setNilfsWitnessMdus] = useState<number>(2);
+  const nilfsMetaMdus = 1 + nilfsWitnessMdus;
+  const nilfsMaxUserMdus = 4096;
+  const nilfsCommitmentsPerUserMdu = BLOBS_PER_MDU;
+  const nilfsCommitmentsBytesPerUserMdu = nilfsCommitmentsPerUserMdu * KZG_COMMITMENT_BYTES;
+  const nilfsTotalCommitmentBytes = nilfsMaxUserMdus * nilfsCommitmentsBytesPerUserMdu;
+  const nilfsSuggestedWitnessMdus = Math.ceil(nilfsTotalCommitmentBytes / MDU_SIZE_BYTES);
+
+  const nilfsExampleFiles = useMemo(() => {
+    const files = [
+      { path: "docs/readme.md", startOffset: 0, sizeBytes: 24 * 1024 },
+      { path: "img/logo.png", startOffset: 24 * 1024, sizeBytes: 640 * 1024 },
+      { path: "datasets/telemetry.bin", startOffset: 8 * 1024 * 1024, sizeBytes: 19 * 1024 * 1024 + 700 * 1024 },
+      { path: "video/clip.mp4", startOffset: 40 * 1024 * 1024 + 128 * 1024, sizeBytes: 27 * 1024 * 1024 + 300 * 1024 },
+      { path: "db/index.sqlite", startOffset: 72 * 1024 * 1024, sizeBytes: 11 * 1024 * 1024 },
+    ];
+    return files.map((f) => ({
+      ...f,
+      ranges: computeNilfsRanges({
+        witnessMdus: nilfsWitnessMdus,
+        startOffsetBytes: f.startOffset,
+        sizeBytes: f.sizeBytes,
+      }),
+    }));
+  }, [nilfsWitnessMdus]);
 
   return (
     <div className="pt-24 pb-12 px-4 max-w-5xl mx-auto space-y-12">
@@ -101,6 +186,10 @@ export const Technology = () => {
             Jump to:{" "}
             <Link className="text-primary hover:underline" to="/technology?section=artifact-map">
               Artifact map
+            </Link>
+            {" · "}
+            <Link className="text-primary hover:underline" to="/technology?section=nilfs-primer">
+              NilFS primer
             </Link>
             {" · "}
             <Link className="text-primary hover:underline" to="/technology?section=worked-example">
@@ -241,6 +330,370 @@ export const Technology = () => {
               </tr>
             </tbody>
           </table>
+        </div>
+      </section>
+
+      <section
+        id="nilfs-primer"
+        className="rounded-2xl border border-border bg-card shadow-sm overflow-hidden"
+        data-testid="technology-nilfs-primer"
+      >
+        <div className="border-b border-border bg-muted/30 px-6 py-5 flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-xl bg-primary/10 border border-primary/20">
+              <HardDrive className="w-5 h-5 text-primary" />
+            </div>
+            <div>
+              <div className="text-xs uppercase tracking-wider text-muted-foreground font-semibold">Filesystem on Slab</div>
+              <h2 className="text-2xl font-bold text-foreground">NilFS: files built on MDUs</h2>
+            </div>
+          </div>
+          <div className="text-[11px] text-muted-foreground">
+            Jump to:{" "}
+            <Link className="text-primary hover:underline" to="/technology?section=nilfs-layout">
+              Indexing layout
+            </Link>
+            {" · "}
+            <Link className="text-primary hover:underline" to="/technology?section=nilfs-example">
+              Worked filesystem
+            </Link>
+            {" · "}
+            <Link className="text-primary hover:underline" to="/technology?section=nilfs-proof-path">
+              Proof path
+            </Link>
+          </div>
+        </div>
+
+        <div className="p-6 space-y-6">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="rounded-xl border border-border bg-background/60 p-4">
+              <div className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold">Mental model</div>
+              <div className="mt-2 text-sm text-muted-foreground">
+                A deal’s <span className="font-semibold text-foreground">slab</span> is an ordered list of MDUs. NilFS turns that slab into a
+                filesystem by storing:
+              </div>
+              <ul className="mt-3 list-disc list-inside space-y-1 text-[12px] text-muted-foreground">
+                <li>
+                  a <span className="font-semibold text-foreground">file table</span>: path → start_offset + length + flags
+                </li>
+                <li>
+                  a <span className="font-semibold text-foreground">root table</span>: slab MDU index → 32-byte root
+                </li>
+              </ul>
+              <div className="mt-3 rounded-lg border border-border bg-secondary/20 p-3 text-[12px] text-muted-foreground">
+                Key mapping: <span className="font-mono text-foreground">path → offset → (mdu, blob)</span>.
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-border bg-background/60 p-4">
+              <div className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold">Slab order</div>
+              <div className="mt-2 text-sm text-muted-foreground">
+                Slab MDUs are ordered as:
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-[12px]">
+                  <span className="rounded-full border border-border bg-background px-3 py-1 font-mono text-foreground">MDU #0</span>
+                  <ArrowRight className="h-4 w-4 text-muted-foreground" />
+                  <span className="rounded-full border border-border bg-background px-3 py-1 font-mono text-foreground">
+                    witness MDUs (#1..#{nilfsWitnessMdus})
+                  </span>
+                  <ArrowRight className="h-4 w-4 text-muted-foreground" />
+                  <span className="rounded-full border border-border bg-background px-3 py-1 font-mono text-foreground">
+                    user data MDUs (start at #{nilfsMetaMdus})
+                  </span>
+                </div>
+              </div>
+              <div className="mt-3 rounded-lg border border-border bg-secondary/20 p-3 text-[12px] text-muted-foreground">
+                In formulas: <span className="font-mono text-foreground">meta_mdus = 1 + witness_mdus</span>.
+              </div>
+            </div>
+          </div>
+
+          <div id="nilfs-layout" className="space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="text-lg font-semibold text-foreground">Indexing layout (MDU #0 Super‑Manifest)</h3>
+              <Link className="text-sm text-primary hover:underline" to="/technology?section=mdu-primer">
+                Back to MDU Primer
+              </Link>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="rounded-xl border border-border bg-background/60 p-4">
+                <div className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold">Memory map</div>
+                <div className="mt-3 space-y-2">
+                  <div className="rounded-lg border border-border overflow-hidden">
+                    <div className="grid grid-cols-12">
+                      <div className="col-span-3 bg-indigo-500/15 px-3 py-2 text-[11px]">
+                        <div className="font-semibold text-foreground">Root Table</div>
+                        <div className="text-muted-foreground">
+                          blobs 0..{NILFS_ROOT_TABLE_BLOBS - 1} ({formatBytes(NILFS_ROOT_TABLE_BLOBS * BLOB_SIZE_BYTES)})
+                        </div>
+                      </div>
+                      <div className="col-span-9 bg-emerald-500/10 px-3 py-2 text-[11px]">
+                        <div className="font-semibold text-foreground">File Table</div>
+                        <div className="text-muted-foreground">
+                          blobs {NILFS_ROOT_TABLE_BLOBS}..{NILFS_ROOT_TABLE_BLOBS + NILFS_FILE_TABLE_BLOBS - 1} (
+                          {formatBytes(NILFS_FILE_TABLE_BLOBS * BLOB_SIZE_BYTES)})
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="text-[12px] text-muted-foreground">
+                    Root table entries are fixed-width <span className="font-mono text-foreground">{NILFS_ROOT_SIZE_BYTES}B</span>. Entry{" "}
+                    <span className="font-mono text-foreground">i</span> stores the root for slab{" "}
+                    <span className="font-mono text-foreground">MDU #(i + 1)</span> (root index 0 commits to MDU #1).
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-xl border border-border bg-background/60 p-4">
+                <div className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold">Structures</div>
+                <div className="mt-3 space-y-3 text-[12px] text-muted-foreground">
+                  <div className="rounded-lg border border-border bg-background p-3">
+                    <div className="font-semibold text-foreground">FileTableHeader</div>
+                    <div className="mt-1 font-mono text-[11px]">
+                      magic[4] • version[1] • record_size[2] • record_count[4] • padding…
+                    </div>
+                    <div className="mt-1">Size: {NILFS_FILE_TABLE_HEADER_BYTES} bytes.</div>
+                  </div>
+                  <div className="rounded-lg border border-border bg-background p-3">
+                    <div className="font-semibold text-foreground">FileRecordV1</div>
+                    <div className="mt-1 font-mono text-[11px]">
+                      start_offset[u64] • length_and_flags[u64] • timestamp[u64] • path[40]
+                    </div>
+                    <div className="mt-1">
+                      Size: {NILFS_FILE_RECORD_BYTES} bytes. Flags are packed in the top 8 bits of{" "}
+                      <span className="font-mono text-foreground">length_and_flags</span>.
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-border bg-secondary/20 p-4">
+              <div className="text-sm font-semibold text-foreground">Deletion + reuse (tombstones)</div>
+              <div className="mt-1 text-[12px] text-muted-foreground">
+                NilFS reuses space by marking deleted records as tombstones (<span className="font-mono text-foreground">path[0] == 0</span>) and
+                inserting new files into a sufficiently large tombstone range, splitting leftover space into a smaller tombstone.
+              </div>
+            </div>
+          </div>
+
+          <div id="nilfs-example" className="space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <FolderTree className="h-5 w-5 text-primary" />
+                <h3 className="text-lg font-semibold text-foreground">Worked filesystem (moderate data)</h3>
+              </div>
+              <div className="text-[11px] text-muted-foreground">
+                Capacity hint: <span className="font-mono text-foreground">max_user_mdus = {nilfsMaxUserMdus}</span>
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-3">
+              <div className="rounded-xl border border-border bg-background/60 p-4">
+                <div className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold">Witness sizing</div>
+                <div className="mt-2 text-[12px] text-muted-foreground">
+                  Each user MDU has {BLOBS_PER_MDU} blob commitments:
+                  <div className="mt-1 font-mono text-foreground">
+                    {BLOBS_PER_MDU} × {KZG_COMMITMENT_BYTES}B = {nilfsCommitmentsBytesPerUserMdu}B
+                  </div>
+                </div>
+                <div className="mt-2 text-[12px] text-muted-foreground">
+                  Total commitment bytes (capacity hint):
+                  <div className="mt-1 font-mono text-foreground">
+                    {nilfsMaxUserMdus} × {nilfsCommitmentsBytesPerUserMdu}B = {formatBytes(nilfsTotalCommitmentBytes)}
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-xl border border-border bg-background/60 p-4">
+                <div className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold">Suggested W</div>
+                <div className="mt-2 text-sm text-muted-foreground">
+                  <div>
+                    <span className="font-semibold text-foreground">W</span> = ceil(commitment_bytes / 8MiB)
+                  </div>
+                  <div className="mt-2 font-mono text-foreground">W = {nilfsSuggestedWitnessMdus}</div>
+                  <div className="mt-2 text-[11px] text-muted-foreground">
+                    In real deals, the gateway reports <span className="font-mono text-foreground">witness_mdus</span>; you don’t guess.
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-xl border border-border bg-background/60 p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold">Choose W (for this example)</div>
+                    <div className="mt-2 text-[12px] text-muted-foreground">
+                      meta_mdus = <span className="font-mono text-foreground">1 + W</span>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => void handleCopy("nilfs_meta_mdus", String(nilfsMetaMdus))}
+                    className="inline-flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-xs font-semibold text-muted-foreground hover:bg-secondary/40"
+                    title="Copy meta_mdus"
+                  >
+                    {copiedKey === "nilfs_meta_mdus" ? (
+                      <Check className="h-3.5 w-3.5 text-emerald-500" />
+                    ) : (
+                      <Copy className="h-3.5 w-3.5" />
+                    )}
+                    {nilfsMetaMdus}
+                  </button>
+                </div>
+
+                <div className="mt-3 grid grid-cols-[1fr_auto] items-center gap-3">
+                  <input
+                    type="range"
+                    min={0}
+                    max={Math.max(1, nilfsSuggestedWitnessMdus * 2)}
+                    value={nilfsWitnessMdus}
+                    onChange={(e) => setNilfsWitnessMdus(clampInt(Number(e.target.value), 0, 128))}
+                    className="w-full"
+                  />
+                  <div className="rounded-lg border border-border bg-secondary/20 px-3 py-2 text-xs font-mono text-foreground">
+                    W={nilfsWitnessMdus}
+                  </div>
+                </div>
+                <div className="mt-2 text-[11px] text-muted-foreground">
+                  User data slab MDUs begin at index <span className="font-mono text-foreground">#{nilfsMetaMdus}</span>.
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-border bg-card overflow-hidden">
+              <div className="border-b border-border bg-muted/30 px-4 py-3 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                Example file table → derived MDU / blob ranges
+              </div>
+              <div className="overflow-auto">
+                <table className="min-w-full divide-y divide-border text-sm">
+                  <thead className="bg-muted/20">
+                    <tr>
+                      <th className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Path</th>
+                      <th className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                        start_offset
+                      </th>
+                      <th className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">size</th>
+                      <th className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">user MDUs</th>
+                      <th className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">slab MDUs</th>
+                      <th className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">global blobs</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {nilfsExampleFiles.map((f) => {
+                      const r = f.ranges;
+                      return (
+                        <tr key={f.path} className="hover:bg-muted/30 transition-colors">
+                          <td className="px-4 py-3 text-foreground font-semibold whitespace-nowrap">{f.path}</td>
+                          <td className="px-4 py-3 text-right font-mono text-[11px] text-muted-foreground">
+                            {f.startOffset.toLocaleString()}
+                          </td>
+                          <td className="px-4 py-3 text-right text-muted-foreground">{formatBytes(f.sizeBytes)}</td>
+                          <td className="px-4 py-3 text-right font-mono text-[11px] text-muted-foreground">
+                            {r ? formatIntRange(r.userMduStart, r.userMduEnd) : "—"}
+                          </td>
+                          <td className="px-4 py-3 text-right font-mono text-[11px] text-muted-foreground">
+                            {r ? formatIntRange(r.slabMduStart, r.slabMduEnd) : "—"}
+                          </td>
+                          <td className="px-4 py-3 text-right font-mono text-[11px] text-muted-foreground">
+                            {r ? formatBigintRange(r.globalBlobStart, r.globalBlobEnd) : "—"}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-border bg-secondary/20 p-4 text-[12px] text-muted-foreground">
+              <div className="font-semibold text-foreground">Mapping formulas</div>
+              <div className="mt-2 font-mono text-[11px] text-foreground whitespace-pre-wrap">
+                {`meta_mdus = 1 + witness_mdus
+user_mdu = floor(start_offset / 8MiB)
+slab_mdu = meta_mdus + user_mdu
+blob_in_mdu = floor((start_offset % 8MiB) / 128KiB)
+global_blob = slab_mdu * 64 + blob_in_mdu`}
+              </div>
+            </div>
+          </div>
+
+          <div id="nilfs-proof-path" className="space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="text-lg font-semibold text-foreground">Proof path (how bytes bind to the deal)</h3>
+              <Link className="text-sm text-primary hover:underline" to="/technology?section=mdu-primer">
+                Artifact definitions
+              </Link>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="rounded-xl border border-border bg-background/60 p-4">
+                <div className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold">Step 1: resolve the file</div>
+                <ol className="mt-2 space-y-2 text-[12px] text-muted-foreground list-decimal list-inside">
+                  <li>Read NilFS file table in slab MDU #0.</li>
+                  <li>
+                    Find <span className="font-mono text-foreground">start_offset</span> +{" "}
+                    <span className="font-mono text-foreground">length</span>.
+                  </li>
+                  <li>Convert the byte range into slab MDUs and global blob indices (above).</li>
+                </ol>
+              </div>
+
+              <div className="rounded-xl border border-border bg-background/60 p-4">
+                <div className="text-[10px] uppercase tracking-wide text-muted-foreground font-semibold">Step 2: verify inclusion</div>
+                <ol className="mt-2 space-y-2 text-[12px] text-muted-foreground list-decimal list-inside">
+                  <li>
+                    <span className="font-semibold text-foreground">manifest_root</span> (KZG, 48B) commits to the ordered vector of per‑MDU roots.
+                  </li>
+                  <li>
+                    Each <span className="font-semibold text-foreground">MDU root</span> (32B) commits to the 64 blob commitments for that MDU.
+                  </li>
+                  <li>
+                    Each <span className="font-semibold text-foreground">blob commitment</span> (KZG, 48B) commits to the blob bytes.
+                  </li>
+                </ol>
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-border bg-card overflow-hidden">
+              <div className="border-b border-border bg-muted/30 px-6 py-4">
+                <div className="text-sm font-semibold text-foreground">Chained proof sketch (3 hops)</div>
+                <div className="mt-1 text-[12px] text-muted-foreground">
+                  Deal commitment <span className="font-mono">→</span> MDU <span className="font-mono">→</span> Blob{" "}
+                  <span className="font-mono">→</span> Bytes.
+                </div>
+              </div>
+              <div className="p-6">
+                <div className="grid gap-3">
+                  {[
+                    {
+                      label: "Hop 1 (KZG)",
+                      detail: "Prove slab MDU root at mdu_index is included in the manifest commitment.",
+                    },
+                    {
+                      label: "Hop 2 (Merkle)",
+                      detail: "Prove blob commitment at blob_index is included in that MDU root.",
+                    },
+                    {
+                      label: "Hop 3 (KZG)",
+                      detail: "Prove the bytes you fetched are consistent with the blob commitment.",
+                    },
+                  ].map((row) => (
+                    <div key={row.label} className="flex items-start gap-3 rounded-lg border border-border bg-background/60 p-3">
+                      <div className="rounded-md border border-border bg-secondary/30 px-2 py-1 text-[11px] font-semibold text-foreground">
+                        {row.label}
+                      </div>
+                      <div className="text-[12px] text-muted-foreground">{row.detail}</div>
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-4 text-[12px] text-muted-foreground">
+                  NilFS makes the <span className="font-mono text-foreground">path → offset</span> mapping explicit; the chained proof makes the{" "}
+                  <span className="font-mono text-foreground">bytes → deal</span> binding verifiable.
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
Adds a developer-grade NilFS primer to `/#/technology` that explains how NilStore builds a filesystem on top of the slab (MDUs).

Highlights:
- NilFS mental model (path → offset → (MDU, blob)) and slab order recap.
- MDU #0 (Super-Manifest) indexing layout: Root Table + File Table (byte-accurate structure descriptions).
- Worked moderate filesystem example with derived user/slab MDU ranges + global blob ranges.
- Proof-path explanation (manifest → MDU → blob → bytes) with a 3-hop chained-proof sketch.

Note: Per rollout guidance, **do not merge** until the CI check **Workers Builds: nil-store** is green.
