### PR TITLE
PR24: enforce stack ordinal alignment checks

### DIFF
--- a/docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md
+++ b/docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md
@@ -30,6 +30,7 @@
 22. `stack/sp-discipline-21-evidence-collision-guard`
 23. `stack/sp-discipline-22-doc-sequence-guard`
 24. `stack/sp-discipline-23-doc-ordinal-guard`
+25. `stack/sp-discipline-24-stack-ordinal-guard`
 
 ## Mandatory Gate Results
 All commands below were executed from repo root unless noted.
@@ -327,6 +328,34 @@ All commands below were executed from repo root unless noted.
 74. `bash scripts/ci/test_sp_discipline_docs_consistency.sh`
 - Result: pass
 - Notes: Revalidated ordinal and sequence scenario coverage after PR23 doc updates.
+
+75. `bash scripts/ci/test_sp_discipline_stack_integrity.sh`
+- Result: pass
+- Notes: Extended scenario matrix validated markdown list ordinal continuity and list/branch index alignment failures.
+
+76. `bash scripts/ci/check_sp_discipline_stack_integrity.sh`
+- Result: pass
+- Notes: Repo stack docs pass with combined ancestry + merged checks and new ordinal/index alignment enforcement.
+
+77. `bash scripts/ci/run_sp_discipline_stack_gates.sh`
+- Result: pass
+- Notes: Full matrix pass with stack-integrity ordinal scenarios integrated into the gate sequence.
+
+78. `bash scripts/ci/capture_sp_discipline_gate_evidence.sh`
+- Result: pass
+- Notes: Generated `_artifacts/ci/sp_discipline_stack_gates_20260403T113931Z.log` and `_artifacts/ci/sp_discipline_stack_gates_20260403T113931Z.md` after PR24 changes.
+
+79. `bash scripts/ci/test_sp_discipline_stack_integrity.sh`
+- Result: pass
+- Notes: Revalidated stack-integrity scenario suite after appending PR24 evidence entries.
+
+80. `bash scripts/ci/check_sp_discipline_docs_consistency.sh`
+- Result: pass
+- Notes: Revalidated branch-list parity and `YES MERGE` reminder text after PR24 evidence updates.
+
+81. `bash scripts/ci/check_sp_discipline_stack_integrity.sh`
+- Result: pass
+- Notes: Revalidated stack ancestry/merged guards with local PR24 head chained after PR23.
 
 ## Test Harness Hardening Included
 - `scripts/run_devnet_alpha_multi_sp.sh`

--- a/docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md
+++ b/docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md
@@ -48,6 +48,7 @@ Implement a deterministic, testable discipline system so unreliable SPs are prog
 22. `stack/sp-discipline-21-evidence-collision-guard`
 23. `stack/sp-discipline-22-doc-sequence-guard`
 24. `stack/sp-discipline-23-doc-ordinal-guard`
+25. `stack/sp-discipline-24-stack-ordinal-guard`
 
 Each branch is cut from the previous stack branch, not from `main`.
 
@@ -579,6 +580,28 @@ Exit Criteria:
 - Plan/evidence docs fail validation on markdown list ordinal gaps or ordinal offsets.
 - Ordinal alignment checks are deterministic and regression-tested.
 - Full stack gate runner remains green with ordinal guard checks enabled.
+
+## PR 24: Stack Integrity Ordinal Alignment Guard and Scenarios
+Scope:
+- Enforce markdown list ordinal continuity (`1..N`) directly in stack integrity validation.
+- Enforce ordinal-to-branch index alignment in stack integrity checks (`item 1 -> stack ...-00-*`).
+- Extend stack-integrity scenario tests to cover ordinal gaps and index mismatches.
+
+Files (expected):
+- `scripts/ci/check_sp_discipline_stack_integrity.sh`
+- `scripts/ci/test_sp_discipline_stack_integrity.sh`
+- `docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md`
+- `docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md`
+
+Test Gate:
+1. `bash scripts/ci/test_sp_discipline_stack_integrity.sh` (must pass)
+2. `bash scripts/ci/run_sp_discipline_stack_gates.sh` (must pass with stack-ordinal scenarios included)
+3. `bash scripts/ci/capture_sp_discipline_gate_evidence.sh` (must pass and write artifacts)
+
+Exit Criteria:
+- Stack integrity check fails fast on ordinal gaps or list/branch index mismatches.
+- New negative scenarios are deterministic and regression-tested.
+- Full stack gate runner remains green with stack-ordinal guard checks enabled.
 
 ## Cross-PR Regression Matrix
 Run this matrix at minimum for PRs 02-06 (state/economics/repair/UX affecting):

--- a/scripts/ci/check_sp_discipline_stack_integrity.sh
+++ b/scripts/ci/check_sp_discipline_stack_integrity.sh
@@ -18,8 +18,55 @@ if ! git remote get-url "$REMOTE" >/dev/null 2>&1; then
   exit 2
 fi
 
+extract_numbered_branches() {
+  sed -n 's/^\([0-9][0-9]*\)\. `\(stack\/sp-discipline-[^`]*\)`/\1 \2/p' "$STACK_DOC"
+}
+
+check_list_and_branch_alignment() {
+  local expected_item=1
+  local expected_branch=0
+  local saw_any=0
+  local row
+
+  while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    saw_any=1
+    local item_raw="${row%% *}"
+    local branch="${row#* }"
+    local item_num=$((10#$item_raw))
+    local idx_raw
+    idx_raw="$(printf '%s' "$branch" | sed -nE 's#^stack/sp-discipline-([0-9]+)-.*#\1#p')"
+    if [ -z "$idx_raw" ]; then
+      echo "ERROR: could not parse stack index from branch entry: $branch" >&2
+      exit 1
+    fi
+    local branch_num=$((10#$idx_raw))
+
+    if [ "$item_num" -ne "$expected_item" ]; then
+      printf 'ERROR: non-contiguous markdown list numbering in %s (expected item %d, got %d at %s)\n' \
+        "$STACK_DOC" "$expected_item" "$item_num" "$branch" >&2
+      exit 1
+    fi
+    if [ "$branch_num" -ne "$expected_branch" ]; then
+      printf 'ERROR: list/branch index mismatch in %s (item %d expects branch %02d, got %02d at %s)\n' \
+        "$STACK_DOC" "$item_num" "$expected_branch" "$branch_num" "$branch" >&2
+      exit 1
+    fi
+
+    expected_item=$((expected_item + 1))
+    expected_branch=$((expected_branch + 1))
+  done < <(extract_numbered_branches)
+
+  if [ "$saw_any" -ne 1 ]; then
+    echo "ERROR: expected numbered stack branch rows in $STACK_DOC" >&2
+    exit 2
+  fi
+}
+
 echo "==> Fetching remote refs from $REMOTE..."
 git fetch "$REMOTE" --prune >/dev/null
+
+check_list_and_branch_alignment
 
 STACK_BRANCHES=()
 while IFS= read -r branch; do

--- a/scripts/ci/test_sp_discipline_stack_integrity.sh
+++ b/scripts/ci/test_sp_discipline_stack_integrity.sh
@@ -51,6 +51,8 @@ VALID_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-01-
 DUP_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-01-taxonomy-and-signals`\n3. `stack/sp-discipline-01-taxonomy-and-signals`'
 ORDER_BAD_LIST=$'1. `stack/sp-discipline-01-taxonomy-and-signals`\n2. `stack/sp-discipline-00-merge-gate`'
 MISSING_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-99-not-a-real-branch`'
+ORDINAL_GAP_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n3. `stack/sp-discipline-01-taxonomy-and-signals`'
+INDEX_MISMATCH_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-02-conviction-state`'
 
 echo "==> Case 1: valid stack order passes"
 write_stack_doc "$VALID_LIST"
@@ -89,5 +91,13 @@ if run_case_with_base "$MERGED_BASE_REF"; then
   exit 1
 fi
 echo "OK: expected failure for case: already-merged-into-base"
+
+echo "==> Case 6: markdown list ordinal gap fails"
+write_stack_doc "$ORDINAL_GAP_LIST"
+expect_fail "ordinal-gap"
+
+echo "==> Case 7: list/branch index mismatch fails"
+write_stack_doc "$INDEX_MISMATCH_LIST"
+expect_fail "index-mismatch"
 
 echo "SP discipline stack integrity scenario tests passed."


### PR DESCRIPTION
## Summary
- add ordinal continuity and ordinal-to-branch index alignment checks to stack integrity validation
- extend stack-integrity scenario tests with ordinal-gap and index-mismatch failure cases
- update PR stack and execution evidence docs with PR24 scope and gate results

## Testing
- bash scripts/ci/test_sp_discipline_stack_integrity.sh
- bash scripts/ci/check_sp_discipline_stack_integrity.sh
- bash scripts/ci/check_sp_discipline_docs_consistency.sh
- bash scripts/ci/run_sp_discipline_stack_gates.sh
- bash scripts/ci/capture_sp_discipline_gate_evidence.sh
- bash scripts/ci/check_sp_discipline_docs_consistency.sh
- bash scripts/ci/check_sp_discipline_stack_integrity.sh

## Merge Safety
Do not merge to main without explicit human approval comment containing exact phrase: YES MERGE