### PR TITLE
SP discipline PR21: evidence collision guard and overwrite control

### DIFF
--- a/docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md
+++ b/docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md
@@ -27,6 +27,7 @@
 19. `stack/sp-discipline-18-yes-merge-scenarios`
 20. `stack/sp-discipline-19-evidence-capture-scenarios`
 21. `stack/sp-discipline-20-gate-runner-scenarios`
+22. `stack/sp-discipline-21-evidence-collision-guard`
 
 ## Mandatory Gate Results
 All commands below were executed from repo root unless noted.
@@ -260,6 +261,26 @@ All commands below were executed from repo root unless noted.
 58. `bash scripts/ci/check_sp_discipline_docs_consistency.sh`
 - Result: pass
 - Notes: Final parity check after appending PR20 evidence entries.
+
+59. `bash scripts/ci/test_sp_discipline_evidence_capture.sh`
+- Result: pass
+- Notes: Extended scenario matrix validated artifact collision failure by default and explicit overwrite replacement via `SP_DISCIPLINE_EVIDENCE_OVERWRITE=1`.
+
+60. `bash scripts/ci/run_sp_discipline_stack_gates.sh`
+- Result: pass
+- Notes: Full matrix pass with evidence-collision scenarios integrated into evidence-capture checks.
+
+61. `bash scripts/ci/capture_sp_discipline_gate_evidence.sh`
+- Result: pass
+- Notes: Generated `_artifacts/ci/sp_discipline_stack_gates_20260403T111113Z.log` and `_artifacts/ci/sp_discipline_stack_gates_20260403T111113Z.md` after PR21 changes.
+
+62. `bash scripts/ci/check_sp_discipline_docs_consistency.sh`
+- Result: pass
+- Notes: Revalidated branch-list parity and `YES MERGE` reminder text after PR21 doc updates.
+
+63. `bash scripts/ci/test_sp_discipline_evidence_capture.sh`
+- Result: pass
+- Notes: Revalidated collision/overwrite scenario coverage after PR21 doc updates.
 
 ## Test Harness Hardening Included
 - `scripts/run_devnet_alpha_multi_sp.sh`

--- a/docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md
+++ b/docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md
@@ -45,6 +45,7 @@ Implement a deterministic, testable discipline system so unreliable SPs are prog
 19. `stack/sp-discipline-18-yes-merge-scenarios`
 20. `stack/sp-discipline-19-evidence-capture-scenarios`
 21. `stack/sp-discipline-20-gate-runner-scenarios`
+22. `stack/sp-discipline-21-evidence-collision-guard`
 
 Each branch is cut from the previous stack branch, not from `main`.
 
@@ -510,6 +511,28 @@ Exit Criteria:
 - Gate-runner control flow is covered by deterministic positive and negative scenario tests.
 - Scenario tests validate override hooks without invoking heavyweight commands.
 - Default runner behavior remains full-matrix unless fast-only is explicitly set.
+
+## PR 21: Evidence Artifact Collision Guard and Overwrite Control
+Scope:
+- Prevent silent overwrite of timestamped evidence artifacts when the same timestamp is reused.
+- Add explicit overwrite opt-in (`SP_DISCIPLINE_EVIDENCE_OVERWRITE=1`) for intentional replacement workflows.
+- Extend evidence-capture scenario tests to cover collision failure and overwrite-enabled replacement.
+
+Files (expected):
+- `scripts/ci/capture_sp_discipline_gate_evidence.sh`
+- `scripts/ci/test_sp_discipline_evidence_capture.sh`
+- `docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md`
+- `docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md`
+
+Test Gate:
+1. `bash scripts/ci/test_sp_discipline_evidence_capture.sh` (must pass)
+2. `bash scripts/ci/run_sp_discipline_stack_gates.sh` (must pass with collision scenarios included)
+3. `bash scripts/ci/capture_sp_discipline_gate_evidence.sh` (must pass and write artifacts)
+
+Exit Criteria:
+- Reused timestamps fail fast by default when artifacts already exist.
+- Intentional overwrite is explicit and regression-tested.
+- Full stack gate runner remains green with new evidence collision checks.
 
 ## Cross-PR Regression Matrix
 Run this matrix at minimum for PRs 02-06 (state/economics/repair/UX affecting):

--- a/scripts/ci/capture_sp_discipline_gate_evidence.sh
+++ b/scripts/ci/capture_sp_discipline_gate_evidence.sh
@@ -17,6 +17,17 @@ TS_UTC="${SP_DISCIPLINE_EVIDENCE_TS_UTC:-$(date -u +"%Y%m%dT%H%M%SZ")}"
 LOG_FILE="$OUT_DIR/sp_discipline_stack_gates_${TS_UTC}.log"
 SUMMARY_FILE="$OUT_DIR/sp_discipline_stack_gates_${TS_UTC}.md"
 RUN_COMMAND="bash $GATE_RUNNER_SCRIPT"
+ALLOW_OVERWRITE="${SP_DISCIPLINE_EVIDENCE_OVERWRITE:-0}"
+
+if [ "$ALLOW_OVERWRITE" != "1" ]; then
+  if [ -e "$LOG_FILE" ] || [ -e "$SUMMARY_FILE" ]; then
+    echo "ERROR: evidence artifact already exists for timestamp $TS_UTC" >&2
+    echo "       log: $LOG_FILE" >&2
+    echo "       summary: $SUMMARY_FILE" >&2
+    echo "       Set SP_DISCIPLINE_EVIDENCE_OVERWRITE=1 to replace existing artifacts." >&2
+    exit 2
+  fi
+fi
 
 echo "==> Running full SP discipline stack gates..."
 echo "    log: $LOG_FILE"

--- a/scripts/ci/test_sp_discipline_evidence_capture.sh
+++ b/scripts/ci/test_sp_discipline_evidence_capture.sh
@@ -114,4 +114,35 @@ if [ "$MISSING_STATUS" -ne 2 ]; then
   exit 1
 fi
 
+echo "==> Case 4: existing timestamp artifacts fail without overwrite flag"
+TS_COLLIDE="20260403T120004Z"
+COLLIDE_LOG="$OUT_DIR/sp_discipline_stack_gates_${TS_COLLIDE}.log"
+COLLIDE_SUMMARY="$OUT_DIR/sp_discipline_stack_gates_${TS_COLLIDE}.md"
+echo "preexisting log" >"$COLLIDE_LOG"
+echo "preexisting summary" >"$COLLIDE_SUMMARY"
+set +e
+SP_DISCIPLINE_EVIDENCE_DIR="$OUT_DIR" \
+SP_DISCIPLINE_GATE_RUNNER="$RUNNER_OK" \
+SP_DISCIPLINE_EVIDENCE_TS_UTC="$TS_COLLIDE" \
+bash "$CAPTURE_SCRIPT"
+COLLIDE_STATUS=$?
+set -e
+
+if [ "$COLLIDE_STATUS" -ne 2 ]; then
+  echo "ERROR: expected collision exit status 2, got $COLLIDE_STATUS" >&2
+  exit 1
+fi
+expect_contains "$COLLIDE_LOG" "preexisting log"
+expect_contains "$COLLIDE_SUMMARY" "preexisting summary"
+
+echo "==> Case 5: overwrite flag allows replacing existing timestamp artifacts"
+SP_DISCIPLINE_EVIDENCE_DIR="$OUT_DIR" \
+SP_DISCIPLINE_GATE_RUNNER="$RUNNER_OK" \
+SP_DISCIPLINE_EVIDENCE_TS_UTC="$TS_COLLIDE" \
+SP_DISCIPLINE_EVIDENCE_OVERWRITE=1 \
+bash "$CAPTURE_SCRIPT"
+
+expect_contains "$COLLIDE_LOG" "runner ok output"
+expect_contains "$COLLIDE_SUMMARY" "- Result: pass"
+
 echo "SP discipline evidence-capture scenario tests passed."


### PR DESCRIPTION
## Summary
- add evidence-artifact collision guard in capture script to prevent accidental overwrite when timestamp is reused
- add explicit overwrite opt-in via `SP_DISCIPLINE_EVIDENCE_OVERWRITE=1`
- extend evidence-capture scenarios for collision failure and overwrite replacement behavior
- update stack/evidence docs for PR21 and executed gate results

## Testing
- bash -n scripts/ci/capture_sp_discipline_gate_evidence.sh
- bash -n scripts/ci/test_sp_discipline_evidence_capture.sh
- bash scripts/ci/test_sp_discipline_evidence_capture.sh
- bash scripts/ci/run_sp_discipline_stack_gates.sh
- bash scripts/ci/capture_sp_discipline_gate_evidence.sh
- bash scripts/ci/check_sp_discipline_docs_consistency.sh

## Merge Safety
Do not merge to `main` without explicit human approval containing the exact phrase `YES MERGE`.
