### PR TITLE
feat(website): add shared sparse artifact contract

### DIFF
--- a/nil-website/src/lib/upload/sparseArtifacts.test.ts
+++ b/nil-website/src/lib/upload/sparseArtifacts.test.ts
@@ -1,0 +1,104 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  computeSparsePayloadPlan,
+  expandSparseBytes,
+  makeSparseArtifact,
+} from './sparseArtifacts'
+
+test('computeSparsePayloadPlan: empty payload stays empty', () => {
+  assert.deepStrictEqual(computeSparsePayloadPlan(new Uint8Array(0)), {
+    fullSize: 0,
+    sendSize: 0,
+    sparse: false,
+  })
+})
+
+test('computeSparsePayloadPlan: non-zero payload keeps full length', () => {
+  assert.deepStrictEqual(computeSparsePayloadPlan(new Uint8Array([1, 2, 3])), {
+    fullSize: 3,
+    sendSize: 3,
+    sparse: false,
+  })
+})
+
+test('computeSparsePayloadPlan: trailing zeros become implicit', () => {
+  assert.deepStrictEqual(computeSparsePayloadPlan(new Uint8Array([9, 8, 0, 0, 0])), {
+    fullSize: 5,
+    sendSize: 2,
+    sparse: true,
+  })
+})
+
+test('computeSparsePayloadPlan: all-zero non-empty payload preserves one-byte body', () => {
+  assert.deepStrictEqual(computeSparsePayloadPlan(new Uint8Array([0, 0, 0, 0])), {
+    fullSize: 4,
+    sendSize: 1,
+    sparse: true,
+  })
+})
+
+test('computeSparsePayloadPlan: already-truncated payload respects declared full size', () => {
+  assert.deepStrictEqual(computeSparsePayloadPlan(new Uint8Array([1, 2]), 8), {
+    fullSize: 8,
+    sendSize: 2,
+    sparse: true,
+  })
+})
+
+test('makeSparseArtifact: trims payload and preserves artifact identity', () => {
+  const artifact = makeSparseArtifact({
+    kind: 'shard',
+    index: 12,
+    slot: 3,
+    bytes: new Uint8Array([7, 7, 0, 0]),
+  })
+
+  assert.strictEqual(artifact.kind, 'shard')
+  assert.strictEqual(artifact.index, 12)
+  assert.strictEqual(artifact.slot, 3)
+  assert.strictEqual(artifact.fullSize, 4)
+  assert.deepStrictEqual(artifact.bytes, new Uint8Array([7, 7]))
+})
+
+test('makeSparseArtifact: canonicalizes all-zero sparse payloads to one zero byte', () => {
+  const artifact = makeSparseArtifact({
+    kind: 'manifest',
+    bytes: new Uint8Array(0),
+    fullSize: 128 * 1024,
+  })
+
+  assert.strictEqual(artifact.fullSize, 128 * 1024)
+  assert.deepStrictEqual(artifact.bytes, new Uint8Array([0]))
+})
+
+test('makeSparseArtifact: validates bounded-size inputs', () => {
+  assert.throws(
+    () =>
+      makeSparseArtifact({
+        kind: 'mdu',
+        index: 0,
+        bytes: new Uint8Array([1, 2, 3]),
+        fullSize: 2,
+      }),
+    /artifact bytes exceed fullSize/,
+  )
+})
+
+test('makeSparseArtifact: validates shard identity fields', () => {
+  assert.throws(
+    () =>
+      makeSparseArtifact({
+        kind: 'shard',
+        bytes: new Uint8Array([1]),
+        index: 0,
+      }),
+    /integer slot/,
+  )
+})
+
+test('expandSparseBytes: restores implicit zero tail', () => {
+  const expanded = expandSparseBytes(new Uint8Array([5, 4]), 5)
+  assert.deepStrictEqual(expanded, new Uint8Array([5, 4, 0, 0, 0]))
+})

--- a/nil-website/src/lib/upload/sparseArtifacts.ts
+++ b/nil-website/src/lib/upload/sparseArtifacts.ts
@@ -1,0 +1,110 @@
+export type SparseArtifactKind = 'mdu' | 'manifest' | 'shard'
+
+export interface SparseArtifactInput {
+  kind: SparseArtifactKind
+  bytes: Uint8Array
+  fullSize?: number
+  index?: number
+  slot?: number
+}
+
+export interface SparseArtifact {
+  kind: SparseArtifactKind
+  bytes: Uint8Array
+  fullSize: number
+  index?: number
+  slot?: number
+}
+
+export interface SparsePayloadPlan {
+  fullSize: number
+  sendSize: number
+  sparse: boolean
+}
+
+function validateArtifactIdentity(input: SparseArtifactInput): void {
+  if (input.kind === 'mdu' && !Number.isInteger(input.index)) {
+    throw new Error('MDU artifacts require an integer index')
+  }
+  if (input.kind === 'shard') {
+    if (!Number.isInteger(input.index)) {
+      throw new Error('Shard artifacts require an integer index')
+    }
+    if (!Number.isInteger(input.slot)) {
+      throw new Error('Shard artifacts require an integer slot')
+    }
+  }
+}
+
+export function computeSparsePayloadPlan(bytes: Uint8Array, declaredFullSize = bytes.byteLength): SparsePayloadPlan {
+  if (!Number.isInteger(declaredFullSize) || declaredFullSize < 0) {
+    throw new Error('fullSize must be a non-negative integer')
+  }
+  if (bytes.byteLength > declaredFullSize) {
+    throw new Error(`artifact bytes exceed fullSize: ${bytes.byteLength} > ${declaredFullSize}`)
+  }
+  if (declaredFullSize === 0) {
+    return { fullSize: 0, sendSize: 0, sparse: false }
+  }
+
+  for (let i = bytes.byteLength - 1; i >= 0; i -= 1) {
+    if (bytes[i] !== 0) {
+      const sendSize = i + 1
+      return {
+        fullSize: declaredFullSize,
+        sendSize,
+        sparse: sendSize < declaredFullSize,
+      }
+    }
+  }
+
+  // Match the Go uploader semantics: keep a non-empty body for non-empty artifacts.
+  return {
+    fullSize: declaredFullSize,
+    sendSize: 1,
+    sparse: declaredFullSize > 1 || bytes.byteLength !== 1,
+  }
+}
+
+export function makeSparseArtifact(input: SparseArtifactInput): SparseArtifact {
+  validateArtifactIdentity(input)
+
+  const fullSize = input.fullSize ?? input.bytes.byteLength
+  const plan = computeSparsePayloadPlan(input.bytes, fullSize)
+
+  let bytes: Uint8Array
+  if (plan.fullSize === 0) {
+    bytes = new Uint8Array(0)
+  } else if (input.bytes.byteLength >= plan.sendSize) {
+    bytes = input.bytes.slice(0, plan.sendSize)
+  } else if (plan.sendSize === 1 && input.bytes.byteLength === 0) {
+    bytes = new Uint8Array(1)
+  } else {
+    throw new Error(`artifact bytes shorter than planned send size: ${input.bytes.byteLength} < ${plan.sendSize}`)
+  }
+
+  return {
+    kind: input.kind,
+    index: input.index,
+    slot: input.slot,
+    fullSize: plan.fullSize,
+    bytes,
+  }
+}
+
+export function expandSparseBytes(bytes: Uint8Array, fullSize: number): Uint8Array {
+  if (!Number.isInteger(fullSize) || fullSize < 0) {
+    throw new Error('fullSize must be a non-negative integer')
+  }
+  if (bytes.byteLength > fullSize) {
+    throw new Error(`artifact bytes exceed fullSize: ${bytes.byteLength} > ${fullSize}`)
+  }
+
+  if (bytes.byteLength === fullSize) {
+    return bytes.slice()
+  }
+
+  const expanded = new Uint8Array(fullSize)
+  expanded.set(bytes, 0)
+  return expanded
+}


### PR DESCRIPTION
## Summary
- add a shared sparse artifact model for browser upload/storage code
- add Go-matching payload trimming semantics, including the non-empty all-zero rule
- add unit tests for empty, trailing-zero, all-zero, bounded-size, and expansion cases

## Testing
- cd nil-website && npm run test:unit -- src/lib/upload/sparseArtifacts.test.ts
- cd nil_core && cargo build --release
- cd nil_gateway && LD_LIBRARY_PATH=/home/mikers/dev/nil-store/nil-store/nil_core/target/release go test ./... -run 'TestMode2SparsePayloadLength'
- cd nil-website && npm run lint
- cd nil-website && npm run build

## Issue
- closes #150
- parent for #151, #152, #153, #154 stack


## Stack
- position: 1 of 10 in the sparse upload / browser compute / CI modernization stack
- base: `main`
- next PR: #161
- review order: bottom-up from #160 through #169
- merge rule: do not merge this PR before its base PR is merged
- stack validation: top-of-stack CI passed on #169 at `6f21e59c1a73efbfbaebae7c407fa8194183cb20`

