### PR TITLE
feat(website): use payload-aware mode2 browser expansion

### DIFF
--- a/nil-website/src/components/FileSharder.tsx
+++ b/nil-website/src/components/FileSharder.tsx
@@ -2012,7 +2012,7 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
             );
 
             let rawChunk: Uint8Array = new Uint8Array();
-            let encodedMdu: Uint8Array;
+            let encodedMdu: Uint8Array | null = null;
             let encodeMs = 0;
 
             if (isExisting) {
@@ -2022,21 +2022,29 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
               const start = newIndex * RawMduCapacity;
               const end = Math.min(start + RawMduCapacity, bytes.length);
               rawChunk = bytes.subarray(start, end) as Uint8Array;
-              const encodeStart = performance.now();
-              encodedMdu = encodeToMdu(rawChunk);
-              encodeMs = performance.now() - encodeStart;
             }
-
-            userMdus.push({ index: i, data: encodedMdu });
+            const expansionInputSource = isExisting ? encodedMdu : rawChunk;
+            if (!expansionInputSource) {
+              throw new Error(`missing expansion input for user MDU #${i}`)
+            }
             const copyStart = performance.now();
-            const chunkCopy = new Uint8Array(encodedMdu);
+            const chunkCopy = new Uint8Array(expansionInputSource);
             const copyMs = performance.now() - copyStart;
 
             if (useMode2) {
-              addLog(`> Sharding User MDU #${i}${isExisting ? ' (existing)' : ''} (RS ${rsK}+${rsM})...`);
+              addLog(`> Sharding User MDU #${i}${isExisting ? ' (existing)' : ''} (RS ${rsK}+${rsM})${isExisting ? '' : ' via payload-aware path'}...`);
               const wasmStart = performance.now();
-              const result = await workerClient.expandMduRs(chunkCopy, rsK, rsM);
+              const result = isExisting
+                ? await workerClient.expandMduRs(chunkCopy, rsK, rsM)
+                : await workerClient.expandPayloadRs(chunkCopy, rsK, rsM);
               const wasmMs = performance.now() - wasmStart;
+
+              if (!encodedMdu) {
+                const encodeStart = performance.now();
+                encodedMdu = encodeToMdu(rawChunk);
+                encodeMs = performance.now() - encodeStart;
+              }
+              userMdus.push({ index: i, data: encodedMdu });
 
               const rootBytes = toU8(result.mdu_root);
               userRoots.push(rootBytes);
@@ -2051,6 +2059,7 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
               console.log('[perf] user mdu (mode2)', {
                 i,
                 rawBytes: isExisting ? userPayloads[i] ?? 0 : rawChunk.byteLength,
+                expansionPath: isExisting ? 'encoded_mdu' : 'payload',
                 encodeMs,
                 copyMs,
                 wasmMs,
@@ -2079,6 +2088,16 @@ export function FileSharder({ dealId, onCommitSuccess }: FileSharderProps) {
               await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
               continue;
             }
+
+            if (!encodedMdu) {
+              const encodeStart = performance.now();
+              encodedMdu = encodeToMdu(rawChunk);
+              encodeMs = performance.now() - encodeStart;
+            }
+            if (!encodedMdu) {
+              throw new Error(`missing encoded user MDU bytes for user MDU #${i}`)
+            }
+            userMdus.push({ index: i, data: encodedMdu });
 
             addLog(`> Sharding User MDU #${i}...`);
             const batchBlobs = pickBatchBlobs(prevCommitMsPerMdu);


### PR DESCRIPTION
## Summary\n- switch browser Mode 2 expansion for new user payload chunks to the payload-aware worker path\n- keep encoded MDU materialization where local persistence and reconstruction still need it\n- preserve canonical shard/witness outputs while narrowing the browser compute path\n\n## Validation\n- cd nil-website && npm run lint\n- cd nil-website && npm run build\n\nFollow-up validation for the heavier local-stack Mode 2 smoke remains tracked on the issue.\n\nRefs #154

## Stack
- position: 5 of 10 in the sparse upload / browser compute / CI modernization stack
- base PR: #163
- next PR: #165
- review order: bottom-up from #160 through #169
- merge rule: do not merge this PR before its base PR is merged
- retarget rule: after the base PR merges, retarget this PR to `main` before merging it
- stack validation: top-of-stack CI passed on #169 at `6f21e59c1a73efbfbaebae7c407fa8194183cb20`


