### PR TITLE
feat(website): use sparse transport for browser uploads

### DIFF
--- a/nil-website/src/components/FileSharder.tsx
+++ b/nil-website/src/components/FileSharder.tsx
@@ -24,6 +24,7 @@ import { resolveProviderEndpoints } from '../lib/providerDiscovery';
 import { useLocalGateway } from '../hooks/useLocalGateway';
 import { maybeWrapNilceZstd, peekNilceHeader, NILCE_FLAG_COMPRESSION_ZSTD } from '../lib/nilce';
 import { isTrustedLocalGatewayBase } from '../lib/transport/mode';
+import { postSparseArtifact } from '../lib/upload/sparseTransport';
 
 interface ShardItem {
   id: number;
@@ -448,16 +449,19 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
     try {
       for (const base of bases) {
         for (const mdu of metadataMdus) {
-          const res = await fetch(`${base}/sp/upload_mdu`, {
-            method: 'POST',
+          const res = await postSparseArtifact({
+            url: `${base}/sp/upload_mdu`,
             headers: {
               'X-Nil-Deal-ID': dealId,
               'X-Nil-Mdu-Index': String(mdu.index),
               'X-Nil-Manifest-Root': manifestRoot,
               'Content-Type': 'application/octet-stream',
             },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            body: new Blob([mdu.data as any]),
+            artifact: {
+              kind: 'mdu',
+              index: mdu.index,
+              bytes: mdu.data,
+            },
           })
           if (!res.ok) {
             const msg = await res.text().catch(() => '')
@@ -465,15 +469,17 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
           }
         }
 
-        const manRes = await fetch(`${base}/sp/upload_manifest`, {
-          method: 'POST',
+        const manRes = await postSparseArtifact({
+          url: `${base}/sp/upload_manifest`,
           headers: {
             'X-Nil-Deal-ID': dealId,
             'X-Nil-Manifest-Root': manifestRoot,
             'Content-Type': 'application/octet-stream',
           },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          body: new Blob([currentManifestBlob as any]),
+          artifact: {
+            kind: 'manifest',
+            bytes: currentManifestBlob,
+          },
         })
         if (!manRes.ok) {
           const msg = await manRes.text().catch(() => '')
@@ -489,8 +495,8 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
           if (!shard) {
             throw new Error(`missing shard for slot ${slot}`)
           }
-          const res = await fetch(`${base}/sp/upload_shard`, {
-            method: 'POST',
+          const res = await postSparseArtifact({
+            url: `${base}/sp/upload_shard`,
             headers: {
               'X-Nil-Deal-ID': dealId,
               'X-Nil-Mdu-Index': String(slabIndex),
@@ -498,8 +504,12 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
               'X-Nil-Manifest-Root': manifestRoot,
               'Content-Type': 'application/octet-stream',
             },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            body: new Blob([shard as any]),
+            artifact: {
+              kind: 'shard',
+              index: slabIndex,
+              slot,
+              bytes: shard,
+            },
           })
           if (!res.ok) {
             const msg = await res.text().catch(() => '')
@@ -636,16 +646,19 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
         if (!data) {
           throw new Error(`missing local MDU: mdu_${idx}.bin`)
         }
-        const res = await fetch(`${gatewayBase}${mirrorMduPath}`, {
-          method: 'POST',
+        const res = await postSparseArtifact({
+          url: `${gatewayBase}${mirrorMduPath}`,
           headers: {
             'X-Nil-Deal-ID': dealId,
             'X-Nil-Mdu-Index': String(idx),
             'X-Nil-Manifest-Root': manifestRoot,
             'Content-Type': 'application/octet-stream',
           },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          body: new Blob([data as any]),
+          artifact: {
+            kind: 'mdu',
+            index: idx,
+            bytes: data,
+          },
         })
         if (!res.ok) {
           const txt = await res.text().catch(() => '')
@@ -655,15 +668,17 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
 
       const manifestBlob = await readManifestBlob(dealId)
       if (manifestBlob && manifestBlob.byteLength > 0) {
-        const manifestRes = await fetch(`${gatewayBase}${mirrorManifestPath}`, {
-          method: 'POST',
+        const manifestRes = await postSparseArtifact({
+          url: `${gatewayBase}${mirrorManifestPath}`,
           headers: {
             'X-Nil-Deal-ID': dealId,
             'X-Nil-Manifest-Root': manifestRoot,
             'Content-Type': 'application/octet-stream',
           },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          body: new Blob([manifestBlob as any]),
+          artifact: {
+            kind: 'manifest',
+            bytes: manifestBlob,
+          },
         })
         if (!manifestRes.ok) {
           const txt = await manifestRes.text().catch(() => '')
@@ -678,8 +693,8 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
         if (!shard) {
           throw new Error(`missing local shard: mdu_${entry.mduIndex}_slot_${entry.slot}.bin`)
         }
-        const res = await fetch(`${gatewayBase}${mirrorShardPath}`, {
-          method: 'POST',
+        const res = await postSparseArtifact({
+          url: `${gatewayBase}${mirrorShardPath}`,
           headers: {
             'X-Nil-Deal-ID': dealId,
             'X-Nil-Mdu-Index': String(entry.mduIndex),
@@ -687,8 +702,12 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
             'X-Nil-Manifest-Root': manifestRoot,
             'Content-Type': 'application/octet-stream',
           },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          body: new Blob([shard as any]),
+          artifact: {
+            kind: 'shard',
+            index: entry.mduIndex,
+            slot: entry.slot,
+            bytes: shard,
+          },
         })
         if (!res.ok) {
           const txt = await res.text().catch(() => '')
@@ -906,16 +925,19 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
         : collectedMdus
 
       for (const mdu of metadataMdus) {
-        const res = await fetch(`${gatewayBase}${mirrorMduPath}`, {
-          method: 'POST',
+        const res = await postSparseArtifact({
+          url: `${gatewayBase}${mirrorMduPath}`,
           headers: {
             'X-Nil-Deal-ID': dealId,
             'X-Nil-Mdu-Index': String(mdu.index),
             'X-Nil-Manifest-Root': manifestRoot,
             'Content-Type': 'application/octet-stream',
           },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          body: new Blob([mdu.data as any]),
+          artifact: {
+            kind: 'mdu',
+            index: mdu.index,
+            bytes: mdu.data,
+          },
         })
         if (!res.ok) {
           const txt = await res.text().catch(() => '')
@@ -923,15 +945,17 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
         }
       }
 
-      const manifestRes = await fetch(`${gatewayBase}${mirrorManifestPath}`, {
-        method: 'POST',
+      const manifestRes = await postSparseArtifact({
+        url: `${gatewayBase}${mirrorManifestPath}`,
         headers: {
           'X-Nil-Deal-ID': dealId,
           'X-Nil-Manifest-Root': manifestRoot,
           'Content-Type': 'application/octet-stream',
         },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        body: new Blob([currentManifestBlob as any]),
+        artifact: {
+          kind: 'manifest',
+          bytes: currentManifestBlob,
+        },
       })
       if (!manifestRes.ok) {
         const txt = await manifestRes.text().catch(() => '')
@@ -946,8 +970,8 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
             if (!shard) {
               throw new Error(`missing shard for slot ${slot}`)
             }
-            const res = await fetch(`${gatewayBase}${mirrorShardPath}`, {
-              method: 'POST',
+            const res = await postSparseArtifact({
+              url: `${gatewayBase}${mirrorShardPath}`,
               headers: {
                 'X-Nil-Deal-ID': dealId,
                 'X-Nil-Mdu-Index': String(slabIndex),
@@ -955,8 +979,12 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
                 'X-Nil-Manifest-Root': manifestRoot,
                 'Content-Type': 'application/octet-stream',
               },
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              body: new Blob([shard as any]),
+              artifact: {
+                kind: 'shard',
+                index: slabIndex,
+                slot,
+                bytes: shard,
+              },
             })
             if (!res.ok) {
               const txt = await res.text().catch(() => '')

--- a/nil-website/src/hooks/useDirectUpload.ts
+++ b/nil-website/src/hooks/useDirectUpload.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { postSparseArtifact } from '../lib/upload/sparseTransport';
 
 interface DirectUploadOptions {
   dealId: string;
@@ -62,16 +63,19 @@ export function useDirectUpload(options: DirectUploadOptions): DirectUploadResul
       const url = `${providerBaseUrl}/sp/upload_mdu`;
 
       try {
-        const response = await fetch(url, {
-          method: 'POST',
+        const response = await postSparseArtifact({
+          url,
           headers: {
             'X-Nil-Deal-ID': dealId,
             'X-Nil-Mdu-Index': String(mdu.index),
             'X-Nil-Manifest-Root': manifestRoot,
-            'Content-Type': 'application/octet-stream', // Important for raw binary body
+            'Content-Type': 'application/octet-stream',
           },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          body: new Blob([mdu.data as any]),
+          artifact: {
+            kind: 'mdu',
+            index: mdu.index,
+            bytes: mdu.data,
+          },
         });
 
         if (!response.ok) {
@@ -108,15 +112,17 @@ export function useDirectUpload(options: DirectUploadOptions): DirectUploadResul
         }
 
         const url = `${providerBaseUrl}/sp/upload_manifest`
-        const response = await fetch(url, {
-          method: 'POST',
+        const response = await postSparseArtifact({
+          url,
           headers: {
             'X-Nil-Deal-ID': dealId,
             'X-Nil-Manifest-Root': manifestRoot,
             'Content-Type': 'application/octet-stream',
           },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          body: new Blob([manifestBlob as any]),
+          artifact: {
+            kind: 'manifest',
+            bytes: manifestBlob,
+          },
         })
 
         if (!response.ok) {

--- a/nil-website/src/lib/upload/sparseTransport.test.ts
+++ b/nil-website/src/lib/upload/sparseTransport.test.ts
@@ -1,0 +1,86 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { postSparseArtifact } from './sparseTransport'
+
+test('postSparseArtifact sends truncated body with X-Nil-Full-Size', async () => {
+  const calls: Array<{ headers: Record<string, string>; bytes: Uint8Array }> = []
+  const fetchImpl: typeof fetch = async (_url, init) => {
+    const headers = init?.headers as Record<string, string>
+    const body = init?.body as Blob
+    const bytes = new Uint8Array(await body.arrayBuffer())
+    calls.push({ headers, bytes })
+    return new Response('ok', { status: 200 })
+  }
+
+  const response = await postSparseArtifact({
+    url: 'http://example.test/sp/upload_mdu',
+    headers: { 'X-Nil-Deal-ID': '1' },
+    artifact: {
+      kind: 'mdu',
+      index: 0,
+      bytes: new Uint8Array([1, 2, 0, 0]),
+    },
+    fetchImpl,
+  })
+
+  assert.equal(response.status, 200)
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].headers['X-Nil-Full-Size'], '4')
+  assert.deepStrictEqual(calls[0].bytes, new Uint8Array([1, 2]))
+})
+
+test('postSparseArtifact retries once with full payload on sparse rollout rejection', async () => {
+  const calls: Array<{ headers: Record<string, string>; bytes: Uint8Array }> = []
+  const fetchImpl: typeof fetch = async (_url, init) => {
+    const headers = init?.headers as Record<string, string>
+    const body = init?.body as Blob
+    const bytes = new Uint8Array(await body.arrayBuffer())
+    calls.push({ headers, bytes })
+    return calls.length === 1 ? new Response('bad', { status: 400 }) : new Response('ok', { status: 200 })
+  }
+
+  const response = await postSparseArtifact({
+    url: 'http://example.test/sp/upload_manifest',
+    headers: { 'X-Nil-Deal-ID': '1' },
+    artifact: {
+      kind: 'manifest',
+      bytes: new Uint8Array([9, 0, 0]),
+    },
+    fetchImpl,
+  })
+
+  assert.equal(response.status, 200)
+  assert.equal(calls.length, 2)
+  assert.equal(calls[0].headers['X-Nil-Full-Size'], '3')
+  assert.deepStrictEqual(calls[0].bytes, new Uint8Array([9]))
+  assert.equal(calls[1].headers['X-Nil-Full-Size'], undefined)
+  assert.deepStrictEqual(calls[1].bytes, new Uint8Array([9, 0, 0]))
+})
+
+test('postSparseArtifact keeps non-empty all-zero payloads sparse', async () => {
+  const calls: Array<{ headers: Record<string, string>; bytes: Uint8Array }> = []
+  const fetchImpl: typeof fetch = async (_url, init) => {
+    const headers = init?.headers as Record<string, string>
+    const body = init?.body as Blob
+    const bytes = new Uint8Array(await body.arrayBuffer())
+    calls.push({ headers, bytes })
+    return new Response('ok', { status: 200 })
+  }
+
+  await postSparseArtifact({
+    url: 'http://example.test/sp/upload_shard',
+    headers: { 'X-Nil-Deal-ID': '1', 'X-Nil-Slot': '0' },
+    artifact: {
+      kind: 'shard',
+      index: 3,
+      slot: 0,
+      bytes: new Uint8Array(16),
+    },
+    fetchImpl,
+  })
+
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].headers['X-Nil-Full-Size'], '16')
+  assert.deepStrictEqual(calls[0].bytes, new Uint8Array([0]))
+})

--- a/nil-website/src/lib/upload/sparseTransport.ts
+++ b/nil-website/src/lib/upload/sparseTransport.ts
@@ -1,0 +1,48 @@
+import { makeSparseArtifact, type SparseArtifactInput } from './sparseArtifacts'
+
+export interface SparseUploadRequest {
+  url: string
+  headers: Record<string, string>
+  artifact: SparseArtifactInput
+  fetchImpl?: typeof fetch
+}
+
+function shouldRetrySparseUpload(response: Response, sendSize: number, fullSize: number): boolean {
+  return sendSize < fullSize && (response.status === 400 || response.status === 411)
+}
+
+function buildBody(bytes: Uint8Array): Blob {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new Blob([bytes as any])
+}
+
+export async function postSparseArtifact(request: SparseUploadRequest): Promise<Response> {
+  const fetchImpl = request.fetchImpl ?? fetch
+  const sparseArtifact = makeSparseArtifact(request.artifact)
+  const fullPayload = request.artifact.bytes
+
+  const post = async (bodyBytes: Uint8Array, fullSizeHeader?: number): Promise<Response> => {
+    const headers: Record<string, string> = {
+      ...request.headers,
+      'Content-Type': request.headers['Content-Type'] || 'application/octet-stream',
+    }
+    if (fullSizeHeader != null && bodyBytes.byteLength < fullSizeHeader) {
+      headers['X-Nil-Full-Size'] = String(fullSizeHeader)
+    } else {
+      delete headers['X-Nil-Full-Size']
+    }
+
+    return fetchImpl(request.url, {
+      method: 'POST',
+      headers,
+      body: buildBody(bodyBytes),
+    })
+  }
+
+  let response = await post(sparseArtifact.bytes, sparseArtifact.fullSize)
+  if (shouldRetrySparseUpload(response, sparseArtifact.bytes.byteLength, sparseArtifact.fullSize)) {
+    response.body?.cancel?.().catch(() => {})
+    response = await post(fullPayload, undefined)
+  }
+  return response
+}

--- a/nil-website/tests/direct-upload.spec.ts
+++ b/nil-website/tests/direct-upload.spec.ts
@@ -28,6 +28,7 @@ test('Thick Client: Direct Upload and Commit', async ({ page }) => {
 
   let manifestUploadCalls = 0
   let dealCid = ''
+  let sparseUploadObserved = false
 
   // Intercept SP Upload
   await page.route('**/sp/upload_mdu', async (route) => {
@@ -35,10 +36,15 @@ test('Thick Client: Direct Upload and Commit', async ({ page }) => {
     const dealId = headers['x-nil-deal-id']
     const manifestRoot = headers['x-nil-manifest-root']
     const mduIndex = headers['x-nil-mdu-index']
+    const fullSizeHeader = headers['x-nil-full-size']
+    const body = route.request().postDataBuffer()
 
     if (!dealId || !manifestRoot || !mduIndex) {
         console.log(`[SP Upload Mock] Missing headers: Deal=${dealId}, Root=${manifestRoot}, Index=${mduIndex}`)
         return route.fulfill({ status: 400, body: 'Missing headers' })
+    }
+    if (fullSizeHeader && body && body.length < Number(fullSizeHeader)) {
+      sparseUploadObserved = true
     }
     console.log(`[SP Upload Mock] Received MDU #${mduIndex} for Deal ${dealId} (Root: ${manifestRoot})`)
     return route.fulfill({ status: 200, body: 'OK' })
@@ -46,6 +52,12 @@ test('Thick Client: Direct Upload and Commit', async ({ page }) => {
 
   await page.route('**/sp/upload_manifest', async (route) => {
     manifestUploadCalls += 1
+    const headers = route.request().headers()
+    const body = route.request().postDataBuffer()
+    const fullSizeHeader = headers['x-nil-full-size']
+    if (fullSizeHeader && body && body.length < Number(fullSizeHeader)) {
+      sparseUploadObserved = true
+    }
     return route.fulfill({ status: 200, body: 'OK' })
   })
 
@@ -287,6 +299,7 @@ test('Thick Client: Direct Upload and Commit', async ({ page }) => {
   await expect(page.getByRole('button', { name: 'Upload Complete' })).toBeVisible({ timeout: 30000 })
   console.log('Upload complete.')
   await expect.poll(() => manifestUploadCalls, { timeout: 30_000 }).toBeGreaterThan(0)
+  await expect.poll(() => sparseUploadObserved, { timeout: 30_000 }).toBe(true)
 
   // Check "Commit to Chain" button
   const commitBtn = page.getByRole('button', { name: 'Commit to Chain' })
@@ -305,7 +318,18 @@ test('Thick Client: Direct Upload and Commit', async ({ page }) => {
   dealCid = (await page.evaluate(async () => {
     const root = await navigator.storage.getDirectory()
     const dealDir = await root.getDirectoryHandle('deal-1', { create: false })
-    const fh = await dealDir.getFileHandle('manifest_root.txt', { create: false })
+    let storageDir = dealDir
+    try {
+      const activeHandle = await dealDir.getFileHandle('active_generation.txt', { create: false })
+      const activeText = (await (await activeHandle.getFile()).text()).trim()
+      if (activeText) {
+        const generationsDir = await dealDir.getDirectoryHandle('generations', { create: false })
+        storageDir = await generationsDir.getDirectoryHandle(activeText, { create: false })
+      }
+    } catch {
+      // Older layouts may still store files directly at the deal root.
+    }
+    const fh = await storageDir.getFileHandle('manifest_root.txt', { create: false })
     const file = await fh.getFile()
     return file.text()
   })).trim()


### PR DESCRIPTION
Closes #151\n\n## Summary\n- add a shared sparse browser upload transport helper\n- send truncated bodies with X-Nil-Full-Size for direct upload and mirror callsites\n- add browser smoke coverage for sparse upload headers\n\n## Validation\n- cd nil-website && npm run test:unit -- src/lib/upload/sparseArtifacts.test.ts src/lib/upload/sparseTransport.test.ts src/lib/storage/OpfsAdapter.test.ts\n- cd nil-website && npm run lint\n- cd nil-website && npm run build\n- cd nil-website && E2E_BASE_URL=http://127.0.0.1:5173 npm run test:e2e -- tests/direct-upload.spec.ts

## Stack
- position: 2 of 10 in the sparse upload / browser compute / CI modernization stack
- base PR: #160
- next PR: #162
- review order: bottom-up from #160 through #169
- merge rule: do not merge this PR before its base PR is merged
- retarget rule: after the base PR merges, retarget this PR to `main` before merging it
- stack validation: top-of-stack CI passed on #169 at `6f21e59c1a73efbfbaebae7c407fa8194183cb20`


