### PR TITLE
PR23: enforce docs ordinal/index alignment

### DIFF
--- a/docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md
+++ b/docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md
@@ -29,6 +29,7 @@
 21. `stack/sp-discipline-20-gate-runner-scenarios`
 22. `stack/sp-discipline-21-evidence-collision-guard`
 23. `stack/sp-discipline-22-doc-sequence-guard`
+24. `stack/sp-discipline-23-doc-ordinal-guard`
 
 ## Mandatory Gate Results
 All commands below were executed from repo root unless noted.
@@ -302,6 +303,30 @@ All commands below were executed from repo root unless noted.
 68. `bash scripts/ci/check_sp_discipline_docs_consistency.sh`
 - Result: pass
 - Notes: Final parity check after appending PR22 evidence entries.
+
+69. `bash scripts/ci/test_sp_discipline_docs_consistency.sh`
+- Result: pass
+- Notes: Extended scenario matrix validated markdown list ordinal continuity and ordinal-to-branch index alignment failures.
+
+70. `bash scripts/ci/check_sp_discipline_docs_consistency.sh`
+- Result: pass
+- Notes: Repo docs pass with combined sequence + ordinal alignment enforcement.
+
+71. `bash scripts/ci/run_sp_discipline_stack_gates.sh`
+- Result: pass
+- Notes: Full matrix pass with ordinal scenario coverage integrated into docs-consistency checks.
+
+72. `bash scripts/ci/capture_sp_discipline_gate_evidence.sh`
+- Result: pass
+- Notes: Generated `_artifacts/ci/sp_discipline_stack_gates_20260403T112943Z.log` and `_artifacts/ci/sp_discipline_stack_gates_20260403T112943Z.md` after PR23 changes.
+
+73. `bash scripts/ci/check_sp_discipline_docs_consistency.sh`
+- Result: pass
+- Notes: Final branch-list parity and ordinal alignment check after appending PR23 evidence entries.
+
+74. `bash scripts/ci/test_sp_discipline_docs_consistency.sh`
+- Result: pass
+- Notes: Revalidated ordinal and sequence scenario coverage after PR23 doc updates.
 
 ## Test Harness Hardening Included
 - `scripts/run_devnet_alpha_multi_sp.sh`

--- a/docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md
+++ b/docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md
@@ -47,6 +47,7 @@ Implement a deterministic, testable discipline system so unreliable SPs are prog
 21. `stack/sp-discipline-20-gate-runner-scenarios`
 22. `stack/sp-discipline-21-evidence-collision-guard`
 23. `stack/sp-discipline-22-doc-sequence-guard`
+24. `stack/sp-discipline-23-doc-ordinal-guard`
 
 Each branch is cut from the previous stack branch, not from `main`.
 
@@ -556,6 +557,28 @@ Exit Criteria:
 - Plan/evidence docs fail validation on branch gaps or out-of-order numbering.
 - Contiguous numbering checks are deterministic and regression-tested.
 - Full stack gate runner remains green with sequence guard checks enabled.
+
+## PR 23: Docs List Ordinal Alignment Guard and Scenarios
+Scope:
+- Enforce markdown list ordinal continuity (`1..N`) for stack branch rows in both plan and evidence docs.
+- Enforce ordinal-to-branch index alignment (`item 1 -> stack ...-00-*`, `item 2 -> stack ...-01-*`, etc.).
+- Extend docs consistency scenario tests to cover ordinal gaps and ordinal-offset errors.
+
+Files (expected):
+- `scripts/ci/check_sp_discipline_docs_consistency.sh`
+- `scripts/ci/test_sp_discipline_docs_consistency.sh`
+- `docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md`
+- `docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md`
+
+Test Gate:
+1. `bash scripts/ci/test_sp_discipline_docs_consistency.sh` (must pass)
+2. `bash scripts/ci/run_sp_discipline_stack_gates.sh` (must pass with ordinal scenarios included)
+3. `bash scripts/ci/capture_sp_discipline_gate_evidence.sh` (must pass and write artifacts)
+
+Exit Criteria:
+- Plan/evidence docs fail validation on markdown list ordinal gaps or ordinal offsets.
+- Ordinal alignment checks are deterministic and regression-tested.
+- Full stack gate runner remains green with ordinal guard checks enabled.
 
 ## Cross-PR Regression Matrix
 Run this matrix at minimum for PRs 02-06 (state/economics/repair/UX affecting):

--- a/scripts/ci/check_sp_discipline_docs_consistency.sh
+++ b/scripts/ci/check_sp_discipline_docs_consistency.sh
@@ -21,6 +21,11 @@ extract_branches() {
   sed -n 's/^[0-9][0-9]*\. `\(stack\/sp-discipline-[^`]*\)`/\1/p' "$file"
 }
 
+extract_numbered_branches() {
+  local file="$1"
+  sed -n 's/^\([0-9][0-9]*\)\. `\(stack\/sp-discipline-[^`]*\)`/\1 \2/p' "$file"
+}
+
 check_branch_sequence() {
   local label="$1"
   local branches="$2"
@@ -51,6 +56,48 @@ check_branch_sequence() {
   fi
 }
 
+check_list_and_branch_alignment() {
+  local label="$1"
+  local numbered="$2"
+  local expected_item=1
+  local expected_branch=0
+  local saw_any=0
+
+  while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    saw_any=1
+    local item_raw="${row%% *}"
+    local branch="${row#* }"
+    local item_num=$((10#$item_raw))
+    local idx_raw
+    idx_raw="$(printf '%s' "$branch" | sed -nE 's#^stack/sp-discipline-([0-9]+)-.*#\1#p')"
+    if [ -z "$idx_raw" ]; then
+      echo "ERROR: could not parse stack index from $label branch entry: $branch" >&2
+      exit 1
+    fi
+    local branch_num=$((10#$idx_raw))
+
+    if [ "$item_num" -ne "$expected_item" ]; then
+      printf 'ERROR: non-contiguous markdown list numbering in %s doc list (expected item %d, got %d at %s)\n' \
+        "$label" "$expected_item" "$item_num" "$branch" >&2
+      exit 1
+    fi
+    if [ "$branch_num" -ne "$expected_branch" ]; then
+      printf 'ERROR: list/branch index mismatch in %s doc list (item %d expects branch %02d, got %02d at %s)\n' \
+        "$label" "$item_num" "$expected_branch" "$branch_num" "$branch" >&2
+      exit 1
+    fi
+
+    expected_item=$((expected_item + 1))
+    expected_branch=$((expected_branch + 1))
+  done <<< "$numbered"
+
+  if [ "$saw_any" -ne 1 ]; then
+    echo "ERROR: no numbered stack branches parsed from $label doc list" >&2
+    exit 1
+  fi
+}
+
 check_no_duplicates() {
   local label="$1"
   local branches="$2"
@@ -65,14 +112,18 @@ check_no_duplicates() {
 
 PLAN_BRANCHES="$(extract_branches "$PLAN_DOC")"
 EVIDENCE_BRANCHES="$(extract_branches "$EVIDENCE_DOC")"
+PLAN_NUMBERED="$(extract_numbered_branches "$PLAN_DOC")"
+EVIDENCE_NUMBERED="$(extract_numbered_branches "$EVIDENCE_DOC")"
 
-if [ -z "$PLAN_BRANCHES" ] || [ -z "$EVIDENCE_BRANCHES" ]; then
+if [ -z "$PLAN_BRANCHES" ] || [ -z "$EVIDENCE_BRANCHES" ] || [ -z "$PLAN_NUMBERED" ] || [ -z "$EVIDENCE_NUMBERED" ]; then
   echo "ERROR: failed to parse stack branch lists from docs" >&2
   exit 1
 fi
 
 check_no_duplicates "plan" "$PLAN_BRANCHES"
 check_no_duplicates "evidence" "$EVIDENCE_BRANCHES"
+check_list_and_branch_alignment "plan" "$PLAN_NUMBERED"
+check_list_and_branch_alignment "evidence" "$EVIDENCE_NUMBERED"
 check_branch_sequence "plan" "$PLAN_BRANCHES"
 check_branch_sequence "evidence" "$EVIDENCE_BRANCHES"
 

--- a/scripts/ci/test_sp_discipline_docs_consistency.sh
+++ b/scripts/ci/test_sp_discipline_docs_consistency.sh
@@ -66,6 +66,8 @@ DUP_PLAN_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-
 DUP_EVIDENCE_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-01-taxonomy-and-signals`\n3. `stack/sp-discipline-01-taxonomy-and-signals`'
 GAP_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-02-conviction-state`'
 OUT_OF_ORDER_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-02-conviction-state`\n3. `stack/sp-discipline-01-taxonomy-and-signals`'
+ORDINAL_GAP_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n3. `stack/sp-discipline-01-taxonomy-and-signals`'
+ORDINAL_OFFSET_LIST=$'2. `stack/sp-discipline-00-merge-gate`\n3. `stack/sp-discipline-01-taxonomy-and-signals`'
 
 echo "==> Case 1: matching branch lists and YES MERGE text pass"
 write_docs "$BASE_LIST" "$BASE_LIST" "1"
@@ -94,5 +96,13 @@ expect_fail "branch-gap"
 echo "==> Case 7: out-of-order branch numbering fails"
 write_docs "$OUT_OF_ORDER_LIST" "$OUT_OF_ORDER_LIST" "1"
 expect_fail "branch-out-of-order"
+
+echo "==> Case 8: markdown list ordinal gaps fail"
+write_docs "$ORDINAL_GAP_LIST" "$ORDINAL_GAP_LIST" "1"
+expect_fail "ordinal-gap"
+
+echo "==> Case 9: markdown list ordinal offset fails"
+write_docs "$ORDINAL_OFFSET_LIST" "$ORDINAL_OFFSET_LIST" "1"
+expect_fail "ordinal-offset"
 
 echo "SP discipline docs consistency scenario tests passed."


### PR DESCRIPTION
## Summary
- enforce markdown list ordinal continuity (`1..N`) for stack branch rows in plan/evidence docs
- enforce ordinal-to-branch index mapping (item 1 => `stack/sp-discipline-00-*`, item 2 => `stack/sp-discipline-01-*`, etc.)
- extend docs-consistency scenarios with ordinal-gap and ordinal-offset failures
- update stack plan/evidence docs for PR23 and append executed gate evidence

## Testing
- bash -n scripts/ci/check_sp_discipline_docs_consistency.sh
- bash -n scripts/ci/test_sp_discipline_docs_consistency.sh
- bash scripts/ci/test_sp_discipline_docs_consistency.sh
- bash scripts/ci/check_sp_discipline_docs_consistency.sh
- bash scripts/ci/run_sp_discipline_stack_gates.sh
- bash scripts/ci/capture_sp_discipline_gate_evidence.sh
- bash scripts/ci/check_sp_discipline_docs_consistency.sh
- bash scripts/ci/test_sp_discipline_docs_consistency.sh

## Merge Safety
No merge to `main` without explicit human approval comment containing exact phrase `YES MERGE`.
