### PR TITLE
SP discipline PR19: evidence-capture scenarios and deterministic overrides

### DIFF
--- a/docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md
+++ b/docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md
@@ -25,6 +25,7 @@
 17. `stack/sp-discipline-16-stack-integrity-scenarios`
 18. `stack/sp-discipline-17-policy-template-scenarios`
 19. `stack/sp-discipline-18-yes-merge-scenarios`
+20. `stack/sp-discipline-19-evidence-capture-scenarios`
 
 ## Mandatory Gate Results
 All commands below were executed from repo root unless noted.
@@ -214,6 +215,26 @@ All commands below were executed from repo root unless noted.
 47. `bash scripts/ci/capture_sp_discipline_gate_evidence.sh`
 - Result: pass
 - Notes: Generated `_artifacts/ci/sp_discipline_stack_gates_20260403T103519Z.log` and `_artifacts/ci/sp_discipline_stack_gates_20260403T103519Z.md` after PR18 changes.
+
+48. `bash scripts/ci/test_sp_discipline_evidence_capture.sh`
+- Result: pass
+- Notes: Scenario matrix validated pass/fail gate-runner outcomes, deterministic timestamp overrides, summary content assertions, and missing-runner failure handling.
+
+49. `bash scripts/ci/run_sp_discipline_stack_gates.sh`
+- Result: pass
+- Notes: Full matrix pass with evidence-capture scenarios integrated into the gate runner.
+
+50. `bash scripts/ci/capture_sp_discipline_gate_evidence.sh`
+- Result: pass
+- Notes: Generated `_artifacts/ci/sp_discipline_stack_gates_20260403T104615Z.log` and `_artifacts/ci/sp_discipline_stack_gates_20260403T104615Z.md` after PR19 changes.
+
+51. `bash scripts/ci/check_sp_discipline_docs_consistency.sh`
+- Result: pass
+- Notes: Revalidated plan/evidence branch-list parity and `YES MERGE` wording after PR19 doc updates.
+
+52. `bash scripts/ci/test_sp_discipline_evidence_capture.sh`
+- Result: pass
+- Notes: Revalidated deterministic evidence-capture scenarios after PR19 doc updates.
 
 ## Test Harness Hardening Included
 - `scripts/run_devnet_alpha_multi_sp.sh`

--- a/docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md
+++ b/docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md
@@ -43,6 +43,7 @@ Implement a deterministic, testable discipline system so unreliable SPs are prog
 17. `stack/sp-discipline-16-stack-integrity-scenarios`
 18. `stack/sp-discipline-17-policy-template-scenarios`
 19. `stack/sp-discipline-18-yes-merge-scenarios`
+20. `stack/sp-discipline-19-evidence-capture-scenarios`
 
 Each branch is cut from the previous stack branch, not from `main`.
 
@@ -461,6 +462,30 @@ Exit Criteria:
 - `YES MERGE` guard behavior is covered by deterministic positive and negative scenario tests.
 - Near-miss phrases are explicitly rejected by the checker.
 - Gate runner includes explicit scenario coverage for merge-approval enforcement.
+
+## PR 19: Evidence Capture Scenario Tests and Deterministic Overrides
+Scope:
+- Harden evidence capture automation with deterministic timestamp overrides for reproducible scenario assertions.
+- Add gate-runner path override support so capture behavior can be tested in isolated temp environments.
+- Add deterministic evidence-capture scenarios for pass/fail runner outcomes and missing-runner handling.
+- Integrate evidence-capture scenarios into the gate runner before heavyweight keeper/e2e/frontend checks.
+
+Files (expected):
+- `scripts/ci/capture_sp_discipline_gate_evidence.sh`
+- `scripts/ci/test_sp_discipline_evidence_capture.sh`
+- `scripts/ci/run_sp_discipline_stack_gates.sh`
+- `docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md`
+- `docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md`
+
+Test Gate:
+1. `bash scripts/ci/test_sp_discipline_evidence_capture.sh` (must pass)
+2. `bash scripts/ci/run_sp_discipline_stack_gates.sh` (must pass with evidence-capture scenarios included)
+3. `bash scripts/ci/capture_sp_discipline_gate_evidence.sh` (must pass and write artifacts)
+
+Exit Criteria:
+- Evidence capture behavior is covered by deterministic positive and negative scenario tests.
+- Evidence capture can be scenario-tested without executing the full heavyweight gate matrix.
+- Gate runner includes explicit scenario coverage for evidence automation integrity.
 
 ## Cross-PR Regression Matrix
 Run this matrix at minimum for PRs 02-06 (state/economics/repair/UX affecting):

--- a/scripts/ci/capture_sp_discipline_gate_evidence.sh
+++ b/scripts/ci/capture_sp_discipline_gate_evidence.sh
@@ -7,14 +7,21 @@ cd "$ROOT_DIR"
 OUT_DIR="${SP_DISCIPLINE_EVIDENCE_DIR:-$ROOT_DIR/_artifacts/ci}"
 mkdir -p "$OUT_DIR"
 
-TS_UTC="$(date -u +"%Y%m%dT%H%M%SZ")"
+GATE_RUNNER_SCRIPT="${SP_DISCIPLINE_GATE_RUNNER:-scripts/ci/run_sp_discipline_stack_gates.sh}"
+if [ ! -f "$GATE_RUNNER_SCRIPT" ]; then
+  echo "ERROR: missing gate runner script: $GATE_RUNNER_SCRIPT" >&2
+  exit 2
+fi
+
+TS_UTC="${SP_DISCIPLINE_EVIDENCE_TS_UTC:-$(date -u +"%Y%m%dT%H%M%SZ")}"
 LOG_FILE="$OUT_DIR/sp_discipline_stack_gates_${TS_UTC}.log"
 SUMMARY_FILE="$OUT_DIR/sp_discipline_stack_gates_${TS_UTC}.md"
+RUN_COMMAND="bash $GATE_RUNNER_SCRIPT"
 
 echo "==> Running full SP discipline stack gates..."
 echo "    log: $LOG_FILE"
 set +e
-bash scripts/ci/run_sp_discipline_stack_gates.sh 2>&1 | tee "$LOG_FILE"
+bash "$GATE_RUNNER_SCRIPT" 2>&1 | tee "$LOG_FILE"
 RUN_STATUS=${PIPESTATUS[0]}
 set -e
 
@@ -27,7 +34,7 @@ cat > "$SUMMARY_FILE" <<EOF
 # SP Discipline Gate Evidence
 
 - Timestamp (UTC): $TS_UTC
-- Command: \`bash scripts/ci/run_sp_discipline_stack_gates.sh\`
+- Command: \`$RUN_COMMAND\`
 - Result: $RESULT_WORD
 - Exit code: $RUN_STATUS
 - Log file: \`$LOG_FILE\`

--- a/scripts/ci/run_sp_discipline_stack_gates.sh
+++ b/scripts/ci/run_sp_discipline_stack_gates.sh
@@ -61,6 +61,9 @@ run_ok "YES MERGE positive fixture check (must pass)" \
 run_ok "YES MERGE scenario checks" \
   bash scripts/ci/test_yes_merge_check.sh
 
+run_ok "SP discipline evidence-capture scenarios" \
+  bash scripts/ci/test_sp_discipline_evidence_capture.sh
+
 run_ok "keeper determinism/status subset (count=2)" \
   bash -lc "cd nilchain && GOFLAGS=-mod=mod go test ./x/nilchain/keeper -run 'TestCheckMissedProofs_.*|Test.*Discipline.*|Test.*Status.*' -count=2"
 

--- a/scripts/ci/test_sp_discipline_evidence_capture.sh
+++ b/scripts/ci/test_sp_discipline_evidence_capture.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+CAPTURE_SCRIPT="scripts/ci/capture_sp_discipline_gate_evidence.sh"
+if [ ! -x "$CAPTURE_SCRIPT" ]; then
+  echo "ERROR: missing executable capture script: $CAPTURE_SCRIPT" >&2
+  exit 2
+fi
+
+TMPDIR="$(mktemp -d)"
+cleanup() {
+  if [ -d "$TMPDIR" ]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+OUT_DIR="$TMPDIR/out"
+mkdir -p "$OUT_DIR"
+
+RUNNER_OK="$TMPDIR/runner-ok.sh"
+RUNNER_FAIL="$TMPDIR/runner-fail.sh"
+RUNNER_MISSING="$TMPDIR/runner-missing.sh"
+
+cat >"$RUNNER_OK" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "runner ok output"
+exit 0
+EOF
+
+cat >"$RUNNER_FAIL" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "runner fail output"
+exit 7
+EOF
+
+chmod +x "$RUNNER_OK" "$RUNNER_FAIL"
+
+expect_contains() {
+  local file="$1"
+  local pattern="$2"
+  if ! grep -Fq -- "$pattern" "$file"; then
+    echo "ERROR: expected pattern not found in $file: $pattern" >&2
+    exit 1
+  fi
+}
+
+echo "==> Case 1: passing runner writes pass artifacts"
+TS_PASS="20260403T120001Z"
+SP_DISCIPLINE_EVIDENCE_DIR="$OUT_DIR" \
+SP_DISCIPLINE_GATE_RUNNER="$RUNNER_OK" \
+SP_DISCIPLINE_EVIDENCE_TS_UTC="$TS_PASS" \
+bash "$CAPTURE_SCRIPT"
+
+PASS_LOG="$OUT_DIR/sp_discipline_stack_gates_${TS_PASS}.log"
+PASS_SUMMARY="$OUT_DIR/sp_discipline_stack_gates_${TS_PASS}.md"
+
+if [ ! -f "$PASS_LOG" ] || [ ! -f "$PASS_SUMMARY" ]; then
+  echo "ERROR: expected pass artifacts were not created" >&2
+  exit 1
+fi
+
+expect_contains "$PASS_LOG" "runner ok output"
+expect_contains "$PASS_SUMMARY" "- Command: \`bash $RUNNER_OK\`"
+expect_contains "$PASS_SUMMARY" "- Result: pass"
+expect_contains "$PASS_SUMMARY" "- Exit code: 0"
+expect_contains "$PASS_SUMMARY" "YES MERGE"
+
+echo "==> Case 2: failing runner writes fail artifacts and returns runner status"
+TS_FAIL="20260403T120002Z"
+set +e
+SP_DISCIPLINE_EVIDENCE_DIR="$OUT_DIR" \
+SP_DISCIPLINE_GATE_RUNNER="$RUNNER_FAIL" \
+SP_DISCIPLINE_EVIDENCE_TS_UTC="$TS_FAIL" \
+bash "$CAPTURE_SCRIPT"
+FAIL_STATUS=$?
+set -e
+
+if [ "$FAIL_STATUS" -ne 7 ]; then
+  echo "ERROR: expected exit status 7 for failing runner, got $FAIL_STATUS" >&2
+  exit 1
+fi
+
+FAIL_LOG="$OUT_DIR/sp_discipline_stack_gates_${TS_FAIL}.log"
+FAIL_SUMMARY="$OUT_DIR/sp_discipline_stack_gates_${TS_FAIL}.md"
+
+if [ ! -f "$FAIL_LOG" ] || [ ! -f "$FAIL_SUMMARY" ]; then
+  echo "ERROR: expected fail artifacts were not created" >&2
+  exit 1
+fi
+
+expect_contains "$FAIL_LOG" "runner fail output"
+expect_contains "$FAIL_SUMMARY" "- Command: \`bash $RUNNER_FAIL\`"
+expect_contains "$FAIL_SUMMARY" "- Result: fail"
+expect_contains "$FAIL_SUMMARY" "- Exit code: 7"
+expect_contains "$FAIL_SUMMARY" "YES MERGE"
+
+echo "==> Case 3: missing runner script fails with exit 2"
+set +e
+SP_DISCIPLINE_EVIDENCE_DIR="$OUT_DIR" \
+SP_DISCIPLINE_GATE_RUNNER="$RUNNER_MISSING" \
+SP_DISCIPLINE_EVIDENCE_TS_UTC="20260403T120003Z" \
+bash "$CAPTURE_SCRIPT"
+MISSING_STATUS=$?
+set -e
+
+if [ "$MISSING_STATUS" -ne 2 ]; then
+  echo "ERROR: expected exit status 2 for missing runner, got $MISSING_STATUS" >&2
+  exit 1
+fi
+
+echo "SP discipline evidence-capture scenario tests passed."


### PR DESCRIPTION
## Summary
- add deterministic/testability overrides to evidence capture (`SP_DISCIPLINE_GATE_RUNNER`, `SP_DISCIPLINE_EVIDENCE_TS_UTC`)
- add scenario coverage for evidence-capture pass/fail/missing-runner cases
- wire evidence-capture scenarios into the full stack gate runner
- update stack/evidence planning docs for PR19 and executed gates

## Testing
- bash -n scripts/ci/capture_sp_discipline_gate_evidence.sh
- bash -n scripts/ci/test_sp_discipline_evidence_capture.sh
- bash -n scripts/ci/run_sp_discipline_stack_gates.sh
- bash scripts/ci/test_sp_discipline_evidence_capture.sh
- bash scripts/ci/run_sp_discipline_stack_gates.sh
- bash scripts/ci/capture_sp_discipline_gate_evidence.sh
- bash scripts/ci/check_sp_discipline_docs_consistency.sh
- bash scripts/ci/test_sp_discipline_evidence_capture.sh

## Merge Safety
Do not merge to `main` without explicit human approval containing the exact phrase `YES MERGE`.
