### PR TITLE
feat(nil_core): expose payload-aware mode2 wasm expansion

### DIFF
--- a/nil-website/src/lib/mode2ArtifactsV1.test.ts
+++ b/nil-website/src/lib/mode2ArtifactsV1.test.ts
@@ -10,6 +10,7 @@ const __dirname = path.dirname(__filename)
 
 type NilWasmLike = {
   expand_mdu_rs: (encodedUserMdu: Uint8Array, k: number, m: number) => unknown
+  expand_payload_rs_flat: (payloadBytes: Uint8Array, k: number, m: number) => unknown
   compute_mdu_root: (witnessFlat: Uint8Array) => unknown
 }
 
@@ -132,5 +133,28 @@ test('mode2-artifacts-v1 fixture: WASM matches golden hashes', async (t) => {
   for (let slot = 0; slot < shardsList.length; slot++) {
     const name = `mdu_${slabIndex}_slot_${slot}.bin`
     assert.strictEqual(sha256Hex0x(shardsList[slot]), fx.artifact_sha256[name])
+  }
+
+  const payloadExpandedRaw = nilWasm.expand_payload_rs_flat(payload, fx.k, fx.m) as unknown
+  const payloadExpanded = typeof payloadExpandedRaw === 'string' ? JSON.parse(payloadExpandedRaw) : payloadExpandedRaw
+  const payloadWitnessRaw = (payloadExpanded as { witness_flat?: unknown }).witness_flat
+  const payloadShardsRaw = (payloadExpanded as { shards_flat?: unknown }).shards_flat
+  const payloadShardLen = Number((payloadExpanded as { shard_len?: unknown }).shard_len ?? 0)
+
+  assert.ok(payloadWitnessRaw)
+  assert.ok(payloadShardsRaw)
+  assert.ok(Number.isInteger(payloadShardLen) && payloadShardLen > 0)
+
+  const payloadWitnessFlat =
+    payloadWitnessRaw instanceof Uint8Array ? payloadWitnessRaw : new Uint8Array(payloadWitnessRaw as ArrayBufferLike)
+  const payloadShardsFlat =
+    payloadShardsRaw instanceof Uint8Array ? payloadShardsRaw : new Uint8Array(payloadShardsRaw as ArrayBufferLike)
+
+  assert.deepStrictEqual(payloadWitnessFlat, witnessFlat)
+  assert.strictEqual(payloadShardsFlat.byteLength, shardsList.length * payloadShardLen)
+  for (let slot = 0; slot < shardsList.length; slot += 1) {
+    const start = slot * payloadShardLen
+    const end = start + payloadShardLen
+    assert.deepStrictEqual(payloadShardsFlat.slice(start, end), shardsList[slot])
   }
 })

--- a/nil-website/src/lib/worker-client.ts
+++ b/nil-website/src/lib/worker-client.ts
@@ -132,6 +132,10 @@ export const workerClient = {
     return sendMessageToWorker('expandMduRs', { data, k, m }, [data.buffer]) as Promise<ExpandedStripe>;
   },
 
+  async expandPayloadRs(data: Uint8Array, k: number, m: number): Promise<ExpandedStripe> {
+    return sendMessageToWorker('expandPayloadRs', { data, k, m }, [data.buffer]) as Promise<ExpandedStripe>;
+  },
+
   // Compute Manifest Root from a list of MDU roots (concatenated 32-byte roots)
   async computeManifest(roots: Uint8Array): Promise<{ root: Uint8Array; blob: Uint8Array }> {
     return sendMessageToWorker('computeManifest', { roots }, [roots.buffer]) as Promise<{ root: Uint8Array; blob: Uint8Array }>;

--- a/nil-website/src/workers/gateway.worker.ts
+++ b/nil-website/src/workers/gateway.worker.ts
@@ -339,6 +339,37 @@ self.onmessage = async (event) => {
                 result = { witness_flat: witnessFlat, mdu_root: rootBytes, shards: shardsList };
                 break;
             }
+            case 'expandPayloadRs': {
+                if (!nilWasmInstance) throw new Error('NilWasm not initialized. Call initNilWasm first.');
+                const { data, k, m } = payload as { data: Uint8Array; k: number; m: number };
+                if (!(data instanceof Uint8Array)) throw new Error('data must be a Uint8Array');
+
+                const expanded = nilWasmInstance.expand_payload_rs_flat(data, Number(k), Number(m)) as unknown;
+                const parsed = typeof expanded === 'string' ? JSON.parse(expanded) : expanded;
+                const witnessRaw = (parsed as { witness_flat?: unknown }).witness_flat;
+                const shardsRaw = (parsed as { shards_flat?: unknown }).shards_flat;
+                const shardLen = Number((parsed as { shard_len?: unknown }).shard_len ?? 0);
+                if (!Number.isInteger(shardLen) || shardLen <= 0) {
+                    throw new Error('expandPayloadRs returned an invalid shard length');
+                }
+
+                const witnessFlat = witnessRaw instanceof Uint8Array ? witnessRaw : new Uint8Array(witnessRaw as ArrayBufferLike);
+                const shardsFlat = shardsRaw instanceof Uint8Array ? shardsRaw : new Uint8Array(shardsRaw as ArrayBufferLike);
+                if (shardsFlat.byteLength % shardLen !== 0) {
+                    throw new Error('expandPayloadRs returned misaligned shard bytes');
+                }
+
+                const shardsList: Uint8Array[] = [];
+                for (let offset = 0; offset < shardsFlat.byteLength; offset += shardLen) {
+                    shardsList.push(shardsFlat.slice(offset, offset + shardLen));
+                }
+
+                const root = nilWasmInstance.compute_mdu_root(witnessFlat) as unknown;
+                const rootBytes = root instanceof Uint8Array ? root : new Uint8Array(root as ArrayBufferLike);
+
+                result = { witness_flat: witnessFlat, mdu_root: rootBytes, shards: shardsList };
+                break;
+            }
             case 'computeManifest': {
                 if (!nilWasmInstance) throw new Error('NilWasm not initialized. Call initNilWasm first.');
                 const { roots } = payload; // roots is Uint8Array (concatenated 32-byte roots)

--- a/nil_core/src/coding.rs
+++ b/nil_core/src/coding.rs
@@ -441,4 +441,53 @@ mod tests {
             _ => panic!("expected InvalidRsParams, got {err:?}"),
         }
     }
+
+    #[test]
+    fn expand_payload_flat_matches_encoded_mdu_path() {
+        let setup_bytes = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../demos/kzg/trusted_setup.txt"
+        ));
+        let cursor = std::io::Cursor::new(setup_bytes.as_slice());
+        let ctx = KzgContext::load_from_reader(std::io::BufReader::new(cursor)).unwrap();
+
+        let payload_len = 300_000usize;
+        let mut payload = vec![0u8; payload_len];
+        for (i, byte) in payload.iter_mut().enumerate() {
+            *byte = ((i * 17 + 11) % 251) as u8;
+        }
+
+        let encoded = encode_to_mdu(&payload);
+        let expanded = expand_mdu_encoded(&ctx, &encoded, DATA_SHARDS_NUM, PARITY_SHARDS_NUM).unwrap();
+
+        let rows = BLOBS_PER_MDU / DATA_SHARDS_NUM;
+        let shard_count = DATA_SHARDS_NUM + PARITY_SHARDS_NUM;
+        let shard_len = rows * BLOB_SIZE;
+        let mut witness_flat = vec![0u8; shard_count * rows * 48];
+        let mut shards_flat = vec![0u8; shard_count * shard_len];
+
+        expand_payload_flat(
+            &ctx,
+            &payload,
+            DATA_SHARDS_NUM,
+            PARITY_SHARDS_NUM,
+            &mut witness_flat,
+            &mut shards_flat,
+        )
+        .unwrap();
+
+        let expected_witness_flat: Vec<u8> = expanded
+            .witness
+            .iter()
+            .flat_map(|w| w.iter().copied())
+            .collect();
+        assert_eq!(witness_flat, expected_witness_flat);
+
+        let expected_shards_flat: Vec<u8> = expanded
+            .shards
+            .iter()
+            .flat_map(|shard| shard.iter().copied())
+            .collect();
+        assert_eq!(shards_flat, expected_shards_flat);
+    }
 }

--- a/nil_core/src/wasm.rs
+++ b/nil_core/src/wasm.rs
@@ -1,9 +1,10 @@
-use crate::coding::{expand_mdu, expand_mdu_encoded};
+use crate::coding::{expand_mdu, expand_mdu_encoded, expand_payload_flat};
 use crate::kzg::KzgContext;
 use crate::builder::Mdu0Builder;
 use crate::layout::{FileRecordV1, pack_length_and_flags};
 use wasm_bindgen::prelude::*;
 use js_sys::Uint8Array;
+use crate::kzg::{BLOB_SIZE, BLOBS_PER_MDU};
 
 #[wasm_bindgen]
 pub struct NilWasm {
@@ -33,6 +34,49 @@ impl NilWasm {
     pub fn expand_mdu_rs(&self, mdu_bytes: &[u8], k: u32, m: u32) -> Result<JsValue, JsValue> {
         let res = expand_mdu_encoded(&self.kzg_ctx, mdu_bytes, k as usize, m as usize)
             .map_err(|e| JsValue::from_str(&format!("Expansion failed: {:?}", e)))?;
+
+        serde_wasm_bindgen::to_value(&res)
+            .map_err(|e| JsValue::from_str(&format!("Serialization failed: {:?}", e)))
+    }
+
+    pub fn expand_payload_rs_flat(&self, payload_bytes: &[u8], k: u32, m: u32) -> Result<JsValue, JsValue> {
+        let data_shards = k as usize;
+        let parity_shards = m as usize;
+        if data_shards == 0 || parity_shards == 0 {
+            return Err(JsValue::from_str("RS parameters must be positive"));
+        }
+        if BLOBS_PER_MDU % data_shards != 0 {
+            return Err(JsValue::from_str("Invalid RS parameters"));
+        }
+
+        let rows = BLOBS_PER_MDU / data_shards;
+        let shard_count = data_shards + parity_shards;
+        let shard_len = rows * BLOB_SIZE;
+        let mut witness_flat = vec![0u8; shard_count * rows * 48];
+        let mut shards_flat = vec![0u8; shard_count * shard_len];
+
+        expand_payload_flat(
+            &self.kzg_ctx,
+            payload_bytes,
+            data_shards,
+            parity_shards,
+            &mut witness_flat,
+            &mut shards_flat,
+        )
+        .map_err(|e| JsValue::from_str(&format!("Expansion failed: {:?}", e)))?;
+
+        #[derive(serde::Serialize)]
+        struct ExpandPayloadFlatResult {
+            witness_flat: Vec<u8>,
+            shards_flat: Vec<u8>,
+            shard_len: usize,
+        }
+
+        let res = ExpandPayloadFlatResult {
+            witness_flat,
+            shards_flat,
+            shard_len,
+        };
 
         serde_wasm_bindgen::to_value(&res)
             .map_err(|e| JsValue::from_str(&format!("Serialization failed: {:?}", e)))


### PR DESCRIPTION
## Summary\n- expose payload-length-aware Mode 2 expansion from nil_core to the WASM surface\n- thread the new worker/client API through nil-website without changing canonical fixture outputs\n- extend parity coverage so payload-aware expansion matches the encoded-MDU path\n\n## Validation\n- cd nil_core && cargo test --verbose\n- cd nil-website && npm run build\n- cd nil-website && npm run test:unit -- src/lib/mode2ArtifactsV1.test.ts\n\nRefs #153

## Stack
- position: 4 of 10 in the sparse upload / browser compute / CI modernization stack
- base PR: #162
- next PR: #164
- review order: bottom-up from #160 through #169
- merge rule: do not merge this PR before its base PR is merged
- retarget rule: after the base PR merges, retarget this PR to `main` before merging it
- stack validation: top-of-stack CI passed on #169 at `6f21e59c1a73efbfbaebae7c407fa8194183cb20`


