### PR TITLE
feat(website): persist sparse OPFS slab artifacts

### DIFF
--- a/nil-website/src/lib/storage/OpfsAdapter.test.ts
+++ b/nil-website/src/lib/storage/OpfsAdapter.test.ts
@@ -162,6 +162,17 @@ test('OpfsAdapter: writeMdu and readMdu', async () => {
     assert.deepStrictEqual(readData, data, 'Read data should match written data');
 });
 
+test('OpfsAdapter: sparse MDU write zero-extends on read and hides sidecar files', async () => {
+    const dealId = 'test-deal-sparse-mdu';
+    await OpfsAdapter.writeMdu(dealId, 3, new Uint8Array([1, 2]), 4);
+
+    const readData = await OpfsAdapter.readMdu(dealId, 3);
+    assert.deepStrictEqual(readData, new Uint8Array([1, 2, 0, 0]));
+
+    const files = await OpfsAdapter.listDealFiles(dealId);
+    assert.deepStrictEqual(files, ['mdu_3.bin']);
+});
+
 test('OpfsAdapter: writeShard and readShard', async () => {
     const dealId = 'test-deal-write-read-shard';
     const mduIndex = 42;
@@ -182,6 +193,19 @@ test('OpfsAdapter: writeManifestBlob and readManifestBlob', async () => {
 
     const readBlob = await OpfsAdapter.readManifestBlob(dealId);
     assert.deepStrictEqual(readBlob, blob, 'Read manifest blob should match written manifest blob');
+});
+
+test('OpfsAdapter: sparse shard and manifest writes zero-extend on read', async () => {
+    const dealId = 'test-deal-sparse-shard-manifest';
+
+    await OpfsAdapter.writeShard(dealId, 9, 2, new Uint8Array([5]), 3);
+    await OpfsAdapter.writeManifestBlob(dealId, new Uint8Array([7, 8, 0, 0]));
+
+    const readShard = await OpfsAdapter.readShard(dealId, 9, 2);
+    const readManifest = await OpfsAdapter.readManifestBlob(dealId);
+
+    assert.deepStrictEqual(readShard, new Uint8Array([5, 0, 0]));
+    assert.deepStrictEqual(readManifest, new Uint8Array([7, 8, 0, 0]));
 });
 
 test('OpfsAdapter: write/read/delete slab metadata', async () => {
@@ -388,4 +412,35 @@ test('OpfsAdapter: atomic slab generation swap serves new generation and cleans 
     assert.ok(files.includes('mdu_0.bin'))
     assert.ok(files.includes('mdu_1.bin'))
     assert.ok(files.includes('manifest.bin'))
+})
+
+test('OpfsAdapter: atomic slab generation swap rehydrates sparse artifacts on read', async () => {
+    const dealId = 'test-deal-atomic-sparse-swap'
+    const root = '0x' + 'ee'.repeat(48)
+
+    await OpfsAdapter.writeSlabGenerationAtomically(dealId, {
+        manifestRoot: root,
+        manifestBlob: new Uint8Array([1]),
+        manifestBlobFullSize: 4,
+        mdus: [
+            { index: 0, data: new Uint8Array([9]), fullSize: 3 },
+            { index: 1, data: new Uint8Array([8, 7]), fullSize: 4 },
+        ],
+        shards: [
+            { mduIndex: 1, slot: 0, data: new Uint8Array([6]), fullSize: 2 },
+        ],
+        metadata: makeMetadata({
+            dealId,
+            manifestRoot: root,
+            generationId: root.slice(2),
+        }),
+    })
+
+    assert.deepStrictEqual(await OpfsAdapter.readManifestBlob(dealId), new Uint8Array([1, 0, 0, 0]))
+    assert.deepStrictEqual(await OpfsAdapter.readMdu(dealId, 0), new Uint8Array([9, 0, 0]))
+    assert.deepStrictEqual(await OpfsAdapter.readMdu(dealId, 1), new Uint8Array([8, 7, 0, 0]))
+    assert.deepStrictEqual(await OpfsAdapter.readShard(dealId, 1, 0), new Uint8Array([6, 0]))
+    const files = await OpfsAdapter.listDealFiles(dealId)
+    assert.ok(files.includes('manifest.bin'))
+    assert.ok(!files.some((name) => name.endsWith('.meta.json')))
 })

--- a/nil-website/src/lib/storage/OpfsAdapter.ts
+++ b/nil-website/src/lib/storage/OpfsAdapter.ts
@@ -2,27 +2,32 @@
 
 import { sha256 } from '@noble/hashes/sha2.js'
 import { bytesToHex } from '@noble/hashes/utils.js'
+import { expandSparseBytes, makeSparseArtifact, type SparseArtifactInput } from '../upload/sparseArtifacts'
 
 const SLAB_METADATA_FILE = 'slab_meta.json'
 const GENERATIONS_DIR = 'generations'
 const ACTIVE_GENERATION_POINTER_FILE = 'active_generation.txt'
 const GENERATION_COMPLETE_MARKER_FILE = '.generation_complete'
 const GENERATION_DIR_PREFIX = 'gen-'
+const ARTIFACT_META_SUFFIX = '.meta.json'
 
 export interface GenerationMduWrite {
     index: number
     data: Uint8Array
+    fullSize?: number
 }
 
 export interface GenerationShardWrite {
     mduIndex: number
     slot: number
     data: Uint8Array
+    fullSize?: number
 }
 
 export interface AtomicSlabGenerationWriteInput {
     manifestRoot: string
     manifestBlob?: Uint8Array | null
+    manifestBlobFullSize?: number
     mdus: GenerationMduWrite[]
     shards?: GenerationShardWrite[]
     metadata: SlabMetadata
@@ -223,6 +228,60 @@ async function readBlob(dealId: string, name: string): Promise<Uint8Array | null
 async function deleteDealFile(dealId: string, name: string): Promise<void> {
     const dir = await resolveActiveStorageDirectory(dealId, true)
     await removeEntryIfExists(dir, name)
+    await removeEntryIfExists(dir, artifactMetaFileName(name))
+}
+
+function artifactMetaFileName(name: string): string {
+    return `${name}${ARTIFACT_META_SUFFIX}`
+}
+
+function isArtifactMetaFileName(name: string): boolean {
+    return name.endsWith(ARTIFACT_META_SUFFIX)
+}
+
+async function writeArtifactToDirectory(
+    dir: FileSystemDirectoryHandle,
+    name: string,
+    artifact: SparseArtifactInput,
+): Promise<void> {
+    const sparseArtifact = makeSparseArtifact(artifact)
+    await writeBlobToDirectory(dir, name, sparseArtifact.bytes)
+    if (sparseArtifact.bytes.byteLength < sparseArtifact.fullSize) {
+        const meta = JSON.stringify({ full_size: sparseArtifact.fullSize })
+        await writeBlobToDirectory(dir, artifactMetaFileName(name), new TextEncoder().encode(meta))
+        return
+    }
+    await removeEntryIfExists(dir, artifactMetaFileName(name))
+}
+
+async function readArtifactMetaFullSize(dir: FileSystemDirectoryHandle, name: string): Promise<number | null> {
+    const bytes = await readBlobFromDirectory(dir, artifactMetaFileName(name))
+    if (!bytes) return null
+    const text = new TextDecoder().decode(bytes)
+    const parsed = JSON.parse(text) as { full_size?: unknown }
+    const fullSize = parsed.full_size
+    if (!Number.isInteger(fullSize) || Number(fullSize) < 0) {
+        throw new Error(`invalid sparse artifact metadata for ${name}`)
+    }
+    return Number(fullSize)
+}
+
+async function readArtifactFromDirectory(dir: FileSystemDirectoryHandle, name: string): Promise<Uint8Array | null> {
+    const bytes = await readBlobFromDirectory(dir, name)
+    if (!bytes) return null
+    const fullSize = await readArtifactMetaFullSize(dir, name)
+    if (fullSize == null) return bytes
+    return expandSparseBytes(bytes, fullSize)
+}
+
+async function writeArtifact(dealId: string, name: string, artifact: SparseArtifactInput): Promise<void> {
+    const dir = await resolveActiveStorageDirectory(dealId, true)
+    await writeArtifactToDirectory(dir, name, artifact)
+}
+
+async function readArtifact(dealId: string, name: string): Promise<Uint8Array | null> {
+    const dir = await resolveActiveStorageDirectory(dealId, true)
+    return readArtifactFromDirectory(dir, name)
 }
 
 /**
@@ -231,14 +290,25 @@ async function deleteDealFile(dealId: string, name: string): Promise<void> {
  * @param mduIndex The index of the MDU (e.g., 0 for MDU #0).
  * @param data The Uint8Array containing the MDU's binary data.
  */
-export async function writeMdu(dealId: string, mduIndex: number, data: Uint8Array): Promise<void> {
+export async function writeMdu(
+    dealId: string,
+    mduIndex: number,
+    data: Uint8Array,
+    fullSize?: number,
+): Promise<void> {
     const fileName = `mdu_${mduIndex}.bin`;
-    await writeBlob(dealId, fileName, data);
+    await writeArtifact(dealId, fileName, { kind: 'mdu', index: mduIndex, bytes: data, fullSize });
 }
 
-export async function writeShard(dealId: string, mduIndex: number, slot: number, data: Uint8Array): Promise<void> {
+export async function writeShard(
+    dealId: string,
+    mduIndex: number,
+    slot: number,
+    data: Uint8Array,
+    fullSize?: number,
+): Promise<void> {
     const fileName = `mdu_${mduIndex}_slot_${slot}.bin`;
-    await writeBlob(dealId, fileName, data);
+    await writeArtifact(dealId, fileName, { kind: 'shard', index: mduIndex, slot, bytes: data, fullSize });
 }
 
 /**
@@ -249,12 +319,12 @@ export async function writeShard(dealId: string, mduIndex: number, slot: number,
  */
 export async function readMdu(dealId: string, mduIndex: number): Promise<Uint8Array | null> {
     const fileName = `mdu_${mduIndex}.bin`;
-    return await readBlob(dealId, fileName);
+    return await readArtifact(dealId, fileName);
 }
 
 export async function readShard(dealId: string, mduIndex: number, slot: number): Promise<Uint8Array | null> {
     const fileName = `mdu_${mduIndex}_slot_${slot}.bin`;
-    return await readBlob(dealId, fileName);
+    return await readArtifact(dealId, fileName);
 }
 
 /**
@@ -268,6 +338,7 @@ export async function listDealFiles(dealId: string): Promise<string[]> {
     // @ts-expect-error - FileSystemDirectoryHandle is iterable
     for await (const entry of dealDir.values()) {
         if (entry.kind === 'file') {
+            if (isArtifactMetaFileName(entry.name)) continue
             fileNames.push(entry.name);
         }
     }
@@ -340,20 +411,34 @@ export async function writeSlabGenerationAtomically(
     try {
         await writeBlobToDirectory(generationDir, 'manifest_root.txt', new TextEncoder().encode(`${manifestRoot}\n`))
         if (input.manifestBlob && input.manifestBlob.byteLength > 0) {
-            await writeBlobToDirectory(generationDir, 'manifest.bin', input.manifestBlob)
+            await writeArtifactToDirectory(generationDir, 'manifest.bin', {
+                kind: 'manifest',
+                bytes: input.manifestBlob,
+                fullSize: input.manifestBlobFullSize,
+            })
         } else {
             throw new Error('manifest blob is required for atomic generation write')
         }
 
         for (const mdu of mdus) {
-            await writeBlobToDirectory(generationDir, `mdu_${Math.floor(mdu.index)}.bin`, mdu.data)
+            const index = Math.floor(mdu.index)
+            await writeArtifactToDirectory(generationDir, `mdu_${index}.bin`, {
+                kind: 'mdu',
+                index,
+                bytes: mdu.data,
+                fullSize: mdu.fullSize,
+            })
         }
         for (const shard of shards) {
-            await writeBlobToDirectory(
-                generationDir,
-                `mdu_${Math.floor(shard.mduIndex)}_slot_${Math.floor(shard.slot)}.bin`,
-                shard.data,
-            )
+            const mduIndex = Math.floor(shard.mduIndex)
+            const slot = Math.floor(shard.slot)
+            await writeArtifactToDirectory(generationDir, `mdu_${mduIndex}_slot_${slot}.bin`, {
+                kind: 'shard',
+                index: mduIndex,
+                slot,
+                bytes: shard.data,
+                fullSize: shard.fullSize,
+            })
         }
 
         metadata.generation_id = String(metadata.generation_id || generationIdFallback).trim() || generationIdFallback
@@ -381,12 +466,16 @@ export async function writeManifestRoot(dealId: string, manifestRoot: string): P
     await writeBlob(dealId, 'manifest_root.txt', new TextEncoder().encode(normalized));
 }
 
-export async function writeManifestBlob(dealId: string, manifestBlob: Uint8Array): Promise<void> {
-    await writeBlob(dealId, 'manifest.bin', manifestBlob);
+export async function writeManifestBlob(
+    dealId: string,
+    manifestBlob: Uint8Array,
+    fullSize?: number,
+): Promise<void> {
+    await writeArtifact(dealId, 'manifest.bin', { kind: 'manifest', bytes: manifestBlob, fullSize });
 }
 
 export async function readManifestBlob(dealId: string): Promise<Uint8Array | null> {
-    return await readBlob(dealId, 'manifest.bin');
+    return await readArtifact(dealId, 'manifest.bin');
 }
 
 export async function readManifestRoot(dealId: string): Promise<string | null> {


### PR DESCRIPTION
Closes #152\n\n## Summary\n- store sparse manifest, MDU, and shard artifacts in OPFS with logical full-size sidecars\n- zero-extend sparse artifacts on read so existing callers keep full logical bytes\n- make atomic generation swaps sparse-aware while hiding sidecar files from listings\n\n## Validation\n- cd nil-website && npm run test:unit -- src/lib/upload/sparseArtifacts.test.ts src/lib/upload/sparseTransport.test.ts src/lib/storage/OpfsAdapter.test.ts\n- cd nil-website && npm run lint\n- cd nil-website && npm run build

## Stack
- position: 3 of 10 in the sparse upload / browser compute / CI modernization stack
- base PR: #161
- next PR: #163
- review order: bottom-up from #160 through #169
- merge rule: do not merge this PR before its base PR is merged
- retarget rule: after the base PR merges, retarget this PR to `main` before merging it
- stack validation: top-of-stack CI passed on #169 at `6f21e59c1a73efbfbaebae7c407fa8194183cb20`


