### PR TITLE
PR25: prioritize duplicate diagnostics in stack integrity

### DIFF
--- a/docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md
+++ b/docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md
@@ -31,6 +31,7 @@
 23. `stack/sp-discipline-22-doc-sequence-guard`
 24. `stack/sp-discipline-23-doc-ordinal-guard`
 25. `stack/sp-discipline-24-stack-ordinal-guard`
+26. `stack/sp-discipline-25-stack-duplicate-diagnostics`
 
 ## Mandatory Gate Results
 All commands below were executed from repo root unless noted.
@@ -356,6 +357,38 @@ All commands below were executed from repo root unless noted.
 81. `bash scripts/ci/check_sp_discipline_stack_integrity.sh`
 - Result: pass
 - Notes: Revalidated stack ancestry/merged guards with local PR24 head chained after PR23.
+
+82. `bash scripts/ci/test_sp_discipline_stack_integrity.sh`
+- Result: pass
+- Notes: Scenario suite now asserts deterministic failure diagnostics for duplicate branches, missing refs, ordinal gaps, and index mismatches.
+
+83. `bash scripts/ci/check_sp_discipline_stack_integrity.sh`
+- Result: pass
+- Notes: Revalidated stack integrity with duplicate-first diagnostics enabled before ordinal/index enforcement.
+
+84. `bash scripts/ci/check_sp_discipline_docs_consistency.sh`
+- Result: pass
+- Notes: Revalidated plan/evidence parity and `YES MERGE` reminder after adding branch 26 docs entries.
+
+85. `bash scripts/ci/run_sp_discipline_stack_gates.sh`
+- Result: pass
+- Notes: Full matrix pass with updated stack-integrity scenario diagnostics.
+
+86. `bash scripts/ci/capture_sp_discipline_gate_evidence.sh`
+- Result: pass
+- Notes: Generated `_artifacts/ci/sp_discipline_stack_gates_20260403T115036Z.log` and `_artifacts/ci/sp_discipline_stack_gates_20260403T115036Z.md` after PR25 changes.
+
+87. `bash scripts/ci/check_sp_discipline_docs_consistency.sh`
+- Result: pass
+- Notes: Final branch-list parity and `YES MERGE` reminder validation after appending PR25 evidence entries.
+
+88. `bash scripts/ci/check_sp_discipline_stack_integrity.sh`
+- Result: pass
+- Notes: Final stack ancestry/merged validation with PR25 local head chained after PR24.
+
+89. `bash scripts/ci/check_sp_discipline_docs_consistency.sh`
+- Result: pass
+- Notes: Final consistency re-check after appending PR25 closeout entries.
 
 ## Test Harness Hardening Included
 - `scripts/run_devnet_alpha_multi_sp.sh`

--- a/docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md
+++ b/docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md
@@ -49,6 +49,7 @@ Implement a deterministic, testable discipline system so unreliable SPs are prog
 23. `stack/sp-discipline-22-doc-sequence-guard`
 24. `stack/sp-discipline-23-doc-ordinal-guard`
 25. `stack/sp-discipline-24-stack-ordinal-guard`
+26. `stack/sp-discipline-25-stack-duplicate-diagnostics`
 
 Each branch is cut from the previous stack branch, not from `main`.
 
@@ -602,6 +603,29 @@ Exit Criteria:
 - Stack integrity check fails fast on ordinal gaps or list/branch index mismatches.
 - New negative scenarios are deterministic and regression-tested.
 - Full stack gate runner remains green with stack-ordinal guard checks enabled.
+
+## PR 25: Stack Integrity Duplicate-First Diagnostics and Scenario Assertions
+Scope:
+- Prioritize duplicate-branch detection in stack integrity checks so duplicate rows report a dedicated duplicate error.
+- Keep ordinal/index alignment enforcement intact after duplicate validation.
+- Strengthen stack-integrity scenario tests with deterministic failure-message assertions for duplicate, missing-ref, ordinal-gap, and index-mismatch paths.
+
+Files (expected):
+- `scripts/ci/check_sp_discipline_stack_integrity.sh`
+- `scripts/ci/test_sp_discipline_stack_integrity.sh`
+- `docs/planning/SP_DISCIPLINE_PR_STACK_2026-04.md`
+- `docs/planning/SP_DISCIPLINE_EXECUTION_EVIDENCE_2026-04.md`
+
+Test Gate:
+1. `bash scripts/ci/test_sp_discipline_stack_integrity.sh` (must pass)
+2. `bash scripts/ci/check_sp_discipline_stack_integrity.sh` (must pass)
+3. `bash scripts/ci/run_sp_discipline_stack_gates.sh` (must pass with stack-integrity diagnostics unchanged for happy path)
+4. `bash scripts/ci/capture_sp_discipline_gate_evidence.sh` (must pass and write artifacts)
+
+Exit Criteria:
+- Duplicate branch rows fail with explicit duplicate diagnostics instead of masked index-mismatch errors.
+- Scenario suite asserts key failure messages for duplicate/missing-ref/ordinal/index guardrails.
+- Full stack gate runner remains green.
 
 ## Cross-PR Regression Matrix
 Run this matrix at minimum for PRs 02-06 (state/economics/repair/UX affecting):

--- a/scripts/ci/check_sp_discipline_stack_integrity.sh
+++ b/scripts/ci/check_sp_discipline_stack_integrity.sh
@@ -66,8 +66,6 @@ check_list_and_branch_alignment() {
 echo "==> Fetching remote refs from $REMOTE..."
 git fetch "$REMOTE" --prune >/dev/null
 
-check_list_and_branch_alignment
-
 STACK_BRANCHES=()
 while IFS= read -r branch; do
   [ -n "$branch" ] || continue
@@ -89,6 +87,8 @@ if [ -n "$DUP_BRANCHES" ]; then
   echo "$DUP_BRANCHES" >&2
   exit 1
 fi
+
+check_list_and_branch_alignment
 
 HEAD_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 STACK_REFS=()

--- a/scripts/ci/test_sp_discipline_stack_integrity.sh
+++ b/scripts/ci/test_sp_discipline_stack_integrity.sh
@@ -40,8 +40,28 @@ run_case_with_base() {
 expect_fail() {
   local label="$1"
   shift
-  if run_case "$@"; then
+  local output
+  if output="$(run_case "$@" 2>&1)"; then
     echo "ERROR: expected failure for case: $label" >&2
+    exit 1
+  fi
+  echo "OK: expected failure for case: $label"
+}
+
+expect_fail_with() {
+  local label="$1"
+  local expected_substring="$2"
+  shift 2
+  local output
+  if output="$(run_case "$@" 2>&1)"; then
+    echo "ERROR: expected failure for case: $label" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$output" | grep -Fq "$expected_substring"; then
+    echo "ERROR: expected failure output for case '$label' to contain: $expected_substring" >&2
+    echo "---- output start ----" >&2
+    printf '%s\n' "$output" >&2
+    echo "---- output end ----" >&2
     exit 1
   fi
   echo "OK: expected failure for case: $label"
@@ -50,7 +70,7 @@ expect_fail() {
 VALID_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-01-taxonomy-and-signals`'
 DUP_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-01-taxonomy-and-signals`\n3. `stack/sp-discipline-01-taxonomy-and-signals`'
 ORDER_BAD_LIST=$'1. `stack/sp-discipline-01-taxonomy-and-signals`\n2. `stack/sp-discipline-00-merge-gate`'
-MISSING_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-99-not-a-real-branch`'
+MISSING_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-01-not-a-real-branch`'
 ORDINAL_GAP_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n3. `stack/sp-discipline-01-taxonomy-and-signals`'
 INDEX_MISMATCH_LIST=$'1. `stack/sp-discipline-00-merge-gate`\n2. `stack/sp-discipline-02-conviction-state`'
 
@@ -60,15 +80,15 @@ run_case
 
 echo "==> Case 2: duplicate stack entries fail"
 write_stack_doc "$DUP_LIST"
-expect_fail "duplicate-branches"
+expect_fail_with "duplicate-branches" "duplicate stack branches found"
 
 echo "==> Case 3: missing branch reference fails"
 write_stack_doc "$MISSING_LIST"
-expect_fail "missing-branch"
+expect_fail_with "missing-branch" "missing required stack branch ref"
 
-echo "==> Case 4: ancestry order violation fails"
+echo "==> Case 4: list/branch order mismatch fails"
 write_stack_doc "$ORDER_BAD_LIST"
-expect_fail "order-violation"
+expect_fail_with "order-violation" "list/branch index mismatch"
 
 MERGED_BASE_REF=""
 for candidate in \
@@ -94,10 +114,10 @@ echo "OK: expected failure for case: already-merged-into-base"
 
 echo "==> Case 6: markdown list ordinal gap fails"
 write_stack_doc "$ORDINAL_GAP_LIST"
-expect_fail "ordinal-gap"
+expect_fail_with "ordinal-gap" "non-contiguous markdown list numbering"
 
 echo "==> Case 7: list/branch index mismatch fails"
 write_stack_doc "$INDEX_MISMATCH_LIST"
-expect_fail "index-mismatch"
+expect_fail_with "index-mismatch" "list/branch index mismatch"
 
 echo "SP discipline stack integrity scenario tests passed."


### PR DESCRIPTION
## Summary
- run duplicate-branch detection before ordinal/index alignment in stack integrity checks so duplicate rows report explicit duplicate diagnostics
- strengthen stack-integrity scenario tests with deterministic failure-message assertions
- update PR stack and execution evidence docs with PR25 scope and gate/evidence results

## Testing
- bash -n scripts/ci/check_sp_discipline_stack_integrity.sh
- bash -n scripts/ci/test_sp_discipline_stack_integrity.sh
- bash scripts/ci/test_sp_discipline_stack_integrity.sh
- bash scripts/ci/check_sp_discipline_stack_integrity.sh
- bash scripts/ci/check_sp_discipline_docs_consistency.sh
- bash scripts/ci/run_sp_discipline_stack_gates.sh
- bash scripts/ci/capture_sp_discipline_gate_evidence.sh
- bash scripts/ci/check_sp_discipline_docs_consistency.sh
- bash scripts/ci/check_sp_discipline_stack_integrity.sh

## Merge Safety
Do not merge to main without explicit human approval comment containing exact phrase: YES MERGE