### PR TITLE
PR22: enforce contiguous docs stack numbering

### DIFF
--- a/docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md
+++ b/docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md
@@ -28,6 +28,7 @@
 20. `stack/sp-discipline-19-evidence-capture-scenarios`
 21. `stack/sp-discipline-20-gate-runner-scenarios`
 22. `stack/sp-discipline-21-evidence-collision-guard`
+23. `stack/sp-discipline-22-doc-sequence-guard`
 
 ## Mandatory Gate Results
 All commands below were executed from repo root unless noted.
@@ -281,6 +282,26 @@ All commands below were executed from repo root unless noted.
 63. `bash scripts/ci/test_sp_discipline_evidence_capture.sh`
 - Result: pass
 - Notes: Revalidated collision/overwrite scenario coverage after PR21 doc updates.
+
+64. `bash scripts/ci/test_sp_discipline_docs_consistency.sh`
+- Result: pass
+- Notes: Extended scenario matrix validated new contiguous-numbering guard, including branch-gap and out-of-order failures.
+
+65. `bash scripts/ci/check_sp_discipline_docs_consistency.sh`
+- Result: pass
+- Notes: Repo docs pass with contiguous stack numbering enforcement enabled for plan and evidence branch lists.
+
+66. `bash scripts/ci/run_sp_discipline_stack_gates.sh`
+- Result: pass
+- Notes: Full matrix pass with docs-consistency sequence scenarios integrated into the gate runner.
+
+67. `bash scripts/ci/capture_sp_discipline_gate_evidence.sh`
+- Result: pass
+- Notes: Generated `_artifacts/ci/sp_discipline_stack_gates_20260403T112036Z.log` and `_artifacts/ci/sp_discipline_stack_gates_20260403T112036Z.md` after PR22 changes.
+
+68. `bash scripts/ci/check_sp_discipline_docs_consistency.sh`
+- Result: pass
+- Notes: Final parity check after appending PR22 evidence entries.
 
 ## Test Harness Hardening Included
 - `scripts/run_devnet_alpha_multi_sp.sh`

--- a/docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md
+++ b/docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md
@@ -46,6 +46,7 @@ Implement a deterministic, testable discipline system so unreliable SPs are prog
 20. `stack/sp-discipline-19-evidence-capture-scenarios`
 21. `stack/sp-discipline-20-gate-runner-scenarios`
 22. `stack/sp-discipline-21-evidence-collision-guard`
+23. `stack/sp-discipline-22-doc-sequence-guard`
 
 Each branch is cut from the previous stack branch, not from `main`.
 
@@ -533,6 +534,28 @@ Exit Criteria:
 - Reused timestamps fail fast by default when artifacts already exist.
 - Intentional overwrite is explicit and regression-tested.
 - Full stack gate runner remains green with new evidence collision checks.
+
+## PR 22: Docs Branch Sequence Guard and Scenario Coverage
+Scope:
+- Enforce contiguous stack branch numbering (`00..N` without gaps or reordering) in docs consistency validation.
+- Fail fast when either plan or evidence branch lists drift from contiguous numbering.
+- Extend docs consistency scenario tests with branch-gap and out-of-order branch cases.
+
+Files (expected):
+- `scripts/ci/check_sp_discipline_docs_consistency.sh`
+- `scripts/ci/test_sp_discipline_docs_consistency.sh`
+- `docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md`
+- `docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md`
+
+Test Gate:
+1. `bash scripts/ci/test_sp_discipline_docs_consistency.sh` (must pass)
+2. `bash scripts/ci/run_sp_discipline_stack_gates.sh` (must pass with numbering scenarios included)
+3. `bash scripts/ci/capture_sp_discipline_gate_evidence.sh` (must pass and write artifacts)
+
+Exit Criteria:
+- Plan/evidence docs fail validation on branch gaps or out-of-order numbering.
+- Contiguous numbering checks are deterministic and regression-tested.
+- Full stack gate runner remains green with sequence guard checks enabled.
 
 ## Cross-PR Regression Matrix
 Run this matrix at minimum for PRs 02-06 (state/economics/repair/UX affecting):

--- a/scripts/ci/check_sp_discipline_docs_consistency.sh
+++ b/scripts/ci/check_sp_discipline_docs_consistency.sh
@@ -21,6 +21,36 @@ extract_branches() {
   sed -n 's/^[0-9][0-9]*\. `\(stack\/sp-discipline-[^`]*\)`/\1/p' "$file"
 }
 
+check_branch_sequence() {
+  local label="$1"
+  local branches="$2"
+  local expected=0
+  local saw_any=0
+
+  while IFS= read -r branch; do
+    [ -n "$branch" ] || continue
+    saw_any=1
+    local idx_raw
+    idx_raw="$(printf '%s' "$branch" | sed -nE 's#^stack/sp-discipline-([0-9]+)-.*#\1#p')"
+    if [ -z "$idx_raw" ]; then
+      echo "ERROR: could not parse stack index from $label branch entry: $branch" >&2
+      exit 1
+    fi
+    local idx_num=$((10#$idx_raw))
+    if [ "$idx_num" -ne "$expected" ]; then
+      printf 'ERROR: non-contiguous stack numbering in %s doc list (expected %02d, got %02d at %s)\n' \
+        "$label" "$expected" "$idx_num" "$branch" >&2
+      exit 1
+    fi
+    expected=$((expected + 1))
+  done <<< "$branches"
+
+  if [ "$saw_any" -ne 1 ]; then
+    echo "ERROR: no stack branches parsed from $label doc list" >&2
+    exit 1
+  fi
+}
+
 check_no_duplicates() {
   local label="$1"
   local branches="$2"
@@ -43,6 +73,8 @@ fi
 
 check_no_duplicates "plan" "$PLAN_BRANCHES"
 check_no_duplicates "evidence" "$EVIDENCE_BRANCHES"
+check_branch_sequence "plan" "$PLAN_BRANCHES"
+check_branch_sequence "evidence" "$EVIDENCE_BRANCHES"
 
 if [ "$PLAN_BRANCHES" != "$EVIDENCE_BRANCHES" ]; then
   echo "ERROR: stack branch lists differ between plan and evidence docs" >&2

--- a/scripts/ci/test_sp_discipline_docs_consistency.sh
+++ b/scripts/ci/test_sp_discipline_docs_consistency.sh
@@ -64,6 +64,8 @@ BASE_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-01-t
 MISMATCH_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-02-conviction-state`'
 DUP_PLAN_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-01-taxonomy-and-signals`\n3. `stack/sp-discipline-01-taxonomy-and-signals`'
 DUP_EVIDENCE_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-01-taxonomy-and-signals`\n3. `stack/sp-discipline-01-taxonomy-and-signals`'
+GAP_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-02-conviction-state`'
+OUT_OF_ORDER_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-02-conviction-state`\n3. `stack/sp-discipline-01-taxonomy-and-signals`'
 
 echo "==> Case 1: matching branch lists and YES MERGE text pass"
 write_docs "$BASE_LIST" "$BASE_LIST" "1"
@@ -84,5 +86,13 @@ expect_fail "evidence-duplicate"
 echo "==> Case 5: missing YES MERGE reminder text fails"
 write_docs "$BASE_LIST" "$BASE_LIST" "0"
 expect_fail "missing-yes-merge"
+
+echo "==> Case 6: non-contiguous branch numbering fails"
+write_docs "$GAP_LIST" "$GAP_LIST" "1"
+expect_fail "branch-gap"
+
+echo "==> Case 7: out-of-order branch numbering fails"
+write_docs "$OUT_OF_ORDER_LIST" "$OUT_OF_ORDER_LIST" "1"
+expect_fail "branch-out-of-order"
 
 echo "SP discipline docs consistency scenario tests passed."


### PR DESCRIPTION
## Summary
- enforce contiguous `stack/sp-discipline-XX-*` numbering in docs consistency checks
- fail when plan/evidence branch lists contain numbering gaps or out-of-order entries
- extend docs-consistency scenario coverage for branch-gap and branch-order failures
- update stack plan/evidence docs for PR22 and record executed gate evidence

## Testing
- bash -n scripts/ci/check_sp_discipline_docs_consistency.sh
- bash -n scripts/ci/test_sp_discipline_docs_consistency.sh
- bash scripts/ci/test_sp_discipline_docs_consistency.sh
- bash scripts/ci/check_sp_discipline_docs_consistency.sh
- bash scripts/ci/run_sp_discipline_stack_gates.sh
- bash scripts/ci/capture_sp_discipline_gate_evidence.sh
- bash scripts/ci/check_sp_discipline_docs_consistency.sh

## Merge Safety
No merge to `main` without explicit human approval comment containing exact phrase `YES MERGE`.
